### PR TITLE
Restore two-job release-plz flow for branch protection

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Job 2: Publish to crates.io + create git tag when release-plz bumped versions.
   # release-plz release is a no-op if the local version already matches crates.io,

--- a/crates/libaipm/tests/bdd.rs
+++ b/crates/libaipm/tests/bdd.rs
@@ -468,15 +468,19 @@ fn main() {
     // validation.feature requires `aipm validate` (not yet implemented).
     // See GitHub issues for enabling remaining feature files and directories.
     let base = concat!(env!("CARGO_MANIFEST_DIR"), "/../../tests/features/manifest");
-    futures::executor::block_on(
-        AipmWorld::cucumber()
-            .with_default_cli()
-            .filter_run(base, |feat, _, _| {
-                let path = feat.path.as_deref().unwrap_or_default();
-                let name = path.to_string_lossy();
-                name.contains("init.feature")
-                    || name.contains("versioning.feature")
-                    || name.contains("workspace-init.feature")
-            }),
-    );
+    futures::executor::block_on(AipmWorld::cucumber().with_default_cli().filter_run(
+        base,
+        |feat, _, _| {
+            let name = feat
+                .path
+                .as_deref()
+                .and_then(|p| p.file_name())
+                .map(|n| n.to_string_lossy())
+                .unwrap_or_default();
+            matches!(
+                name.as_ref(),
+                "init.feature" | "versioning.feature" | "workspace-init.feature"
+            )
+        },
+    ));
 }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,7 +20,7 @@ semver_check = true
 # Publish crates to crates.io via cargo publish
 publish_allow_dirty = false
 
-# Auto-merge release PRs after CI passes (requires repo setting: Allow auto-merge)
+# Create release PRs as non-draft so they are eligible for GitHub auto-merge
 pr_draft = false
 
 # Require clean working directory


### PR DESCRIPTION
## Summary
- Restores the `release-pr` job that creates a PR with version bumps + CHANGELOG updates (driven by `cargo-semver-checks` API analysis)
- The `release` job publishes to crates.io and creates git tags only after the release PR is merged
- Required for branch protection — release-plz can't push directly to main

## Flow
```
push to main → release-pr job creates/updates a Release PR
  → merge Release PR → release job publishes to crates.io + creates git tag
    → tag triggers release.yml → builds binaries → draft GitHub Release
```