### PR TITLE
fix: add marketplace.json to scaffold and rename starter plugin

### DIFF
--- a/crates/aipm/tests/init_e2e.rs
+++ b/crates/aipm/tests/init_e2e.rs
@@ -26,7 +26,10 @@ fn init_default_creates_marketplace_only() {
     aipm().args(["init", &dir.display().to_string()]).assert().success();
 
     assert!(!dir.join("aipm.toml").exists(), "aipm.toml should NOT exist");
-    assert!(dir.join(".ai/starter/aipm.toml").exists(), ".ai/starter/aipm.toml should exist");
+    assert!(
+        dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
+        ".ai/starter-aipm-plugin/aipm.toml should exist"
+    );
     assert!(dir.join(".claude/settings.json").exists(), ".claude/settings.json should exist");
 }
 
@@ -55,7 +58,10 @@ fn init_marketplace_only() {
 
     aipm().args(["init", "--marketplace", &dir.display().to_string()]).assert().success();
 
-    assert!(dir.join(".ai/starter/aipm.toml").exists(), ".ai/starter should exist");
+    assert!(
+        dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
+        ".ai/starter-aipm-plugin should exist"
+    );
     assert!(!dir.join("aipm.toml").exists(), "aipm.toml should NOT exist");
 }
 
@@ -137,8 +143,8 @@ fn init_starter_manifest_valid_toml() {
 
     aipm().args(["init", "--marketplace", &dir.display().to_string()]).assert().success();
 
-    let content = std::fs::read_to_string(dir.join(".ai/starter/aipm.toml")).unwrap();
-    assert!(content.contains("name = \"starter\""));
+    let content = std::fs::read_to_string(dir.join(".ai/starter-aipm-plugin/aipm.toml")).unwrap();
+    assert!(content.contains("name = \"starter-aipm-plugin\""));
     assert!(content.contains("version = \"0.1.0\""));
     assert!(content.contains("type = \"composite\""));
 }

--- a/crates/libaipm/src/workspace_init/adaptors/claude.rs
+++ b/crates/libaipm/src/workspace_init/adaptors/claude.rs
@@ -29,11 +29,14 @@ impl ToolAdaptor for Adaptor {
             &settings_path,
             "{\n\
              \x20 \"extraKnownMarketplaces\": {\n\
-             \x20   \"local\": {\n\
+             \x20   \"local-repo-plugins\": {\n\
              \x20     \"source\": {\n\
              \x20       \"source\": \"directory\",\n\
              \x20       \"path\": \".ai\"\n\
-             \x20     }\n\
+             \x20     },\n\
+             \x20     \"enabledPlugins\": [\n\
+             \x20       \"starter-aipm-plugin\"\n\
+             \x20     ]\n\
              \x20   }\n\
              \x20 }\n\
              }\n",
@@ -56,7 +59,7 @@ fn merge_claude_settings(settings_path: &Path) -> Result<bool, Error> {
     })?;
 
     if let Some(ekm) = obj.get("extraKnownMarketplaces") {
-        if ekm.get("local").is_some() {
+        if ekm.get("local-repo-plugins").is_some() {
             return Ok(false);
         }
     }
@@ -65,17 +68,18 @@ fn merge_claude_settings(settings_path: &Path) -> Result<bool, Error> {
         "source": {
             "source": "directory",
             "path": ".ai"
-        }
+        },
+        "enabledPlugins": ["starter-aipm-plugin"]
     });
 
     if let Some(ekm) = obj.get_mut("extraKnownMarketplaces") {
         if let Some(ekm_obj) = ekm.as_object_mut() {
-            ekm_obj.insert("local".to_string(), marketplace_entry);
+            ekm_obj.insert("local-repo-plugins".to_string(), marketplace_entry);
         }
     } else {
         obj.insert(
             "extraKnownMarketplaces".to_string(),
-            serde_json::json!({ "local": marketplace_entry }),
+            serde_json::json!({ "local-repo-plugins": marketplace_entry }),
         );
     }
 
