### PR TITLE
Better default plugin with scaffold skill, agent, hook, and --no-starter flag

### DIFF
--- a/crates/aipm/src/main.rs
+++ b/crates/aipm/src/main.rs
@@ -26,6 +26,10 @@ enum Commands {
         #[arg(long)]
         marketplace: bool,
 
+        /// Skip the starter plugin (create bare .ai/ directory only).
+        #[arg(long)]
+        no_starter: bool,
+
         /// Directory to initialize (defaults to current directory).
         #[arg(default_value = ".")]
         dir: PathBuf,
@@ -36,7 +40,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Init { workspace, marketplace, dir }) => {
+        Some(Commands::Init { workspace, marketplace, no_starter, dir }) => {
             let dir = if dir.as_os_str() == "." { std::env::current_dir()? } else { dir };
 
             // If neither flag is set, default to marketplace only
@@ -49,6 +53,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 dir: &dir,
                 workspace: do_workspace,
                 marketplace: do_marketplace,
+                no_starter,
             };
 
             let result = libaipm::workspace_init::init(&opts, &adaptors)?;
@@ -60,7 +65,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                         format!("Initialized workspace in {}", dir.display())
                     },
                     libaipm::workspace_init::InitAction::MarketplaceCreated => {
-                        "Created .ai/ marketplace with starter plugin".to_string()
+                        if no_starter {
+                            "Created .ai/ marketplace (no starter plugin)".to_string()
+                        } else {
+                            "Created .ai/ marketplace with starter plugin".to_string()
+                        }
                     },
                     libaipm::workspace_init::InitAction::ToolConfigured(name) => {
                         format!("Configured {name} settings")

--- a/crates/libaipm/src/workspace_init/mod.rs
+++ b/crates/libaipm/src/workspace_init/mod.rs
@@ -36,6 +36,8 @@ pub struct Options<'a> {
     pub workspace: bool,
     /// Generate `.ai/` marketplace + tool settings.
     pub marketplace: bool,
+    /// Skip the starter plugin (bare `.ai/` directory only).
+    pub no_starter: bool,
 }
 
 /// Actions taken during initialization — used for user feedback.
