### PR TITLE
Fix release PR auto-merge using correct action output

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -32,11 +32,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
-      - name: Enable auto-merge on release PR
-        if: steps.release_plz.outputs.pr_number != ''
-        run: gh pr merge ${{ steps.release_plz.outputs.pr_number }} --auto --squash
+      - name: Enable auto-merge on release PRs
+        if: steps.release_plz.outputs.prs_created != '[]'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          PRS_CREATED: ${{ steps.release_plz.outputs.prs_created }}
+        run: |
+          echo "$PRS_CREATED" | jq -r '.[].number' | while read -r pr; do
+            gh pr merge "$pr" --auto --squash
+          done
 
   # Job 2: Publish to crates.io + create git tag when release-plz bumped versions.
   # release-plz release is a no-op if the local version already matches crates.io,


### PR DESCRIPTION
## Summary
- `release-plz/action@v0.5` outputs `prs_created` (a JSON array), not `pr_number`
- The old `if` condition was always false, so `gh pr merge --auto` never ran
- Updated to iterate over `prs_created` array and enable auto-merge on each PR

## Test plan
- [ ] Merge this PR and push a change to main
- [ ] Verify the release workflow's "Enable auto-merge" step actually executes
- [ ] Confirm the release PR auto-merges after CI passes