### PR TITLE
feat: add conventional commit hook for changelog generation

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Validate conventional commit format on the commit message.
+# Activate with: git config core.hooksPath .githooks
+
+MSG=$(head -1 "$1")
+PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+'
+
+# Allow merge commits and release-plz auto-commits
+if echo "$MSG" | grep -qE '^Merge '; then
+  exit 0
+fi
+
+if ! echo "$MSG" | grep -qE "$PATTERN"; then
+  echo "ERROR: Commit message must follow conventional commits format:"
+  echo ""
+  echo "  type: description"
+  echo "  type(scope): description"
+  echo ""
+  echo "Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+  echo ""
+  echo "Examples:"
+  echo "  feat: add scaffold skill and --no-starter flag"
+  echo "  fix(cli): correct argument parsing for init command"
+  echo "  refactor: extract ToolAdaptor trait"
+  echo ""
+  echo "Got: $MSG"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds a `.githooks/commit-msg` hook that validates commit messages follow the [conventional commits](https://www.conventionalcommits.org/) format (`type: description`)
- This enables `git-cliff` to parse commits into structured changelog entries — the existing `cliff.toml` + `release-plz.toml` pipeline is already wired, but changelogs have been empty because commits lacked conventional prefixes
- Merge commits are allowed through without validation

## Setup
After cloning, activate with:
```
git config core.hooksPath .githooks
```

## Test plan
- [x] Bad messages rejected with helpful error
- [x] Valid conventional messages (`feat:`, `fix:`, etc.) pass
- [x] Merge commits pass
- [ ] Does not affect CI or release-plz workflows (local-only hook)