@@ -101,7 +103,7 @@ pub fn init(opts: &Options<'_>, adaptors: &[Box<dyn ToolAdaptor>]) -> Result<Ini
     }
 
     if opts.marketplace {
-        scaffold_marketplace(opts.dir)?;
+        scaffold_marketplace(opts.dir, opts.no_starter)?;
         actions.push(InitAction::MarketplaceCreated);
 
         for adaptor in adaptors {
@@ -162,21 +164,14 @@ fn generate_workspace_manifest() -> String {
 // Marketplace scaffolding
 // =============================================================================
 
-fn scaffold_marketplace(dir: &Path) -> Result<(), Error> {
+fn scaffold_marketplace(dir: &Path, no_starter: bool) -> Result<(), Error> {
     let ai_dir = dir.join(".ai");
     if ai_dir.exists() {
         return Err(Error::MarketplaceAlreadyExists(dir.to_path_buf()));
     }
 
-    let starter = ai_dir.join("starter");
-
-    // Create directory tree
-    std::fs::create_dir_all(starter.join(".claude-plugin"))?;
-    std::fs::create_dir_all(starter.join("skills").join("hello"))?;
-    std::fs::create_dir_all(starter.join("agents"))?;
-    std::fs::create_dir_all(starter.join("hooks"))?;
-
-    // .ai/.gitignore
+    // Always create .ai/ and .gitignore
+    std::fs::create_dir_all(&ai_dir)?;
     write_file(
         &ai_dir.join(".gitignore"),
         "# Managed by aipm — registry-installed plugins are symlinked here.\n\
@@ -185,8 +180,27 @@ fn scaffold_marketplace(dir: &Path) -> Result<(), Error> {
          # === aipm managed end ===\n",
     )?;
 
-    // .ai/starter/skills/hello/SKILL.md (must be written before manifest validation)
-    write_file(&starter.join("skills").join("hello").join("SKILL.md"), &generate_skill_template())?;
+    if no_starter {
+        return Ok(());
+    }
+
+    let starter = ai_dir.join("starter");
+
+    // Create directory tree
+    std::fs::create_dir_all(starter.join(".claude-plugin"))?;
+    std::fs::create_dir_all(starter.join("skills").join("scaffold-plugin"))?;
+    std::fs::create_dir_all(starter.join("scripts"))?;
+    std::fs::create_dir_all(starter.join("agents"))?;
+    std::fs::create_dir_all(starter.join("hooks"))?;
+
+    // Write all component files before manifest validation
+    write_file(
+        &starter.join("skills").join("scaffold-plugin").join("SKILL.md"),
+        &generate_skill_template(),
+    )?;
+    write_file(&starter.join("scripts").join("scaffold-plugin.ts"), &generate_scaffold_script())?;
+    write_file(&starter.join("agents").join("marketplace-scanner.md"), &generate_agent_template())?;
+    write_file(&starter.join("hooks").join("hooks.json"), &generate_hook_template())?;
 
     // .ai/starter/aipm.toml
     let starter_manifest = generate_starter_manifest();
@@ -202,10 +216,6 @@ fn scaffold_marketplace(dir: &Path) -> Result<(), Error> {
     // .ai/starter/.mcp.json
     write_file(&starter.join(".mcp.json"), &generate_mcp_stub())?;
 
-    // .gitkeep files
-    write_file(&starter.join("agents").join(".gitkeep"), "")?;
-    write_file(&starter.join("hooks").join(".gitkeep"), "")?;
-
     Ok(())
 }
 
@@ -215,14 +225,17 @@ fn generate_starter_manifest() -> String {
      version = \"0.1.0\"\n\
      type = \"composite\"\n\
      edition = \"2024\"\n\
-     description = \"Starter plugin — customize or rename this directory\"\n\
+     description = \"Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage\"\n\
      \n\
      # [dependencies]\n\
      # Add registry dependencies here, e.g.:\n\
      # shared-skill = \"^1.0\"\n\
      \n\
      [components]\n\
-     skills = [\"skills/hello/SKILL.md\"]\n"
+     skills = [\"skills/scaffold-plugin/SKILL.md\"]\n\
+     agents = [\"agents/marketplace-scanner.md\"]\n\
+     hooks = [\"hooks/hooks.json\"]\n\
+     scripts = [\"scripts/scaffold-plugin.ts\"]\n"
         .to_string()
 }
 
@@ -230,25 +243,122 @@ fn generate_plugin_json() -> String {
     "{\n\
      \x20 \"name\": \"starter\",\n\
      \x20 \"version\": \"0.1.0\",\n\
-     \x20 \"description\": \"Starter plugin — customize or rename this directory\"\n\
+     \x20 \"description\": \"Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage\"\n\
      }\n"
     .to_string()
 }
 
 fn generate_skill_template() -> String {
     "---\n\
-     description: A starter skill — describe what it does so Claude knows when to use it\n\
+     description: Scaffold a new AI plugin in the .ai/ marketplace directory. Use when the user wants to create a new plugin, skill, agent, or hook package.\n\
      ---\n\
      \n\
-     # Hello Skill\n\
+     # Scaffold Plugin\n\
      \n\
-     This is a starter skill template. Customize the description in the frontmatter\n\
-     above so your AI coding tool can auto-discover when to invoke this skill.\n\
+     Create a new plugin in the `.ai/` marketplace directory.\n\
      \n\
      ## Instructions\n\
      \n\
-     Replace this content with instructions for the AI agent when this skill is active.\n"
+     1. Ask the user for a plugin name (lowercase, hyphens allowed) if not provided.\n\
+     2. Run the scaffolding script:\n\
+     \x20  ```bash\n\
+     \x20  node --experimental-strip-types .ai/starter/scripts/scaffold-plugin.ts <plugin-name>\n\
+     \x20  ```\n\
+     3. Report the created file tree to the user.\n\
+     4. Suggest next steps: edit the generated `SKILL.md`, add agents or hooks, update `aipm.toml`.\n\
+     \n\
+     ## Notes\n\
+     \n\
+     - The script creates `.ai/<plugin-name>/` with a valid `aipm.toml` and starter skill.\n\
+     - If the directory already exists, the script exits with an error message.\n\
+     - After scaffolding, the user should customize the generated files.\n"
         .to_string()
+}
+
+fn generate_scaffold_script() -> String {
+    "import { mkdirSync, writeFileSync, existsSync } from \"fs\";\n\
+     import { join } from \"path\";\n\
+     \n\
+     const name = process.argv[2];\n\
+     if (!name) {\n\
+     \x20 process.stderr.write(\"Usage: node --experimental-strip-types scaffold-plugin.ts <plugin-name>\\n\");\n\
+     \x20 process.exit(1);\n\
+     }\n\
+     \n\
+     const aiDir = join(process.cwd(), \".ai\");\n\
+     const pluginDir = join(aiDir, name);\n\
+     \n\
+     if (existsSync(pluginDir)) {\n\
+     \x20 process.stderr.write(`Error: .ai/${name}/ already exists\\n`);\n\
+     \x20 process.exit(1);\n\
+     }\n\
+     \n\
+     mkdirSync(join(pluginDir, \".claude-plugin\"), { recursive: true });\n\
+     mkdirSync(join(pluginDir, \"skills\", name), { recursive: true });\n\
+     mkdirSync(join(pluginDir, \"agents\"), { recursive: true });\n\
+     mkdirSync(join(pluginDir, \"hooks\"), { recursive: true });\n\
+     \n\
+     writeFileSync(\n\
+     \x20 join(pluginDir, \"aipm.toml\"),\n\
+     \x20 `[package]\\nname = \"${name}\"\\nversion = \"0.1.0\"\\ntype = \"composite\"\\nedition = \"2024\"\\ndescription = \"TODO: describe ${name}\"\\n\\n[components]\\nskills = [\"skills/${name}/SKILL.md\"]\\n`\n\
+     );\n\
+     \n\
+     writeFileSync(\n\
+     \x20 join(pluginDir, \"skills\", name, \"SKILL.md\"),\n\
+     \x20 `---\\ndescription: TODO — describe when this skill should be invoked\\n---\\n\\n# ${name}\\n\\nReplace this with instructions for the AI agent.\\n`\n\
+     );\n\
+     \n\
+     writeFileSync(\n\
+     \x20 join(pluginDir, \".claude-plugin\", \"plugin.json\"),\n\
+     \x20 JSON.stringify({ name, version: \"0.1.0\", description: `TODO: describe ${name}` }, null, 2) + \"\\n\"\n\
+     );\n\
+     \n\
+     process.stdout.write(`Created .ai/${name}/ with starter structure\\n`);\n"
+        .to_string()
+}
+
+fn generate_agent_template() -> String {
+    "---\n\
+     name: marketplace-scanner\n\
+     description: Scan and explain the contents of the .ai/ marketplace directory. Use when the user wants to understand what plugins, skills, agents, or hooks are installed locally.\n\
+     tools:\n\
+     \x20 - Read\n\
+     \x20 - Glob\n\
+     \x20 - Grep\n\
+     \x20 - LS\n\
+     ---\n\
+     \n\
+     # Marketplace Scanner\n\
+     \n\
+     You are a read-only analysis agent for the `.ai/` marketplace directory.\n\
+     \n\
+     ## Instructions\n\
+     \n\
+     1. List all plugin directories under `.ai/` (each subdirectory with an `aipm.toml`).\n\
+     2. For each plugin, read its `aipm.toml` and summarize:\n\
+     \x20  - Package name, version, type, and description\n\
+     \x20  - Declared components (skills, agents, hooks, scripts)\n\
+     3. If asked about a specific component, read and explain its contents.\n\
+     4. Never modify any files — you are read-only.\n\
+     \n\
+     ## Scope\n\
+     \n\
+     - Only scan files within the `.ai/` directory.\n\
+     - Do not access files outside `.ai/` unless explicitly asked.\n\
+     - Report any `aipm.toml` parse issues you encounter.\n"
+        .to_string()
+}
+
+fn generate_hook_template() -> String {
+    "{\n\
+     \x20 \"hooks\": [\n\
+     \x20   {\n\
+     \x20     \"event\": \"PostToolUse\",\n\
+     \x20     \"command\": \"echo \\\"$(date -u +%Y-%m-%dT%H:%M:%SZ) tool=$TOOL_NAME\\\" >> .ai/.tool-usage.log\"\n\
+     \x20   }\n\
+     \x20 ]\n\
+     }\n"
+    .to_string()
 }
 
 fn generate_mcp_stub() -> String {
@@ -302,9 +412,23 @@ mod tests {
     #[test]
     fn starter_manifest_round_trips() {
         let (tmp, _guard) = make_temp_dir("starter-rt");
-        let skill_dir = tmp.join("skills").join("hello");
+
+        // Create all component files that the manifest declares
+        let skill_dir = tmp.join("skills").join("scaffold-plugin");
         std::fs::create_dir_all(&skill_dir).ok();
         std::fs::File::create(skill_dir.join("SKILL.md")).ok();
+
+        let agents_dir = tmp.join("agents");
+        std::fs::create_dir_all(&agents_dir).ok();
+        std::fs::File::create(agents_dir.join("marketplace-scanner.md")).ok();
+
+        let hooks_dir = tmp.join("hooks");
+        std::fs::create_dir_all(&hooks_dir).ok();
+        std::fs::File::create(hooks_dir.join("hooks.json")).ok();
+
+        let scripts_dir = tmp.join("scripts");
+        std::fs::create_dir_all(&scripts_dir).ok();
+        std::fs::File::create(scripts_dir.join("scaffold-plugin.ts")).ok();
 
         let content = generate_starter_manifest();
         let result = crate::manifest::parse_and_validate(&content, Some(&tmp));
@@ -317,7 +441,8 @@ mod tests {
     fn init_workspace_creates_manifest() {
         let (tmp, _guard) = make_temp_dir("ws-create");
         let adaptors = default_adaptors();
-        let result = init(&Options { dir: &tmp, workspace: true, marketplace: false }, &adaptors);
+        let opts = Options { dir: &tmp, workspace: true, marketplace: false, no_starter: false };
+        let result = init(&opts, &adaptors);
         assert!(result.is_ok());
         assert!(result.is_ok_and(|r| r.actions.contains(&InitAction::WorkspaceCreated)));
         assert!(tmp.join("aipm.toml").exists());
@@ -332,17 +457,19 @@ mod tests {
     fn init_marketplace_creates_tree() {
         let (tmp, _guard) = make_temp_dir("mp-create");
         let adaptors = default_adaptors();
-        let result = init(&Options { dir: &tmp, workspace: false, marketplace: true }, &adaptors);
+        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let result = init(&opts, &adaptors);
         assert!(result.is_ok());
         assert!(result.is_ok_and(|r| r.actions.contains(&InitAction::MarketplaceCreated)));
 
         assert!(tmp.join(".ai").is_dir());
         assert!(tmp.join(".ai/starter/aipm.toml").exists());
         assert!(tmp.join(".ai/starter/.claude-plugin/plugin.json").exists());
-        assert!(tmp.join(".ai/starter/skills/hello/SKILL.md").exists());
+        assert!(tmp.join(".ai/starter/skills/scaffold-plugin/SKILL.md").exists());
+        assert!(tmp.join(".ai/starter/scripts/scaffold-plugin.ts").exists());
+        assert!(tmp.join(".ai/starter/agents/marketplace-scanner.md").exists());
+        assert!(tmp.join(".ai/starter/hooks/hooks.json").exists());
         assert!(tmp.join(".ai/starter/.mcp.json").exists());
-        assert!(tmp.join(".ai/starter/agents/.gitkeep").exists());
-        assert!(tmp.join(".ai/starter/hooks/.gitkeep").exists());
         assert!(tmp.join(".ai/.gitignore").exists());
 
         cleanup(&tmp);
@@ -354,7 +481,8 @@ mod tests {
         std::fs::File::create(tmp.join("aipm.toml")).ok();
 
         let adaptors = default_adaptors();
-        let result = init(&Options { dir: &tmp, workspace: true, marketplace: false }, &adaptors);
+        let opts = Options { dir: &tmp, workspace: true, marketplace: false, no_starter: false };
+        let result = init(&opts, &adaptors);
         assert!(result.is_err());
         let err = result.err();
         assert!(err.is_some_and(|e| e.to_string().contains("already initialized")));
@@ -368,7 +496,8 @@ mod tests {
         std::fs::create_dir_all(tmp.join(".ai")).ok();
 
         let adaptors = default_adaptors();
-        let result = init(&Options { dir: &tmp, workspace: false, marketplace: true }, &adaptors);
+        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let result = init(&opts, &adaptors);
         assert!(result.is_err());
         let err = result.err();
         assert!(err.is_some_and(|e| e.to_string().contains("already exists")));
@@ -380,7 +509,8 @@ mod tests {
     fn init_both_creates_everything() {
         let (tmp, _guard) = make_temp_dir("both");
         let adaptors = default_adaptors();
-        let result = init(&Options { dir: &tmp, workspace: true, marketplace: true }, &adaptors);
+        let opts = Options { dir: &tmp, workspace: true, marketplace: true, no_starter: false };
+        let result = init(&opts, &adaptors);
         assert!(result.is_ok());
         let r = result.ok();
         assert!(r.as_ref().is_some_and(|r| r.actions.contains(&InitAction::WorkspaceCreated)));
@@ -395,7 +525,8 @@ mod tests {
     fn init_with_no_adaptors() {
         let (tmp, _guard) = make_temp_dir("no-adaptors");
         let adaptors: Vec<Box<dyn ToolAdaptor>> = vec![];
-        let result = init(&Options { dir: &tmp, workspace: false, marketplace: true }, &adaptors);
+        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let result = init(&opts, &adaptors);
         assert!(result.is_ok());
         assert!(tmp.join(".ai").is_dir());
         // No .claude/ directory should exist
@@ -408,7 +539,8 @@ mod tests {
     fn gitignore_has_managed_markers() {
         let (tmp, _guard) = make_temp_dir("gitignore");
         let adaptors = default_adaptors();
-        let result = init(&Options { dir: &tmp, workspace: false, marketplace: true }, &adaptors);
+        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let result = init(&opts, &adaptors);
         assert!(result.is_ok());
 
         let content = std::fs::read_to_string(tmp.join(".ai/.gitignore"));
@@ -441,5 +573,73 @@ mod tests {
         let content = generate_workspace_manifest();
         assert!(content.contains("members = [\".ai/*\"]"));
         assert!(content.contains("plugins_dir = \".ai\""));
+    }
+
+    #[test]
+    fn agent_template_has_frontmatter() {
+        let content = generate_agent_template();
+        assert!(content.starts_with("---\n"));
+        assert!(content.contains("name:"));
+        assert!(content.contains("description:"));
+        assert!(content.contains("tools:"));
+        assert!(content.contains("- Read"));
+        assert!(content.contains("- Glob"));
+        assert!(content.contains("- Grep"));
+        assert!(content.contains("- LS"));
+    }
+
+    #[test]
+    fn hook_template_is_valid_json() {
+        let json = generate_hook_template();
+        let parsed: Result<serde_json::Value, _> = serde_json::from_str(&json);
+        assert!(parsed.is_ok(), "hook template should be valid JSON: {parsed:?}");
+        let v = parsed.ok();
+        assert!(v.as_ref().is_some_and(|v| v.get("hooks").is_some()));
+        assert!(v.is_some_and(|v| {
+            v.get("hooks").and_then(|h| h.as_array()).is_some_and(|a| !a.is_empty())
+        }));
+    }
+
+    #[test]
+    fn scaffold_script_is_nonempty() {
+        let content = generate_scaffold_script();
+        assert!(!content.is_empty());
+        assert!(content.contains("mkdirSync"));
+        assert!(content.contains("writeFileSync"));
+        assert!(content.contains("experimental-strip-types"));
+    }
+
+    #[test]
+    fn init_marketplace_no_starter() {
+        let (tmp, _guard) = make_temp_dir("no-starter");
+        let adaptors = default_adaptors();
+        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: true };
+        let result = init(&opts, &adaptors);
+        assert!(result.is_ok());
+        assert!(result.is_ok_and(|r| r.actions.contains(&InitAction::MarketplaceCreated)));
+
+        // .ai/ and .gitignore exist
+        assert!(tmp.join(".ai").is_dir());
+        assert!(tmp.join(".ai/.gitignore").exists());
+        // starter/ does NOT exist
+        assert!(!tmp.join(".ai/starter").exists());
+
+        cleanup(&tmp);
+    }
+
+    #[test]
+    fn init_no_starter_still_configures_tools() {
+        let (tmp, _guard) = make_temp_dir("no-starter-tools");
+        let adaptors = default_adaptors();
+        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: true };
+        let result = init(&opts, &adaptors);
+        assert!(result.is_ok());
+
+        // Tool settings should still be applied
+        assert!(tmp.join(".claude/settings.json").exists());
+        // But no starter plugin
+        assert!(!tmp.join(".ai/starter").exists());
+
+        cleanup(&tmp);
     }
 }

--- a/research/docs/2026-03-20-30-better-default-plugin.md
+++ b/research/docs/2026-03-20-30-better-default-plugin.md
@@ -1,0 +1,191 @@
+---
+date: 2026-03-20 07:38:32 PDT
+researcher: Claude
+git_commit: cf04f8826ae4c297f20d3366c1e33e28ab988888
+branch: main
+repository: aipm
+topic: "GitHub Issue #30 — Create a better default plugin for aipm init"
+tags: [research, codebase, init, plugin, starter, command, skill, agent, hook, marketplace]
+status: complete
+last_updated: 2026-03-20
+last_updated_by: Claude
+---
+
+# Research: GitHub Issue #30 — Create a Better Default Plugin
+
+## Research Question
+
+GitHub Issue #30 requests that `aipm init` scaffold a more useful and informative default plugin containing:
+1. A **command** (or skill with model invocation turned off) — a small TypeScript script that helps scaffold a new plugin in the `.ai` marketplace
+2. A **sub-agent** scoped strictly to understand/scan code in the `.ai` marketplace
+3. A **hook** providing basic logging after any model runs
+4. All markdown in each file **under 50 lines**
+
+## Summary
+
+The current `aipm init` scaffolds a minimal "starter" plugin at `.ai/starter/` with a single generic `SKILL.md` and empty `agents/` and `hooks/` directories (`.gitkeep` only). Issue #30 asks to replace this with a more functional default plugin containing three real components — a scaffolding command/skill, a marketplace-scanning sub-agent, and a logging hook — all with concise markdown (< 50 lines per file).
+
+## Detailed Findings
+
+### Current Starter Plugin (What Exists Today)
+
+The marketplace scaffolding is implemented in [`scaffold_marketplace()`](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/crates/libaipm/src/workspace_init/mod.rs#L165-L210).
+
+Current `.ai/starter/` tree:
+
+```
+.ai/
+  .gitignore
+  starter/
+    aipm.toml                    # [package] name="starter", type="composite"
+    .claude-plugin/plugin.json   # Claude Code plugin metadata
+    .mcp.json                    # empty MCP stub
+    skills/hello/SKILL.md        # generic placeholder skill
+    agents/.gitkeep              # empty
+    hooks/.gitkeep               # empty
+```
+
+**Key observations:**
+- The `SKILL.md` is a 12-line generic template with no real functionality (`workspace_init/mod.rs:238-252`)
+- Agents and hooks directories have no content — just `.gitkeep` files
+- The manifest at `workspace_init/mod.rs:212-227` declares only `skills = ["skills/hello/SKILL.md"]`
+- The `plugin.json` at `workspace_init/mod.rs:229-236` mirrors basic package metadata
+
+### Component 1: Command/Skill (Scaffold New Plugin)
+
+**Issue requirement:** A command or skill with model invocation turned off, leveraging a small TypeScript script to scaffold a new plugin in `.ai`.
+
+**Current codebase state:**
+- Skills are declared in `[components] skills` as paths to `SKILL.md` files (`manifest/types.rs:118`)
+- Commands are declared in `[components] commands` as legacy skill format (`manifest/types.rs:121`)
+- SKILL.md files use YAML frontmatter; Claude Code supports `disable-model-invocation` in frontmatter per Copilot conventions (`research/docs/2026-03-16-copilot-agent-discovery.md:69`)
+- The `[components] scripts` field (`manifest/types.rs:136`) exists for utility scripts that skills/hooks can reference
+- AIPM treats SKILL.md and script files as opaque — it validates path existence only (`manifest/validate.rs:167-192`)
+
+**What needs to change in `scaffold_marketplace()`:**
+- Replace `skills/hello/SKILL.md` with a new skill (e.g., `skills/scaffold-plugin/SKILL.md`) that instructs the AI to run a TypeScript script for scaffolding
+- Add a TypeScript script (e.g., `scripts/scaffold-plugin.ts`) referenced by the skill
+- Update the manifest to list the new skill and script paths in `[components]`
+- Ensure the skill frontmatter includes a `description` that clearly states when to invoke it
+
+### Component 2: Sub-Agent (Marketplace Scanner)
+
+**Issue requirement:** A sub-agent scoped strictly to understand and scan code in the `.ai` marketplace.
+
+**Current codebase state:**
+- Agents are declared in `[components] agents` as paths to agent markdown files (`manifest/types.rs:124`)
+- Agent markdown files use YAML frontmatter with `name`, `description`, `tools`, `model` keys (`research/docs/2026-03-16-claude-code-defaults.md:160`)
+- The `tools` frontmatter key is the scoping mechanism — restricts which tools an agent can use
+- Currently `agents/.gitkeep` is the only file in the agents directory
+- BDD quality lint (P2, unimplemented) will warn on missing `tools` declaration (`tests/features/guardrails/quality.feature:35-38`)
+
+**What needs to change in `scaffold_marketplace()`:**
+- Replace `agents/.gitkeep` with an actual agent markdown file (e.g., `agents/marketplace-scanner.md`)
+- The agent should have `tools` frontmatter restricting capabilities (e.g., Read, Glob, Grep, LS only — no Edit/Write)
+- The agent's instructions should be scoped to scanning/understanding `.ai/` directory contents
+- Update the manifest to list the agent path in `[components] agents`
+
+### Component 3: Hook (Post-Model Logging)
+
+**Issue requirement:** A hook providing basic logging after any model runs.
+
+**Current codebase state:**
+- Hooks are declared in `[components] hooks` as paths to JSON files (`manifest/types.rs:127`)
+- Claude Code hooks use `hooks.json` format with event-based lifecycle hooks (`research/docs/2026-03-16-claude-code-defaults.md:157`)
+- Known hook events: `PreToolUse`, `PostToolUse` (and likely others from Claude Code's hook system)
+- Currently `hooks/.gitkeep` is the only file in the hooks directory
+- BDD quality lint (P2, unimplemented) will validate hook event names (`tests/features/guardrails/quality.feature:40-44`)
+
+**What needs to change in `scaffold_marketplace()`:**
+- Replace `hooks/.gitkeep` with `hooks/hooks.json` containing a post-model-run logging hook
+- The hook should reference an event like `PostToolUse` or equivalent "after model runs" event
+- Include a simple script or inline command for logging (e.g., append to a log file)
+- Update the manifest to list `hooks = ["hooks/hooks.json"]` in `[components]`
+
+### Manifest Changes Required
+
+The current starter manifest (`workspace_init/mod.rs:212-227`) declares:
+
+```toml
+[components]
+skills = ["skills/hello/SKILL.md"]
+```
+
+It needs to become something like:
+
+```toml
+[components]
+skills = ["skills/scaffold-plugin/SKILL.md"]
+agents = ["agents/marketplace-scanner.md"]
+hooks = ["hooks/hooks.json"]
+scripts = ["scripts/scaffold-plugin.ts"]
+```
+
+### 50-Line Markdown Constraint
+
+All three markdown files (skill SKILL.md, agent .md, and any supporting docs) must be under 50 lines each. The current skill template is 12 lines, well under the limit.
+
+### Validation Considerations
+
+- `parse_and_validate()` with `base_dir` at `workspace_init/mod.rs:196-197` validates that all component paths exist on disk — all new files must be written **before** this validation call
+- The current code already follows this pattern: `SKILL.md` is written at line 189, before validation at line 196
+- New component files (agent .md, hooks.json, scripts/scaffold-plugin.ts) must also be written before validation
+
+## Code References
+
+- [`scaffold_marketplace()`](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/crates/libaipm/src/workspace_init/mod.rs#L165-L210) — Main function to modify
+- [`generate_starter_manifest()`](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/crates/libaipm/src/workspace_init/mod.rs#L212-L227) — Manifest template to update
+- [`generate_skill_template()`](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/crates/libaipm/src/workspace_init/mod.rs#L238-L252) — Skill template to replace
+- [`generate_plugin_json()`](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/crates/libaipm/src/workspace_init/mod.rs#L229-L236) — Plugin JSON (may need description update)
+- [`Components` struct](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/crates/libaipm/src/manifest/types.rs#L115-L143) — All valid component fields
+- [`validate_component_paths()`](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/crates/libaipm/src/manifest/validate.rs#L167-L192) — Path existence validation
+- [`PluginType` enum](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/crates/libaipm/src/manifest/types.rs#L208-L221) — Valid plugin types
+- [Claude Code defaults research](https://github.com/TheLarkInn/aipm/blob/cf04f8826ae4c297f20d3366c1e33e28ab988888/research/docs/2026-03-16-claude-code-defaults.md#L153-L160) — SKILL.md, hooks.json, and agent .md format reference
+
+## Architecture Documentation
+
+### How `aipm init` Flows
+
+1. CLI parses `Init` subcommand (`crates/aipm/src/main.rs:19-32`)
+2. Defaults to marketplace-only if no flags (`main.rs:43-44`)
+3. Loads tool adaptors — currently only Claude Code (`workspace_init/adaptors/mod.rs:13-15`)
+4. Calls `workspace_init::init()` (`workspace_init/mod.rs:95-115`)
+5. `scaffold_marketplace()` creates `.ai/starter/` tree (`mod.rs:165-210`) — **this is the function to modify**
+6. Tool adaptors create/merge settings files (`adaptors/claude.rs:19-42`)
+7. `InitResult` with action summaries returned to CLI for display (`main.rs:57-70`)
+
+### Template Generation Pattern
+
+All content is generated by dedicated `generate_*()` functions in `workspace_init/mod.rs`:
+- `generate_workspace_manifest()` (lines 140-159)
+- `generate_starter_manifest()` (lines 212-227)
+- `generate_plugin_json()` (lines 229-236)
+- `generate_skill_template()` (lines 238-252)
+- `generate_mcp_stub()` (lines 254-256)
+
+New content for issue #30 should follow this pattern — add `generate_agent_template()`, `generate_hook_template()`, and `generate_scaffold_script()` functions.
+
+### Write-Before-Validate Ordering
+
+Files must be written to disk before `parse_and_validate()` is called at line 196-197, because validation checks that component paths exist on disk. The existing code already establishes this pattern (SKILL.md written at line 189, validation at line 196).
+
+## Historical Context (from research/)
+
+- `research/docs/2026-03-16-claude-code-defaults.md` — Documents Claude Code's native file formats: SKILL.md with YAML frontmatter, hooks.json with lifecycle events (PreToolUse, PostToolUse), agent markdown with tools/model scoping
+- `research/docs/2026-03-16-copilot-agent-discovery.md` — Documents `disable-model-invocation` frontmatter key for skills/agents (relevant for the "model invocation turned off" requirement)
+- `research/docs/2026-03-16-aipm-init-workspace-marketplace.md` — Original research backing the workspace/marketplace init design
+- `specs/2026-03-16-aipm-init-workspace-marketplace.md` — Specification for the init command
+- `specs/2026-03-19-init-tool-adaptor-refactor.md` — Specification for the ToolAdaptor trait pattern used in init
+
+## Related Research
+
+- `research/docs/2026-03-16-claude-code-defaults.md` — Claude Code plugin format reference
+- `research/docs/2026-03-16-copilot-agent-discovery.md` — Cross-tool agent discovery model
+- `research/docs/2026-03-16-aipm-init-workspace-marketplace.md` — Init workspace/marketplace design
+
+## Open Questions
+
+1. **TypeScript script runtime:** The issue says "a small TypeScript script" for the scaffolding command — does the starter plugin need to include `ts-node`/`tsx` as a dependency, or should it use a different runtime (e.g., plain shell script, or `npx tsx`)?
+2. **Hook event name:** The issue says "after any model runs" — is this `PostToolUse`, `Notification`, or a different Claude Code hook event? The research only documents `PreToolUse` and `PostToolUse`.
+3. **Plugin naming:** Should the default plugin remain named "starter" or be renamed to something more descriptive?
+4. **Script path in manifest:** The `[components] scripts` field exists in the schema but no current scaffold uses it — needs confirmation that scripts are validated the same way as other component paths.

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -1,37 +1,196 @@
 [
   {
-    "category": "refactor",
-    "description": "Restructure workspace_init.rs into workspace_init/ module directory with mod.rs + adaptors/claude.rs",
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Create ToolAdaptor trait and ClaudeAdaptor, move Claude settings logic into adaptor",
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Delete vscode and copilot settings code, tests, and BDD scenarios",
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Update init() to accept adaptors slice and replace InitAction::ClaudeSettingsWritten with ToolConfigured(String)",
+    "category": "functional",
+    "description": "Add --no-starter flag to Options struct and thread through init() to scaffold_marketplace()",
+    "steps": [
+      "Add `no_starter: bool` field to `Options` struct in `workspace_init/mod.rs`",
+      "Update `scaffold_marketplace()` signature to accept `no_starter: bool` parameter",
+      "Update `init()` to pass `opts.no_starter` to `scaffold_marketplace()`",
+      "In `scaffold_marketplace()`, create `.ai/` and `.gitignore` before the `no_starter` check",
+      "Add early return `Ok(())` when `no_starter` is true, skipping all starter plugin scaffolding",
+      "Verify `cargo build --workspace` compiles (fix all `Options` construction sites to include `no_starter: false`)"
+    ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Update CLI main.rs: pass adaptors to init(), handle ToolConfigured action, change default to marketplace-only",
+    "description": "Add --no-starter CLI argument to aipm init command",
+    "steps": [
+      "Add `#[arg(long)] no_starter: bool` field to `Commands::Init` in `crates/aipm/src/main.rs`",
+      "Pass `no_starter` through to `Options` struct in the init handler",
+      "Update `MarketplaceCreated` output message to conditionally show '(no starter plugin)' when `no_starter` is true",
+      "Verify `cargo build --workspace` compiles",
+      "Test `aipm init --help` shows the new `--no-starter` flag"
+    ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Update BDD scenario: default init creates marketplace only (no aipm.toml)",
+    "description": "Add generate_scaffold_script() function returning TypeScript scaffolding script",
+    "steps": [
+      "Create `generate_scaffold_script()` function in `workspace_init/mod.rs` that returns the TypeScript script as a String",
+      "Script must use only Node.js built-ins (fs, path, process) — no npm dependencies",
+      "Script usage line must reference `node --experimental-strip-types`",
+      "Script must create plugin directory with `.claude-plugin/`, `skills/<name>/`, `agents/`, `hooks/` subdirectories",
+      "Script must write `aipm.toml`, `SKILL.md`, and `plugin.json` files",
+      "Script must check for existing directory and exit with error if it exists",
+      "Verify the function returns valid TypeScript content under 50 lines"
+    ],
     "passes": true
   },
   {
-    "category": "validation",
-    "description": "Full build verification — all four checks pass with zero warnings",
+    "category": "functional",
+    "description": "Add generate_agent_template() function returning marketplace-scanner agent markdown",
+    "steps": [
+      "Create `generate_agent_template()` function in `workspace_init/mod.rs`",
+      "Agent markdown must include YAML frontmatter with `name`, `description`, and `tools` keys",
+      "Tools must be restricted to read-only: Read, Glob, Grep, LS",
+      "Instructions must scope the agent to `.ai/` directory analysis only",
+      "Verify the content is under 50 lines",
+      "Verify frontmatter starts with `---` delimiter"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Add generate_hook_template() function returning hooks.json with PostToolUse logging",
+    "steps": [
+      "Create `generate_hook_template()` function in `workspace_init/mod.rs`",
+      "Hook JSON must contain a `hooks` array with one entry",
+      "Entry must have `event: PostToolUse` and a shell command that appends to `.ai/.tool-usage.log`",
+      "Verify the output is valid JSON by parsing with serde_json",
+      "Verify the content is under 50 lines"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update generate_skill_template() to return scaffold-plugin skill content",
+    "steps": [
+      "Replace the existing hello skill content in `generate_skill_template()` with the scaffold-plugin SKILL.md content",
+      "Skill must have YAML frontmatter with `description` key referencing plugin scaffolding",
+      "Instructions must reference `node --experimental-strip-types .ai/starter/scripts/scaffold-plugin.ts <plugin-name>`",
+      "Verify the content starts with `---` delimiter and contains `description:`",
+      "Verify the content is under 50 lines"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update generate_starter_manifest() to declare all four component types",
+    "steps": [
+      "Update `generate_starter_manifest()` to include `skills`, `agents`, `hooks`, and `scripts` in `[components]`",
+      "Skills path: `skills/scaffold-plugin/SKILL.md`",
+      "Agents path: `agents/marketplace-scanner.md`",
+      "Hooks path: `hooks/hooks.json`",
+      "Scripts path: `scripts/scaffold-plugin.ts`",
+      "Update the description to: 'Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage'",
+      "Verify manifest round-trips through `parse_and_validate()` (requires component files on disk)"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update generate_plugin_json() description to match new plugin purpose",
+    "steps": [
+      "Update the `description` field in `generate_plugin_json()` to 'Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage'",
+      "Verify the output is valid JSON with `name`, `version`, and `description` fields"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update scaffold_marketplace() directory tree and file writes for new components",
+    "steps": [
+      "Replace `skills/hello/` directory creation with `skills/scaffold-plugin/`",
+      "Add `scripts/` directory creation: `std::fs::create_dir_all(starter.join(\"scripts\"))`",
+      "Write `skills/scaffold-plugin/SKILL.md` using `generate_skill_template()` before validation",
+      "Write `scripts/scaffold-plugin.ts` using `generate_scaffold_script()` before validation",
+      "Write `agents/marketplace-scanner.md` using `generate_agent_template()` before validation",
+      "Write `hooks/hooks.json` using `generate_hook_template()` before validation",
+      "Remove the two `.gitkeep` write_file calls for `agents/.gitkeep` and `hooks/.gitkeep`",
+      "Ensure all component files are written BEFORE `parse_and_validate()` call",
+      "Verify `parse_and_validate()` succeeds with the updated manifest and all component files on disk"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update existing unit tests for new starter plugin structure",
+    "steps": [
+      "Update `starter_manifest_round_trips` test to create all four component files in temp dir (scaffold-plugin/SKILL.md, marketplace-scanner.md, hooks.json, scaffold-plugin.ts)",
+      "Update `init_marketplace_creates_tree` test to assert new file paths and remove `.gitkeep` assertions",
+      "Update `skill_template_has_frontmatter` test — content changes but `description:` assertion still holds",
+      "Add `no_starter: false` to ALL existing `Options` struct constructions in tests",
+      "Verify all modified tests pass with `cargo test --workspace`"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Add new unit tests for generate_*() template functions",
+    "steps": [
+      "Add `agent_template_has_frontmatter` test: verify agent markdown contains `name:`, `description:`, `tools:` in frontmatter",
+      "Add `hook_template_is_valid_json` test: verify `generate_hook_template()` parses as valid JSON with a `hooks` array",
+      "Add `scaffold_script_is_nonempty` test: verify `generate_scaffold_script()` is non-empty and contains expected markers (e.g., `mkdirSync`, `writeFileSync`)",
+      "Verify all new tests pass with `cargo test --workspace`"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Add unit tests for --no-starter behavior",
+    "steps": [
+      "Add `init_marketplace_no_starter` test: init with `no_starter: true`, verify `.ai/` and `.ai/.gitignore` exist but `.ai/starter/` does not",
+      "Add `init_no_starter_still_configures_tools` test: init with `no_starter: true` and default adaptors, verify `.claude/settings.json` is created",
+      "Verify all new tests pass with `cargo test --workspace`"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update BDD scenarios for new starter plugin file paths",
+    "steps": [
+      "Update 'Marketplace generates a Claude Code plugin structure' scenario: replace `skills/hello/SKILL.md` with `skills/scaffold-plugin/SKILL.md`, add assertions for `agents/marketplace-scanner.md`, `hooks/hooks.json`, `scripts/scaffold-plugin.ts`",
+      "Update 'Marketplace generates a starter skill with description frontmatter' scenario: change path from `skills/hello/SKILL.md` to `skills/scaffold-plugin/SKILL.md`",
+      "Update 'Initialize a workspace with default marketplace' scenario: add `scripts/` to the directory list",
+      "Verify BDD scenarios pass with `cargo test --workspace`"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Add BDD scenarios for new starter plugin components",
+    "steps": [
+      "Add scenario 'Starter plugin includes a marketplace scanner agent': assert `agents/marketplace-scanner.md` exists and contains `tools:` frontmatter",
+      "Add scenario 'Starter plugin includes a logging hook': assert `hooks/hooks.json` exists and contains `PostToolUse`",
+      "Add scenario 'Starter plugin includes a scaffold script': assert `scripts/scaffold-plugin.ts` exists",
+      "Verify new BDD scenarios pass with `cargo test --workspace`"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Add BDD scenarios for --no-starter flag behavior",
+    "steps": [
+      "Add scenario 'No-starter flag creates bare marketplace directory': run `aipm init --no-starter`, assert `.ai/` and `.ai/.gitignore` exist but `.ai/starter/` does not",
+      "Add scenario 'No-starter flag still configures tool settings': run `aipm init --no-starter`, assert `.claude/settings.json` is created",
+      "Add scenario 'No-starter flag with workspace creates both minus starter': run `aipm init --workspace --marketplace --no-starter`, assert `aipm.toml` + `.ai/` exist but no `.ai/starter/`",
+      "Verify new BDD scenarios pass with `cargo test --workspace`"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Final validation: full build, test, clippy, and fmt suite passes",
+    "steps": [
+      "Run `cargo build --workspace` — zero errors",
+      "Run `cargo test --workspace` — all tests pass",
+      "Run `cargo clippy --workspace -- -D warnings` — zero warnings",
+      "Run `cargo fmt --check` — no formatting issues",
+      "Verify no `#[allow(...)]` or `#[expect(...)]` attributes were added",
+      "Verify no `.unwrap()`, `.expect()`, `panic!()`, `println!()` usage in new code"
+    ],
     "passes": true
   }
 ]

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -1,33 +1,32 @@
-## 2026-03-19 — Feature 1: Restructure workspace_init into module directory
-- Moved workspace_init.rs → workspace_init/mod.rs
-- Created adaptors/mod.rs and adaptors/claude.rs stubs
-- All checks pass, no logic changes
+2026-03-20: Better Default Plugin (Issue #30) — All 16 features implemented
 
-## 2026-03-19 — Features 2-6: ToolAdaptor trait, Claude adaptor, delete vscode/copilot, CLI update
+Features completed:
+  1. ✅ Add --no-starter flag to Options struct and thread through init() → scaffold_marketplace()
+  2. ✅ Add --no-starter CLI argument to aipm init command
+  3. ✅ Add generate_scaffold_script() — TypeScript scaffolding script
+  4. ✅ Add generate_agent_template() — marketplace-scanner agent markdown
+  5. ✅ Add generate_hook_template() — hooks.json with PostToolUse logging
+  6. ✅ Update generate_skill_template() — scaffold-plugin skill content
+  7. ✅ Update generate_starter_manifest() — declare all four component types
+  8. ✅ Update generate_plugin_json() — new description
+  9. ✅ Update scaffold_marketplace() — new directory tree, file writes, remove .gitkeep
+ 10. ✅ Update existing unit tests for new starter plugin structure
+ 11. ✅ Add new unit tests for generate_*() template functions
+ 12. ✅ Add unit tests for --no-starter behavior
+ 13. ✅ Update BDD scenarios for new starter plugin file paths
+ 14. ✅ Add BDD scenarios for new starter plugin components
+ 15. ✅ Add BDD scenarios for --no-starter flag behavior
+ 16. ✅ Final validation: full build/test/clippy/fmt suite passes
 
-### What was done:
-- Created ToolAdaptor trait in workspace_init/mod.rs with name() and apply() methods
-- Created claude::Adaptor implementing ToolAdaptor (moved from write_claude_settings)
-- Created adaptors::defaults() returning vec![Box::new(claude::Adaptor)]
-- Deleted all vscode/copilot code: write_vscode_settings, merge_vscode_settings, write_copilot_config
-- Deleted InitAction::VscodeSettingsWritten and CopilotConfigWritten
-- Replaced InitAction::ClaudeSettingsWritten with ToolConfigured(String)
-- Removed Copy derive from InitAction (String is not Copy)
-- Updated init() to accept &[Box<dyn ToolAdaptor>] and loop over adaptors
-- Updated CLI: default changed from (workspace+marketplace) to (marketplace only)
-- Updated CLI: ToolConfigured(name) match arm
-- Deleted 5 vscode/copilot unit tests, moved 3 Claude tests to adaptors/claude.rs
-- Added init_with_no_adaptors test
-- Deleted 3 BDD scenarios (vscode/copilot), updated default init scenario
-- Made write_file pub(crate) for adaptor access
+Test results:
+  - cargo build --workspace: ✅ zero errors
+  - cargo test --workspace: ✅ 82 unit + 25 e2e + 48 BDD = all pass (0 failures)
+  - cargo clippy --workspace -- -D warnings: ✅ zero warnings
+  - cargo fmt --check: ✅ clean
 
-### Naming adjustments (clippy module_name_repetitions):
-- ClaudeAdaptor → claude::Adaptor
-- default_adaptors() → defaults()
-
-### Verification:
-- cargo build --workspace: PASS
-- cargo test --workspace: PASS (42 scenarios: 29 passed, 13 skipped)
-- cargo clippy --workspace -- -D warnings: PASS
-- cargo fmt --check: PASS
-- No vscode/copilot references in workspace_init code or BDD features
+Files modified:
+  - crates/libaipm/src/workspace_init/mod.rs (core scaffolding + tests)
+  - crates/aipm/src/main.rs (CLI --no-starter flag)
+  - tests/features/manifest/workspace-init.feature (BDD scenarios)
+  - research/feature-list.json (tracking)
+  - research/progress.txt (this file)

--- a/specs/2026-03-20-better-default-plugin.md
+++ b/specs/2026-03-20-better-default-plugin.md
@@ -1,0 +1,557 @@
+# Better Default Plugin for `aipm init`
+
+| Document Metadata      | Details                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------- |
+| Author(s)              | selarkin                                                                                    |
+| Status                 | Draft (WIP)                                                                                 |
+| Team / Owner           | AI Dev Tooling                                                                              |
+| Created / Last Updated | 2026-03-20                                                                                  |
+| Research               | [research/docs/2026-03-20-30-better-default-plugin.md](../research/docs/2026-03-20-30-better-default-plugin.md) |
+| Issue                  | GitHub Issue #30                                                                            |
+
+## 1. Executive Summary
+
+This spec replaces the minimal "starter" plugin scaffolded by `aipm init` with a functional default plugin containing three real components: (1) a scaffold-plugin skill that runs a TypeScript script (via Node's `--experimental-strip-types`) to create new plugins in `.ai/`, (2) a marketplace-scanner sub-agent scoped to read-only analysis of the `.ai/` directory, and (3) a post-model logging hook. A new `--no-starter` CLI flag allows users to skip the starter plugin entirely, creating only the bare `.ai/` directory. All markdown files stay under 50 lines. Changes touch `scaffold_marketplace()` and its `generate_*()` helpers in `workspace_init/mod.rs`, plus the `Options` struct and CLI argument parsing for the new flag.
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+`aipm init --marketplace` scaffolds a `.ai/starter/` plugin with a single placeholder skill and empty `agents/` and `hooks/` directories ([research §Current Starter Plugin](../research/docs/2026-03-20-30-better-default-plugin.md)):
+
+```
+.ai/
+  .gitignore
+  starter/
+    aipm.toml                    # [components] skills = ["skills/hello/SKILL.md"]
+    .claude-plugin/plugin.json
+    .mcp.json
+    skills/hello/SKILL.md        # 12-line generic placeholder
+    agents/.gitkeep              # empty
+    hooks/.gitkeep               # empty
+```
+
+The `SKILL.md` contains boilerplate instructions with no real functionality. Agents and hooks directories are stubs. Users get no working examples of these component types after init.
+
+### 2.2 The Problem
+
+| Problem | Impact |
+|---------|--------|
+| Starter skill is a generic placeholder | Users don't learn how skills work or how to create plugins |
+| No agent example | Users have no reference for agent scoping (`tools` frontmatter) or markdown agent format |
+| No hook example | Users don't see how hooks.json lifecycle events work |
+| `.gitkeep` stubs signal "not ready" | Sends the wrong message about the platform's capabilities |
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] Replace `skills/hello/SKILL.md` with `skills/scaffold-plugin/SKILL.md` — a skill that invokes a TypeScript script to scaffold a new plugin directory in `.ai/`
+- [ ] Add `scripts/scaffold-plugin.ts` — a small TypeScript script (run via `node --experimental-strip-types`) that creates the plugin directory structure
+- [ ] Replace `agents/.gitkeep` with `agents/marketplace-scanner.md` — a sub-agent scoped to read-only `.ai/` directory analysis
+- [ ] Replace `hooks/.gitkeep` with `hooks/hooks.json` — a hook providing basic logging after model runs
+- [ ] Update `generate_starter_manifest()` to declare all four components: skills, agents, hooks, scripts
+- [ ] Update `generate_plugin_json()` description to reflect the new plugin purpose
+- [ ] Keep all markdown files under 50 lines each
+- [ ] All new files must be written before `parse_and_validate()` call (write-before-validate ordering)
+- [ ] Add `--no-starter` CLI flag to `aipm init` that skips the starter plugin (creates bare `.ai/` directory with only `.gitignore`)
+- [ ] Thread the `no_starter` option through `Options` struct and `scaffold_marketplace()`
+- [ ] All `cargo build/test/clippy/fmt` must pass with zero warnings
+- [ ] Update BDD scenarios to assert new file paths and `--no-starter` behavior
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] Renaming the plugin from "starter" — keep the existing name for backwards compatibility with docs
+- [ ] Bundling a TypeScript runtime — the script requires Node.js >= 22.6.0 with `--experimental-strip-types` support; no third-party runners needed
+- [ ] Implementing the P2 quality lint guardrails for agents/hooks — those are separate issues
+- [ ] Changes to the `ToolAdaptor` trait, `ClaudeAdaptor`, or `.claude/settings.json` generation
+- [ ] Changes to the manifest schema (`types.rs`) or validation logic (`validate.rs`)
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 New Directory Tree
+
+After `aipm init --marketplace`, the `.ai/starter/` plugin will contain:
+
+```
+.ai/
+  .gitignore
+  starter/
+    aipm.toml                              # Updated [components] with all four types
+    .claude-plugin/plugin.json             # Updated description
+    .mcp.json                              # Unchanged
+    skills/scaffold-plugin/SKILL.md        # NEW — scaffold-plugin skill
+    scripts/scaffold-plugin.ts             # NEW — TypeScript scaffolding script
+    agents/marketplace-scanner.md          # NEW — read-only .ai/ scanner agent
+    hooks/hooks.json                       # NEW — post-model logging hook
+```
+
+After `aipm init --marketplace --no-starter`, only the bare marketplace directory is created:
+
+```
+.ai/
+  .gitignore
+```
+
+### 4.2 Architectural Pattern
+
+**Template Generation** — follows the existing pattern established by `generate_skill_template()`, `generate_starter_manifest()`, etc. Each new component gets a dedicated `generate_*()` function that returns a `String`. All content is written to disk before manifest validation.
+
+### 4.3 Key Components
+
+| Component | File | Purpose | Technology |
+|-----------|------|---------|------------|
+| Scaffold-Plugin Skill | `skills/scaffold-plugin/SKILL.md` | Instructs the AI to run the scaffolding script when user wants to create a new plugin | Markdown with YAML frontmatter |
+| Scaffold Script | `scripts/scaffold-plugin.ts` | Creates a new plugin directory with `aipm.toml`, skill stub, and `.claude-plugin/` | TypeScript (run via `node --experimental-strip-types`) |
+| Marketplace Scanner | `agents/marketplace-scanner.md` | Sub-agent scoped to read-only analysis of `.ai/` directory contents | Markdown with YAML frontmatter |
+| Logging Hook | `hooks/hooks.json` | Logs a timestamp and tool name after every model tool use | JSON hook config |
+
+## 5. Detailed Design
+
+### 5.1 Scaffold-Plugin Skill — `skills/scaffold-plugin/SKILL.md`
+
+This skill has `disable-model-invocation: false` (default) because the AI needs to interpret user intent (plugin name, description) before invoking the script. The skill instructs the agent to gather parameters and run the TypeScript script.
+
+**Content (under 50 lines):**
+
+```markdown
+---
+description: Scaffold a new AI plugin in the .ai/ marketplace directory. Use when the user wants to create a new plugin, skill, agent, or hook package.
+---
+
+# Scaffold Plugin
+
+Create a new plugin in the `.ai/` marketplace directory.
+
+## Instructions
+
+1. Ask the user for a plugin name (lowercase, hyphens allowed) if not provided.
+2. Run the scaffolding script:
+   ```bash
+   node --experimental-strip-types .ai/starter/scripts/scaffold-plugin.ts <plugin-name>
+   ```
+3. Report the created file tree to the user.
+4. Suggest next steps: edit the generated `SKILL.md`, add agents or hooks, update `aipm.toml`.
+
+## Notes
+
+- The script creates `.ai/<plugin-name>/` with a valid `aipm.toml` and starter skill.
+- If the directory already exists, the script exits with an error message.
+- After scaffolding, the user should customize the generated files.
+```
+
+### 5.2 Scaffold Script — `scripts/scaffold-plugin.ts`
+
+A minimal TypeScript script that creates a new plugin directory. It runs via `node --experimental-strip-types` (Node.js >= 22.6.0) — no third-party TypeScript runners required. It must not use any npm dependencies — only Node.js built-ins (`fs`, `path`, `process`).
+
+**Content:**
+
+```typescript
+import { mkdirSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const name = process.argv[2];
+if (!name) {
+  process.stderr.write("Usage: node --experimental-strip-types scaffold-plugin.ts <plugin-name>\n");
+  process.exit(1);
+}
+
+const aiDir = join(process.cwd(), ".ai");
+const pluginDir = join(aiDir, name);
+
+if (existsSync(pluginDir)) {
+  process.stderr.write(`Error: .ai/${name}/ already exists\n`);
+  process.exit(1);
+}
+
+mkdirSync(join(pluginDir, ".claude-plugin"), { recursive: true });
+mkdirSync(join(pluginDir, "skills", name), { recursive: true });
+mkdirSync(join(pluginDir, "agents"), { recursive: true });
+mkdirSync(join(pluginDir, "hooks"), { recursive: true });
+
+writeFileSync(
+  join(pluginDir, "aipm.toml"),
+  `[package]\nname = "${name}"\nversion = "0.1.0"\ntype = "composite"\nedition = "2024"\ndescription = "TODO: describe ${name}"\n\n[components]\nskills = ["skills/${name}/SKILL.md"]\n`
+);
+
+writeFileSync(
+  join(pluginDir, "skills", name, "SKILL.md"),
+  `---\ndescription: TODO — describe when this skill should be invoked\n---\n\n# ${name}\n\nReplace this with instructions for the AI agent.\n`
+);
+
+writeFileSync(
+  join(pluginDir, ".claude-plugin", "plugin.json"),
+  JSON.stringify({ name, version: "0.1.0", description: `TODO: describe ${name}` }, null, 2) + "\n"
+);
+
+process.stdout.write(`Created .ai/${name}/ with starter structure\n`);
+```
+
+### 5.3 Marketplace Scanner Agent — `agents/marketplace-scanner.md`
+
+Scoped to read-only tools only. The `tools` frontmatter key restricts the agent to `Read`, `Glob`, `Grep`, and `LS` — no `Edit`, `Write`, or `Bash` access. This follows the agent markdown format documented in [Claude Code defaults research §7](../research/docs/2026-03-16-claude-code-defaults.md) and [Copilot agent discovery research](../research/docs/2026-03-16-copilot-agent-discovery.md).
+
+**Content (under 50 lines):**
+
+```markdown
+---
+name: marketplace-scanner
+description: Scan and explain the contents of the .ai/ marketplace directory. Use when the user wants to understand what plugins, skills, agents, or hooks are installed locally.
+tools:
+  - Read
+  - Glob
+  - Grep
+  - LS
+---
+
+# Marketplace Scanner
+
+You are a read-only analysis agent for the `.ai/` marketplace directory.
+
+## Instructions
+
+1. List all plugin directories under `.ai/` (each subdirectory with an `aipm.toml`).
+2. For each plugin, read its `aipm.toml` and summarize:
+   - Package name, version, type, and description
+   - Declared components (skills, agents, hooks, scripts)
+3. If asked about a specific component, read and explain its contents.
+4. Never modify any files — you are read-only.
+
+## Scope
+
+- Only scan files within the `.ai/` directory.
+- Do not access files outside `.ai/` unless explicitly asked.
+- Report any `aipm.toml` parse issues you encounter.
+```
+
+### 5.4 Logging Hook — `hooks/hooks.json`
+
+Uses the `PostToolUse` lifecycle event ([Claude Code defaults research §7](../research/docs/2026-03-16-claude-code-defaults.md)). The hook appends a timestamped log line to `.ai/.tool-usage.log`.
+
+**Content:**
+
+```json
+{
+  "hooks": [
+    {
+      "event": "PostToolUse",
+      "command": "echo \"$(date -u +%Y-%m-%dT%H:%M:%SZ) tool=$TOOL_NAME\" >> .ai/.tool-usage.log"
+    }
+  ]
+}
+```
+
+> **Note:** The `PostToolUse` event and `$TOOL_NAME` environment variable are Claude Code hook conventions. The command is a simple shell one-liner that requires no dependencies. On Windows, this will need a compatible shell (Git Bash, WSL) — this is acceptable for a starter template.
+
+### 5.5 Updated Starter Manifest — `generate_starter_manifest()`
+
+The manifest grows from declaring only `skills` to declaring all four component types:
+
+```toml
+[package]
+name = "starter"
+version = "0.1.0"
+type = "composite"
+edition = "2024"
+description = "Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage"
+
+# [dependencies]
+# Add registry dependencies here, e.g.:
+# shared-skill = "^1.0"
+
+[components]
+skills = ["skills/scaffold-plugin/SKILL.md"]
+agents = ["agents/marketplace-scanner.md"]
+hooks = ["hooks/hooks.json"]
+scripts = ["scripts/scaffold-plugin.ts"]
+```
+
+### 5.6 Updated Plugin JSON — `generate_plugin_json()`
+
+```json
+{
+  "name": "starter",
+  "version": "0.1.0",
+  "description": "Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage"
+}
+```
+
+### 5.7 Changes to `scaffold_marketplace()`
+
+The function's directory creation and file writing steps change as follows:
+
+**Directory creation (replace existing):**
+
+```rust
+// Create directory tree
+std::fs::create_dir_all(starter.join(".claude-plugin"))?;
+std::fs::create_dir_all(starter.join("skills").join("scaffold-plugin"))?;
+std::fs::create_dir_all(starter.join("scripts"))?;
+std::fs::create_dir_all(starter.join("agents"))?;
+std::fs::create_dir_all(starter.join("hooks"))?;
+```
+
+**File writes before validation (all must precede `parse_and_validate()`):**
+
+```rust
+// Write all component files before manifest validation
+write_file(&starter.join("skills").join("scaffold-plugin").join("SKILL.md"),
+           &generate_skill_template())?;
+write_file(&starter.join("scripts").join("scaffold-plugin.ts"),
+           &generate_scaffold_script())?;
+write_file(&starter.join("agents").join("marketplace-scanner.md"),
+           &generate_agent_template())?;
+write_file(&starter.join("hooks").join("hooks.json"),
+           &generate_hook_template())?;
+
+// Write manifest and validate
+let starter_manifest = generate_starter_manifest();
+write_file(&starter.join("aipm.toml"), &starter_manifest)?;
+crate::manifest::parse_and_validate(&starter_manifest, Some(&starter))
+    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+```
+
+**File writes after validation (metadata files):**
+
+```rust
+// .ai/starter/.claude-plugin/plugin.json
+write_file(&starter.join(".claude-plugin").join("plugin.json"), &generate_plugin_json())?;
+
+// .ai/starter/.mcp.json
+write_file(&starter.join(".mcp.json"), &generate_mcp_stub())?;
+```
+
+**Removals:**
+
+- Delete the two `write_file` calls for `.gitkeep` files (lines 206-207)
+- Delete `skills/hello/` directory creation (line 175)
+
+### 5.8 New `generate_*()` Functions
+
+Four functions are modified or added:
+
+| Function | Status | Description |
+|----------|--------|-------------|
+| `generate_starter_manifest()` | **Modified** | Updated `[components]` to include skills, agents, hooks, scripts |
+| `generate_plugin_json()` | **Modified** | Updated description |
+| `generate_skill_template()` | **Modified** | Replaced hello skill with scaffold-plugin skill content |
+| `generate_scaffold_script()` | **New** | Returns the TypeScript script as a string |
+| `generate_agent_template()` | **New** | Returns the marketplace-scanner agent markdown |
+| `generate_hook_template()` | **New** | Returns the hooks.json content |
+| `generate_mcp_stub()` | **Unchanged** | No changes |
+
+### 5.9 `--no-starter` CLI Flag
+
+The `--no-starter` flag allows users to create the `.ai/` marketplace directory without the starter plugin. This is useful for teams that want to manage their own plugin structure from scratch.
+
+#### 5.9.1 CLI Changes — `crates/aipm/src/main.rs`
+
+Add a new argument to the `Init` variant:
+
+```rust
+/// Initialize a workspace for AI plugin management.
+Init {
+    /// Generate a workspace manifest (aipm.toml with [workspace] section).
+    #[arg(long)]
+    workspace: bool,
+
+    /// Generate a .ai/ local marketplace with tool settings.
+    #[arg(long)]
+    marketplace: bool,
+
+    /// Skip the starter plugin (create bare .ai/ directory only).
+    #[arg(long)]
+    no_starter: bool,
+
+    /// Directory to initialize (defaults to current directory).
+    #[arg(default_value = ".")]
+    dir: PathBuf,
+},
+```
+
+Pass the flag through to `Options`:
+
+```rust
+let opts = libaipm::workspace_init::Options {
+    dir: &dir,
+    workspace: do_workspace,
+    marketplace: do_marketplace,
+    no_starter,
+};
+```
+
+Update the `MarketplaceCreated` output message to reflect the mode:
+
+```rust
+libaipm::workspace_init::InitAction::MarketplaceCreated => {
+    if no_starter {
+        "Created .ai/ marketplace (no starter plugin)".to_string()
+    } else {
+        "Created .ai/ marketplace with starter plugin".to_string()
+    }
+},
+```
+
+#### 5.9.2 Options Struct — `workspace_init/mod.rs`
+
+Add `no_starter` to `Options`:
+
+```rust
+/// Options for workspace initialization.
+pub struct Options<'a> {
+    /// Target directory.
+    pub dir: &'a Path,
+    /// Generate workspace manifest.
+    pub workspace: bool,
+    /// Generate `.ai/` marketplace + tool settings.
+    pub marketplace: bool,
+    /// Skip the starter plugin (bare `.ai/` directory only).
+    pub no_starter: bool,
+}
+```
+
+#### 5.9.3 `scaffold_marketplace()` Signature Change
+
+The function gains a `no_starter: bool` parameter:
+
+```rust
+fn scaffold_marketplace(dir: &Path, no_starter: bool) -> Result<(), Error> {
+    let ai_dir = dir.join(".ai");
+    if ai_dir.exists() {
+        return Err(Error::MarketplaceAlreadyExists(dir.to_path_buf()));
+    }
+
+    // Always create .ai/ and .gitignore
+    std::fs::create_dir_all(&ai_dir)?;
+    write_file(
+        &ai_dir.join(".gitignore"),
+        "# Managed by aipm — registry-installed plugins are symlinked here.\n\
+         # Do not edit the section between the markers.\n\
+         # === aipm managed start ===\n\
+         # === aipm managed end ===\n",
+    )?;
+
+    if no_starter {
+        return Ok(());
+    }
+
+    // ... existing starter plugin scaffolding continues here ...
+}
+```
+
+The caller in `init()` passes the flag:
+
+```rust
+if opts.marketplace {
+    scaffold_marketplace(opts.dir, opts.no_starter)?;
+    actions.push(InitAction::MarketplaceCreated);
+    // ...
+}
+```
+
+#### 5.9.4 Flag Interactions
+
+| Flags | Behavior |
+|-------|----------|
+| `aipm init` (no flags) | `--marketplace` implied, starter plugin created |
+| `aipm init --marketplace` | Starter plugin created |
+| `aipm init --marketplace --no-starter` | Bare `.ai/` + `.gitignore` only, no `starter/` |
+| `aipm init --no-starter` | Same as above (`--marketplace` implied) |
+| `aipm init --workspace --no-starter` | Only `aipm.toml`, no `.ai/` directory at all (`--no-starter` has no effect without `--marketplace`) |
+| `aipm init --workspace --marketplace --no-starter` | `aipm.toml` + bare `.ai/` |
+
+> **Note:** `--no-starter` only has meaning when `--marketplace` is active (explicitly or by default). When only `--workspace` is passed, the flag is silently ignored since no marketplace scaffolding occurs.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Reason for Rejection |
+|--------|------|------|---------------------|
+| **Shell script instead of TypeScript** | No runtime dependency | Less readable, harder to maintain, poor Windows compat | TypeScript is more idiomatic for AI tool ecosystems; Node.js `--experimental-strip-types` requires no extra tooling |
+| **`npx tsx` or `ts-node` runner** | Well-known, stable API | Adds a third-party dependency or network fetch; slower cold start | `node --experimental-strip-types` is zero-dependency and ships with Node.js >= 22.6.0 |
+| **Inline skill without script** | Simpler, no scripts/ directory needed | AI would generate the file structure ad-hoc each time; less consistent | A script ensures deterministic output and teaches the scripts component pattern |
+| **`disable-model-invocation: true` on scaffold skill** | Prevents AI from using tokens when scaffolding | The AI needs to interpret user intent (plugin name, description) and report results | Model invocation is necessary for a good UX |
+| **Separate plugin per component** | Demonstrates single-type plugin format | More directories, confusing for first-time users | A single composite plugin is simpler to understand |
+| **Log to stdout instead of file** | Simpler hook command | Ephemeral, user can't review history | A log file provides persistent, reviewable history |
+| **`--starter` opt-in instead of `--no-starter` opt-out** | Explicit consent for starter content | Breaks existing behavior; new users miss the examples | Starter plugin is educational — opt-out is the right default |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Validation
+
+- All four component paths (`skills/scaffold-plugin/SKILL.md`, `agents/marketplace-scanner.md`, `hooks/hooks.json`, `scripts/scaffold-plugin.ts`) must exist on disk before `parse_and_validate()` is called — matching the existing write-before-validate pattern ([research §Validation Considerations](../research/docs/2026-03-20-30-better-default-plugin.md))
+- `validate_component_paths()` at `validate.rs:167-192` already handles `scripts` validation via the `all_paths` array — no validation code changes needed
+- The manifest round-trip test must be updated to create all four component files in the temp directory
+
+### 7.2 50-Line Constraint
+
+| File | Estimated Lines | Under 50? |
+|------|----------------|-----------|
+| `skills/scaffold-plugin/SKILL.md` | ~22 | Yes |
+| `agents/marketplace-scanner.md` | ~26 | Yes |
+| `hooks/hooks.json` | ~8 | Yes |
+| `scripts/scaffold-plugin.ts` | ~35 | Yes |
+
+### 7.3 Platform Considerations
+
+- The hook's `echo` + `date` command uses Unix shell syntax. On Windows with Git Bash or WSL this works. On native Windows cmd.exe it will not — this is acceptable for a starter template that users are expected to customize.
+- The scaffold script uses `process.exit(1)` — note this is in the generated TypeScript file, not in aipm's Rust code, so the `forbid(exit)` lint does not apply.
+- `node --experimental-strip-types` requires Node.js >= 22.6.0. This is the current LTS line (as of 2026). The flag emits a warning to stderr on older Node versions but does not fail — however, type stripping may not work correctly below 22.6.0. The skill instructions should note the minimum Node version.
+
+## 8. Migration, Rollout, and Testing
+
+### 8.1 Deployment Strategy
+
+- [ ] **Phase 1**: Add `no_starter: bool` to `Options` struct and thread it through `init()` → `scaffold_marketplace()`. Add `--no-starter` CLI arg. Existing behavior unchanged (flag defaults to `false`).
+- [ ] **Phase 2**: Add new `generate_*()` functions (`generate_scaffold_script()`, `generate_agent_template()`, `generate_hook_template()`). No functional changes yet — just new dead code.
+- [ ] **Phase 3**: Update `generate_starter_manifest()` and `generate_plugin_json()` with new content.
+- [ ] **Phase 4**: Update `scaffold_marketplace()` — new directory tree, new file writes, remove `.gitkeep` writes, early return when `no_starter` is true.
+- [ ] **Phase 5**: Update `generate_skill_template()` — replace hello skill with scaffold-plugin content.
+- [ ] **Phase 6**: Update unit tests and BDD scenarios (including `--no-starter` cases).
+- [ ] **Phase 7**: Run full `cargo build --workspace && cargo test --workspace && cargo clippy --workspace -- -D warnings && cargo fmt --check`.
+
+### 8.2 Test Plan
+
+**Unit tests to modify (`workspace_init/mod.rs`):**
+
+| Test | Change |
+|------|--------|
+| `starter_manifest_round_trips` | Create all four component files in temp dir (not just `skills/hello/SKILL.md`) |
+| `init_marketplace_creates_tree` | Assert new file paths (`scaffold-plugin/SKILL.md`, `marketplace-scanner.md`, `hooks.json`, `scaffold-plugin.ts`); remove `.gitkeep` assertions |
+| `skill_template_has_frontmatter` | Update assertion — content changes but `description:` frontmatter still present |
+| All tests constructing `Options` | Add `no_starter: false` to existing `Options` structs |
+
+**New unit tests:**
+
+| Test | Purpose |
+|------|---------|
+| `agent_template_has_frontmatter` | Verify agent markdown contains `name:`, `description:`, `tools:` frontmatter |
+| `hook_template_is_valid_json` | Verify `generate_hook_template()` parses as valid JSON with a `hooks` array |
+| `scaffold_script_is_nonempty` | Verify `generate_scaffold_script()` is non-empty and contains expected markers |
+| `init_marketplace_no_starter` | Verify `no_starter: true` creates `.ai/` + `.gitignore` but no `starter/` directory |
+| `init_no_starter_still_configures_tools` | Verify tool adaptors still run when `--no-starter` is set (`.claude/settings.json` is created) |
+
+**BDD scenarios to modify (`tests/features/manifest/workspace-init.feature`):**
+
+| Scenario | Change |
+|----------|--------|
+| "Marketplace generates a Claude Code plugin structure" (line 37-42) | Replace `skills/hello/SKILL.md` assertion with `skills/scaffold-plugin/SKILL.md`; add assertions for `agents/marketplace-scanner.md`, `hooks/hooks.json`, `scripts/scaffold-plugin.ts` |
+| "Marketplace generates a starter skill with description frontmatter" (line 44-48) | Update path from `skills/hello/SKILL.md` to `skills/scaffold-plugin/SKILL.md` |
+| "Initialize a workspace with default marketplace" (line 15-27) | Add `scripts/` to the directory list |
+
+**BDD scenarios to add:**
+
+| Scenario | Purpose |
+|----------|---------|
+| "Starter plugin includes a marketplace scanner agent" | Assert `agents/marketplace-scanner.md` exists and contains `tools:` frontmatter |
+| "Starter plugin includes a logging hook" | Assert `hooks/hooks.json` exists and contains `PostToolUse` |
+| "Starter plugin includes a scaffold script" | Assert `scripts/scaffold-plugin.ts` exists |
+| "No-starter flag creates bare marketplace directory" | Assert `.ai/` and `.ai/.gitignore` exist but `.ai/starter/` does not |
+| "No-starter flag still configures tool settings" | Assert `.claude/settings.json` is created even with `--no-starter` |
+| "No-starter flag with workspace creates both minus starter" | Assert `aipm.toml` + `.ai/` exist but no `.ai/starter/` |
+
+## 9. Open Questions / Unresolved Issues
+
+- [x] **TypeScript runtime assumption**: **RESOLVED** — Use `node --experimental-strip-types` (Node.js >= 22.6.0). Zero third-party dependencies; no `npx tsx` or `ts-node` needed. The flag is stable enough for a starter template, and Node.js 22 is the current LTS.
+- [ ] **Hook event name**: The research documents `PreToolUse` and `PostToolUse` but does not confirm these are the only events. The issue says "after any model runs" which might imply a broader event. **Recommendation**: Use `PostToolUse` as documented — it fires after each tool use which is the closest available event.
+- [ ] **`.ai/.tool-usage.log` in `.gitignore`**: Should the managed `.ai/.gitignore` include `*.log` or `.tool-usage.log` to prevent accidental commits of the log file? **Recommendation**: Yes — add `.tool-usage.log` to the gitignore managed section.
+- [ ] **Windows hook compatibility**: The `echo` + `date` hook command won't work on native Windows cmd.exe. Should we provide a cross-platform alternative (e.g., a Node.js one-liner)? **Recommendation**: Accept the limitation for now — document it in the hook file with a comment. Users on Windows with Git Bash/WSL will be fine.

--- a/tests/features/manifest/workspace-init.feature
+++ b/tests/features/manifest/workspace-init.feature
@@ -21,6 +21,7 @@ Feature: Workspace initialization
       | .ai/                             |
       | .ai/starter/                     |
       | .ai/starter/skills/              |
+      | .ai/starter/scripts/             |
       | .ai/starter/agents/              |
       | .ai/starter/hooks/               |
       | .ai/starter/.claude-plugin/      |
@@ -38,14 +39,51 @@ Feature: Workspace initialization
     Given an empty directory "my-project"
     When the user runs "aipm init --marketplace" in "my-project"
     Then a file ".ai/starter/.claude-plugin/plugin.json" exists in "my-project"
-    And a file ".ai/starter/skills/hello/SKILL.md" exists in "my-project"
+    And a file ".ai/starter/skills/scaffold-plugin/SKILL.md" exists in "my-project"
+    And a file ".ai/starter/scripts/scaffold-plugin.ts" exists in "my-project"
+    And a file ".ai/starter/agents/marketplace-scanner.md" exists in "my-project"
+    And a file ".ai/starter/hooks/hooks.json" exists in "my-project"
     And a file ".ai/starter/.mcp.json" exists in "my-project"
 
   Scenario: Marketplace generates a starter skill with description frontmatter
     Given an empty directory "my-project"
     When the user runs "aipm init --marketplace" in "my-project"
-    Then a file ".ai/starter/skills/hello/SKILL.md" exists in "my-project"
+    Then a file ".ai/starter/skills/scaffold-plugin/SKILL.md" exists in "my-project"
     And the starter skill contains "description:" in the frontmatter
+
+  Scenario: Starter plugin includes a marketplace scanner agent
+    Given an empty directory "my-project"
+    When the user runs "aipm init --marketplace" in "my-project"
+    Then a file ".ai/starter/agents/marketplace-scanner.md" exists in "my-project"
+
+  Scenario: Starter plugin includes a logging hook
+    Given an empty directory "my-project"
+    When the user runs "aipm init --marketplace" in "my-project"
+    Then a file ".ai/starter/hooks/hooks.json" exists in "my-project"
+
+  Scenario: Starter plugin includes a scaffold script
+    Given an empty directory "my-project"
+    When the user runs "aipm init --marketplace" in "my-project"
+    Then a file ".ai/starter/scripts/scaffold-plugin.ts" exists in "my-project"
+
+  Scenario: No-starter flag creates bare marketplace directory
+    Given an empty directory "my-project"
+    When the user runs "aipm init --no-starter" in "my-project"
+    Then a file ".ai/.gitignore" exists in "my-project"
+    And there is no directory ".ai/starter" in "my-project"
+
+  Scenario: No-starter flag still configures tool settings
+    Given an empty directory "my-project"
+    When the user runs "aipm init --no-starter" in "my-project"
+    Then a file ".claude/settings.json" exists in "my-project"
+    And there is no directory ".ai/starter" in "my-project"
+
+  Scenario: No-starter flag with workspace creates both minus starter
+    Given an empty directory "my-project"
+    When the user runs "aipm init --workspace --marketplace --no-starter" in "my-project"
+    Then a file "aipm.toml" is created in "my-project"
+    And a file ".ai/.gitignore" exists in "my-project"
+    And there is no directory ".ai/starter" in "my-project"
 
   Scenario: Generated gitignore has aipm managed markers
     Given an empty directory "my-project"


### PR DESCRIPTION
## Summary

Closes #30

- Replace minimal starter plugin with three functional components: a **scaffold-plugin skill** (TypeScript script via `node --experimental-strip-types`), a **marketplace-scanner sub-agent** (read-only `.ai/` analysis), and a **PostToolUse logging hook** (writes to `.ai/.tool-usage.log`)
- Add `--no-starter` CLI flag to `aipm init` that creates bare `.ai/` directory without the starter plugin
- Remove `.gitkeep` stubs — all component directories now contain real files
- Update starter manifest to declare all four component types (skills, agents, hooks, scripts)

## Test plan

- [x] `cargo build --workspace` — zero errors
- [x] `cargo test --workspace` — 82 unit + 25 e2e + 48 BDD scenarios pass (0 failures)
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] New unit tests: `agent_template_has_frontmatter`, `hook_template_is_valid_json`, `scaffold_script_is_nonempty`, `init_marketplace_no_starter`, `init_no_starter_still_configures_tools`
- [x] New BDD scenarios: marketplace scanner agent, logging hook, scaffold script, `--no-starter` flag (3 scenarios)
- [x] No `#[allow(...)]`, `.unwrap()`, `.expect()`, `panic!()`, or `println!()` in new code