@@ -146,7 +150,7 @@ mod tests {
         std::fs::create_dir_all(tmp.join(".claude")).ok();
         std::fs::write(
             tmp.join(".claude/settings.json"),
-            "{\"extraKnownMarketplaces\": {\"local\": {\"source\": {\"source\": \"directory\", \"path\": \".ai\"}}}}",
+            "{\"extraKnownMarketplaces\": {\"local-repo-plugins\": {\"source\": {\"source\": \"directory\", \"path\": \".ai\"}}}}",
         ).ok();
 
         let adaptor = Adaptor;

--- a/crates/libaipm/src/workspace_init/mod.rs
+++ b/crates/libaipm/src/workspace_init/mod.rs
@@ -180,11 +180,18 @@ fn scaffold_marketplace(dir: &Path, no_starter: bool) -> Result<(), Error> {
          # === aipm managed end ===\n",
     )?;
 
+    // Create marketplace.json in .ai/.claude-plugin/
+    std::fs::create_dir_all(ai_dir.join(".claude-plugin"))?;
+    write_file(
+        &ai_dir.join(".claude-plugin").join("marketplace.json"),
+        &generate_marketplace_json(no_starter),
+    )?;
+
     if no_starter {
         return Ok(());
     }
 
-    let starter = ai_dir.join("starter");
+    let starter = ai_dir.join("starter-aipm-plugin");
 
     // Create directory tree
     std::fs::create_dir_all(starter.join(".claude-plugin"))?;
@@ -202,7 +209,7 @@ fn scaffold_marketplace(dir: &Path, no_starter: bool) -> Result<(), Error> {
     write_file(&starter.join("agents").join("marketplace-scanner.md"), &generate_agent_template())?;
     write_file(&starter.join("hooks").join("hooks.json"), &generate_hook_template())?;
 
-    // .ai/starter/aipm.toml
+    // .ai/starter-aipm-plugin/aipm.toml
     let starter_manifest = generate_starter_manifest();
     write_file(&starter.join("aipm.toml"), &starter_manifest)?;
 
@@ -210,10 +217,10 @@ fn scaffold_marketplace(dir: &Path, no_starter: bool) -> Result<(), Error> {
     crate::manifest::parse_and_validate(&starter_manifest, Some(&starter))
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-    // .ai/starter/.claude-plugin/plugin.json
+    // .ai/starter-aipm-plugin/.claude-plugin/plugin.json
     write_file(&starter.join(".claude-plugin").join("plugin.json"), &generate_plugin_json())?;
 
-    // .ai/starter/.mcp.json
+    // .ai/starter-aipm-plugin/.mcp.json
     write_file(&starter.join(".mcp.json"), &generate_mcp_stub())?;
 
     Ok(())
@@ -221,7 +228,7 @@ fn scaffold_marketplace(dir: &Path, no_starter: bool) -> Result<(), Error> {
 
 fn generate_starter_manifest() -> String {
     "[package]\n\
-     name = \"starter\"\n\
+     name = \"starter-aipm-plugin\"\n\
      version = \"0.1.0\"\n\
      type = \"composite\"\n\
      edition = \"2024\"\n\
@@ -241,7 +248,7 @@ fn generate_starter_manifest() -> String {
 
 fn generate_plugin_json() -> String {
     "{\n\
-     \x20 \"name\": \"starter\",\n\
+     \x20 \"name\": \"starter-aipm-plugin\",\n\
      \x20 \"version\": \"0.1.0\",\n\
      \x20 \"description\": \"Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage\"\n\
      }\n"
@@ -262,7 +269,7 @@ fn generate_skill_template() -> String {
      1. Ask the user for a plugin name (lowercase, hyphens allowed) if not provided.\n\
      2. Run the scaffolding script:\n\
      \x20  ```bash\n\
-     \x20  node --experimental-strip-types .ai/starter/scripts/scaffold-plugin.ts <plugin-name>\n\
+     \x20  node --experimental-strip-types .ai/starter-aipm-plugin/scripts/scaffold-plugin.ts <plugin-name>\n\
      \x20  ```\n\
      3. Report the created file tree to the user.\n\
      4. Suggest next steps: edit the generated `SKILL.md`, add agents or hooks, update `aipm.toml`.\n\
@@ -359,6 +366,40 @@ fn generate_hook_template() -> String {
      \x20 ]\n\
      }\n"
     .to_string()
+}
+
+fn generate_marketplace_json(no_starter: bool) -> String {
+    if no_starter {
+        "{\n\
+         \x20 \"name\": \"local-repo-plugins\",\n\
+         \x20 \"owner\": {\n\
+         \x20   \"name\": \"local\"\n\
+         \x20 },\n\
+         \x20 \"metadata\": {\n\
+         \x20   \"description\": \"Local plugins for this repository\"\n\
+         \x20 },\n\
+         \x20 \"plugins\": []\n\
+         }\n"
+        .to_string()
+    } else {
+        "{\n\
+         \x20 \"name\": \"local-repo-plugins\",\n\
+         \x20 \"owner\": {\n\
+         \x20   \"name\": \"local\"\n\
+         \x20 },\n\
+         \x20 \"metadata\": {\n\
+         \x20   \"description\": \"Local plugins for this repository\"\n\
+         \x20 },\n\
+         \x20 \"plugins\": [\n\
+         \x20   {\n\
+         \x20     \"name\": \"starter-aipm-plugin\",\n\
+         \x20     \"source\": \"./starter-aipm-plugin\",\n\
+         \x20     \"description\": \"Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage\"\n\
+         \x20   }\n\
+         \x20 ]\n\
+         }\n"
+        .to_string()
+    }
 }
 
 fn generate_mcp_stub() -> String {
@@ -463,13 +504,13 @@ mod tests {
         assert!(result.is_ok_and(|r| r.actions.contains(&InitAction::MarketplaceCreated)));
 
         assert!(tmp.join(".ai").is_dir());
-        assert!(tmp.join(".ai/starter/aipm.toml").exists());
-        assert!(tmp.join(".ai/starter/.claude-plugin/plugin.json").exists());
-        assert!(tmp.join(".ai/starter/skills/scaffold-plugin/SKILL.md").exists());
-        assert!(tmp.join(".ai/starter/scripts/scaffold-plugin.ts").exists());
-        assert!(tmp.join(".ai/starter/agents/marketplace-scanner.md").exists());
-        assert!(tmp.join(".ai/starter/hooks/hooks.json").exists());
-        assert!(tmp.join(".ai/starter/.mcp.json").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/aipm.toml").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/.claude-plugin/plugin.json").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/scripts/scaffold-plugin.ts").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/agents/marketplace-scanner.md").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/hooks/hooks.json").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/.mcp.json").exists());
         assert!(tmp.join(".ai/.gitignore").exists());
 
         cleanup(&tmp);
@@ -516,7 +557,7 @@ mod tests {
         assert!(r.as_ref().is_some_and(|r| r.actions.contains(&InitAction::WorkspaceCreated)));
         assert!(r.as_ref().is_some_and(|r| r.actions.contains(&InitAction::MarketplaceCreated)));
         assert!(tmp.join("aipm.toml").exists());
-        assert!(tmp.join(".ai/starter/aipm.toml").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/aipm.toml").exists());
 
         cleanup(&tmp);
     }
@@ -622,7 +663,7 @@ mod tests {
         assert!(tmp.join(".ai").is_dir());
         assert!(tmp.join(".ai/.gitignore").exists());
         // starter/ does NOT exist
-        assert!(!tmp.join(".ai/starter").exists());
+        assert!(!tmp.join(".ai/starter-aipm-plugin").exists());
 
         cleanup(&tmp);
     }
@@ -638,7 +679,7 @@ mod tests {
         // Tool settings should still be applied
         assert!(tmp.join(".claude/settings.json").exists());
         // But no starter plugin
-        assert!(!tmp.join(".ai/starter").exists());
+        assert!(!tmp.join(".ai/starter-aipm-plugin").exists());
 
         cleanup(&tmp);
     }

--- a/tests/features/manifest/workspace-init.feature
+++ b/tests/features/manifest/workspace-init.feature
@@ -19,71 +19,71 @@ Feature: Workspace initialization
     And the following directories exist in "my-project":
       | directory                        |
       | .ai/                             |
-      | .ai/starter/                     |
-      | .ai/starter/skills/              |
-      | .ai/starter/scripts/             |
-      | .ai/starter/agents/              |
-      | .ai/starter/hooks/               |
-      | .ai/starter/.claude-plugin/      |
+      | .ai/starter-aipm-plugin/                     |
+      | .ai/starter-aipm-plugin/skills/              |
+      | .ai/starter-aipm-plugin/scripts/             |
+      | .ai/starter-aipm-plugin/agents/              |
+      | .ai/starter-aipm-plugin/hooks/               |
+      | .ai/starter-aipm-plugin/.claude-plugin/      |
     And a file ".ai/.gitignore" exists in "my-project"
 
   Scenario: Marketplace generates a valid starter plugin manifest
     Given an empty directory "my-project"
     When the user runs "aipm init --workspace --marketplace" in "my-project"
-    Then a file ".ai/starter/aipm.toml" exists in "my-project"
-    And the starter plugin manifest contains the package name "starter"
+    Then a file ".ai/starter-aipm-plugin/aipm.toml" exists in "my-project"
+    And the starter plugin manifest contains the package name "starter-aipm-plugin"
     And the starter plugin manifest contains a version of "0.1.0"
     And the starter plugin manifest contains the plugin type "composite"
 
   Scenario: Marketplace generates a Claude Code plugin structure
     Given an empty directory "my-project"
     When the user runs "aipm init --marketplace" in "my-project"
-    Then a file ".ai/starter/.claude-plugin/plugin.json" exists in "my-project"
-    And a file ".ai/starter/skills/scaffold-plugin/SKILL.md" exists in "my-project"
-    And a file ".ai/starter/scripts/scaffold-plugin.ts" exists in "my-project"
-    And a file ".ai/starter/agents/marketplace-scanner.md" exists in "my-project"
-    And a file ".ai/starter/hooks/hooks.json" exists in "my-project"
-    And a file ".ai/starter/.mcp.json" exists in "my-project"
+    Then a file ".ai/starter-aipm-plugin/.claude-plugin/plugin.json" exists in "my-project"
+    And a file ".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md" exists in "my-project"
+    And a file ".ai/starter-aipm-plugin/scripts/scaffold-plugin.ts" exists in "my-project"
+    And a file ".ai/starter-aipm-plugin/agents/marketplace-scanner.md" exists in "my-project"
+    And a file ".ai/starter-aipm-plugin/hooks/hooks.json" exists in "my-project"
+    And a file ".ai/starter-aipm-plugin/.mcp.json" exists in "my-project"
 
   Scenario: Marketplace generates a starter skill with description frontmatter
     Given an empty directory "my-project"
     When the user runs "aipm init --marketplace" in "my-project"
-    Then a file ".ai/starter/skills/scaffold-plugin/SKILL.md" exists in "my-project"
+    Then a file ".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md" exists in "my-project"
     And the starter skill contains "description:" in the frontmatter
 
   Scenario: Starter plugin includes a marketplace scanner agent
     Given an empty directory "my-project"
     When the user runs "aipm init --marketplace" in "my-project"
-    Then a file ".ai/starter/agents/marketplace-scanner.md" exists in "my-project"
+    Then a file ".ai/starter-aipm-plugin/agents/marketplace-scanner.md" exists in "my-project"
 
   Scenario: Starter plugin includes a logging hook
     Given an empty directory "my-project"
     When the user runs "aipm init --marketplace" in "my-project"
-    Then a file ".ai/starter/hooks/hooks.json" exists in "my-project"
+    Then a file ".ai/starter-aipm-plugin/hooks/hooks.json" exists in "my-project"
 
   Scenario: Starter plugin includes a scaffold script
     Given an empty directory "my-project"
     When the user runs "aipm init --marketplace" in "my-project"
-    Then a file ".ai/starter/scripts/scaffold-plugin.ts" exists in "my-project"
+    Then a file ".ai/starter-aipm-plugin/scripts/scaffold-plugin.ts" exists in "my-project"
 
   Scenario: No-starter flag creates bare marketplace directory
     Given an empty directory "my-project"
     When the user runs "aipm init --no-starter" in "my-project"
     Then a file ".ai/.gitignore" exists in "my-project"
-    And there is no directory ".ai/starter" in "my-project"
+    And there is no directory ".ai/starter-aipm-plugin" in "my-project"
 
   Scenario: No-starter flag still configures tool settings
     Given an empty directory "my-project"
     When the user runs "aipm init --no-starter" in "my-project"
     Then a file ".claude/settings.json" exists in "my-project"
-    And there is no directory ".ai/starter" in "my-project"
+    And there is no directory ".ai/starter-aipm-plugin" in "my-project"
 
   Scenario: No-starter flag with workspace creates both minus starter
     Given an empty directory "my-project"
     When the user runs "aipm init --workspace --marketplace --no-starter" in "my-project"
     Then a file "aipm.toml" is created in "my-project"
     And a file ".ai/.gitignore" exists in "my-project"
-    And there is no directory ".ai/starter" in "my-project"
+    And there is no directory ".ai/starter-aipm-plugin" in "my-project"
 
   Scenario: Generated gitignore has aipm managed markers
     Given an empty directory "my-project"
@@ -103,8 +103,8 @@ Feature: Workspace initialization
     Then the following directories exist in "my-project":
       | directory              |
       | .ai/                   |
-      | .ai/starter/           |
-      | .ai/starter/skills/    |
+      | .ai/starter-aipm-plugin/           |
+      | .ai/starter-aipm-plugin/skills/    |
     And there is no file "aipm.toml" in "my-project"
 
   Scenario: Marketplace skips if .ai directory already exists
@@ -117,7 +117,7 @@ Feature: Workspace initialization
     Given an empty directory "my-project"
     When the user runs "aipm init --workspace" in "my-project"
     Then a file "aipm.toml" is created in "my-project"
-    And there is no directory ".ai/starter" in "my-project"
+    And there is no directory ".ai/starter-aipm-plugin" in "my-project"
 
   Scenario: Default init with no flags creates marketplace only
     Given an empty directory "my-project"
@@ -125,13 +125,13 @@ Feature: Workspace initialization
     Then the following directories exist in "my-project":
       | directory      |
       | .ai/           |
-      | .ai/starter/   |
+      | .ai/starter-aipm-plugin/   |
     And there is no file "aipm.toml" in "my-project"
 
   Scenario: Starter plugin manifest is valid TOML that round-trips through parser
     Given an empty directory "my-project"
     When the user runs "aipm init --marketplace" in "my-project"
-    Then a file ".ai/starter/aipm.toml" exists in "my-project"
+    Then a file ".ai/starter-aipm-plugin/aipm.toml" exists in "my-project"
     And the starter plugin manifest is valid according to aipm schema
 
   Rule: Tool settings integration


### PR DESCRIPTION
## Summary
- Generates `.ai/.claude-plugin/marketplace.json` during `aipm init` scaffold (was missing entirely)
- Renames starter plugin directory from `starter` to `starter-aipm-plugin`
- Changes settings.json marketplace key from `"local"` to `"local-repo-plugins"`
- Auto-enables `starter-aipm-plugin` in `settings.json` via `enabledPlugins`
- `--no-starter` still creates marketplace.json with an empty plugins array

## Test plan
- [x] `cargo build --workspace` — zero warnings
- [x] `cargo test --workspace` — 107 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] BDD scenarios updated for new directory/plugin names