### PR TITLE
test: add marketplace.json output tests across all layers

### DIFF
--- a/crates/aipm/tests/init_e2e.rs
+++ b/crates/aipm/tests/init_e2e.rs
@@ -150,6 +150,61 @@ fn init_starter_manifest_valid_toml() {
 }
 
 // =========================================================================
+// Scenario: Marketplace.json is generated with correct structure
+// =========================================================================
+#[test]
+fn init_marketplace_json_generated() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("mp-json");
+
+    aipm().args(["init", "--marketplace", &dir.display().to_string()]).assert().success();
+
+    let content = std::fs::read_to_string(dir.join(".ai/.claude-plugin/marketplace.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(v["name"], "local-repo-plugins");
+    assert_eq!(v["owner"]["name"], "local");
+    assert_eq!(v["metadata"]["description"], "Local plugins for this repository");
+    assert_eq!(v["plugins"][0]["name"], "starter-aipm-plugin");
+    assert_eq!(v["plugins"][0]["source"], "./starter-aipm-plugin");
+}
+
+// =========================================================================
+// Scenario: Marketplace.json with --no-starter has empty plugins
+// =========================================================================
+#[test]
+fn init_marketplace_json_no_starter_empty_plugins() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("mp-json-nostarter");
+
+    aipm().args(["init", "--no-starter", &dir.display().to_string()]).assert().success();
+
+    let content = std::fs::read_to_string(dir.join(".ai/.claude-plugin/marketplace.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(v["name"], "local-repo-plugins");
+    assert!(v["plugins"].as_array().unwrap().is_empty());
+}
+
+// =========================================================================
+// Scenario: Settings.json has correct marketplace name and enabled plugins
+// =========================================================================
+#[test]
+fn init_settings_json_marketplace_name_and_enabled_plugins() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("settings-check");
+
+    aipm().args(["init", "--marketplace", &dir.display().to_string()]).assert().success();
+
+    let content = std::fs::read_to_string(dir.join(".claude/settings.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(v["extraKnownMarketplaces"]["local-repo-plugins"].is_object());
+    assert_eq!(v["extraKnownMarketplaces"]["local-repo-plugins"]["source"]["path"], ".ai");
+    assert_eq!(
+        v["extraKnownMarketplaces"]["local-repo-plugins"]["enabledPlugins"][0],
+        "starter-aipm-plugin"
+    );
+}
+
+// =========================================================================
 // Scenario: Generated workspace manifest is valid
 // =========================================================================
 #[test]

--- a/crates/libaipm/src/workspace_init/mod.rs
+++ b/crates/libaipm/src/workspace_init/mod.rs
@@ -669,6 +669,97 @@ mod tests {
     }
 
     #[test]
+    fn marketplace_json_with_starter_is_valid() {
+        let json = generate_marketplace_json(false);
+        let parsed: Result<serde_json::Value, _> = serde_json::from_str(&json);
+        assert!(parsed.is_ok(), "marketplace.json should be valid JSON: {parsed:?}");
+        let v = parsed.ok();
+        assert!(v
+            .as_ref()
+            .is_some_and(|v| v.get("name").is_some_and(|n| n == "local-repo-plugins")));
+        assert!(v.as_ref().is_some_and(|v| v.get("owner").is_some()));
+        assert!(v.as_ref().is_some_and(|v| v.get("metadata").is_some()));
+        let plugins = v.as_ref().and_then(|v| v.get("plugins")).and_then(|p| p.as_array());
+        assert!(plugins.is_some_and(|p| p.len() == 1));
+        let plugin = v
+            .as_ref()
+            .and_then(|v| v.get("plugins"))
+            .and_then(|p| p.as_array())
+            .and_then(|a| a.first());
+        assert!(plugin.is_some_and(|p| {
+            p.get("name").is_some_and(|n| n == "starter-aipm-plugin")
+                && p.get("source").is_some_and(|s| s == "./starter-aipm-plugin")
+                && p.get("description").is_some()
+        }));
+    }
+
+    #[test]
+    fn marketplace_json_no_starter_has_empty_plugins() {
+        let json = generate_marketplace_json(true);
+        let parsed: Result<serde_json::Value, _> = serde_json::from_str(&json);
+        assert!(parsed.is_ok(), "marketplace.json should be valid JSON: {parsed:?}");
+        let v = parsed.ok();
+        assert!(v
+            .as_ref()
+            .is_some_and(|v| v.get("name").is_some_and(|n| n == "local-repo-plugins")));
+        let plugins = v.as_ref().and_then(|v| v.get("plugins")).and_then(|p| p.as_array());
+        assert!(plugins.is_some_and(|p| p.is_empty()));
+    }
+
+    #[test]
+    fn init_marketplace_creates_marketplace_json() {
+        let (tmp, _guard) = make_temp_dir("mp-json");
+        let adaptors = default_adaptors();
+        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let result = init(&opts, &adaptors);
+        assert!(result.is_ok());
+
+        let path = tmp.join(".ai/.claude-plugin/marketplace.json");
+        assert!(path.exists(), "marketplace.json should be created");
+        let content = std::fs::read_to_string(&path);
+        assert!(content.is_ok());
+        let parsed: Result<serde_json::Value, _> =
+            serde_json::from_str(content.as_deref().unwrap_or(""));
+        assert!(parsed.is_ok(), "marketplace.json should be valid JSON");
+        let v = parsed.ok();
+        assert!(v
+            .as_ref()
+            .is_some_and(|v| v.get("name").is_some_and(|n| n == "local-repo-plugins")));
+        assert!(v.is_some_and(|v| {
+            v.get("plugins")
+                .and_then(|p| p.as_array())
+                .and_then(|a| a.first())
+                .and_then(|p| p.get("name"))
+                .is_some_and(|n| n == "starter-aipm-plugin")
+        }));
+
+        cleanup(&tmp);
+    }
+
+    #[test]
+    fn init_no_starter_creates_marketplace_json_with_empty_plugins() {
+        let (tmp, _guard) = make_temp_dir("mp-json-nostarter");
+        let adaptors = default_adaptors();
+        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: true };
+        let result = init(&opts, &adaptors);
+        assert!(result.is_ok());
+
+        let path = tmp.join(".ai/.claude-plugin/marketplace.json");
+        assert!(path.exists(), "marketplace.json should be created even with --no-starter");
+        let content = std::fs::read_to_string(&path);
+        assert!(content.is_ok());
+        let parsed: Result<serde_json::Value, _> =
+            serde_json::from_str(content.as_deref().unwrap_or(""));
+        assert!(parsed.is_ok());
+        let v = parsed.ok();
+        assert!(v.is_some_and(|v| {
+            v.get("plugins").and_then(|p| p.as_array()).is_some_and(|a| a.is_empty())
+        }));
+
+        cleanup(&tmp);
+    }
+
+    #[test]
     fn init_no_starter_still_configures_tools() {
         let (tmp, _guard) = make_temp_dir("no-starter-tools");
         let adaptors = default_adaptors();

--- a/tests/features/manifest/workspace-init.feature
+++ b/tests/features/manifest/workspace-init.feature
@@ -134,6 +134,23 @@ Feature: Workspace initialization
     Then a file ".ai/starter-aipm-plugin/aipm.toml" exists in "my-project"
     And the starter plugin manifest is valid according to aipm schema
 
+  Rule: Marketplace manifest generation
+
+    Scenario: Marketplace.json is generated with correct structure
+      Given an empty directory "my-project"
+      When the user runs "aipm init --marketplace" in "my-project"
+      Then a file ".ai/.claude-plugin/marketplace.json" exists in "my-project"
+      And the marketplace.json name is "local-repo-plugins"
+      And the marketplace.json contains a plugin named "starter-aipm-plugin"
+      And the marketplace.json plugin "starter-aipm-plugin" has source "./starter-aipm-plugin"
+
+    Scenario: Marketplace.json with --no-starter has empty plugins array
+      Given an empty directory "my-project"
+      When the user runs "aipm init --no-starter" in "my-project"
+      Then a file ".ai/.claude-plugin/marketplace.json" exists in "my-project"
+      And the marketplace.json name is "local-repo-plugins"
+      And the marketplace.json plugins array is empty
+
   Rule: Tool settings integration
 
     Scenario: Claude Code settings point to .ai/ as local marketplace


### PR DESCRIPTION
## Summary
- Adds unit tests validating `generate_marketplace_json()` output for both with-starter and no-starter cases
- Adds E2E tests snapshotting marketplace.json structure, settings.json marketplace name, and `enabledPlugins`
- Adds BDD scenarios for marketplace.json content validation

## Test plan
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean