### PR TITLE
Enable auto-merge (squash) for release-plz PRs

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,8 +20,9 @@ semver_check = true
 # Publish crates to crates.io via cargo publish
 publish_allow_dirty = false
 
-# Create release PRs as non-draft so they are eligible for GitHub auto-merge
+# Create release PRs as non-draft and auto-merge via squash after CI passes
 pr_draft = false
+pr_auto_merge = "squash"
 
 # Require clean working directory
 allow_dirty = false


### PR DESCRIPTION
## Summary
- Adds `pr_auto_merge = "squash"` to `release-plz.toml`
- Release PRs created by release-plz will now auto-merge via squash after CI passes
- No manual approval or merge button needed

## Prereqs
- [x] Repo setting "Allow auto-merge" enabled
- [x] Branch ruleset has 0 required approvers
- [x] CI status check required