### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1063,7 +1063,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "cucumber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.1.2" }
+libaipm = { path = "crates/libaipm", version = "0.2.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.2.0] - 2026-03-19
+
 ## [0.1.2] - 2026-03-19
 
 ## [0.1.1] - 2026-03-19

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.2.0] - 2026-03-19
+
 ## [0.1.2] - 2026-03-19
 
 ## [0.1.1] - 2026-03-19

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.2.0] - 2026-03-19
+
 ## [0.1.2] - 2026-03-19
 
 ## [0.1.1] - 2026-03-19


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `aipm`: 0.1.2 -> 0.2.0
* `aipm-pack`: 0.1.2 -> 0.2.0

### ⚠ `libaipm` breaking changes

```text
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type InitAction no longer derives Copy, in /tmp/.tmpzr8hXb/aipm/crates/libaipm/src/workspace_init/mod.rs:45

--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum InitAction in /tmp/.tmpzr8hXb/aipm/crates/libaipm/src/workspace_init/mod.rs:45

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant InitAction:ToolConfigured in /tmp/.tmpzr8hXb/aipm/crates/libaipm/src/workspace_init/mod.rs:52

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant InitAction::ClaudeSettingsWritten, previously in file /tmp/.tmp6mCVvK/libaipm/src/workspace_init/mod.rs:32
  variant InitAction::VscodeSettingsWritten, previously in file /tmp/.tmp6mCVvK/libaipm/src/workspace_init/mod.rs:34
  variant InitAction::CopilotConfigWritten, previously in file /tmp/.tmp6mCVvK/libaipm/src/workspace_init/mod.rs:36

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  libaipm::workspace_init::init now takes 2 parameters instead of 1, in /tmp/.tmpzr8hXb/aipm/crates/libaipm/src/workspace_init/mod.rs:95
```

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).