### PR TITLE
docs: add CI and Codecov badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AIPM — AI Plugin Manager
 
+[![CI](https://github.com/TheLarkInn/aipm/actions/workflows/ci.yml/badge.svg)](https://github.com/TheLarkInn/aipm/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/TheLarkInn/aipm/graph/badge.svg)](https://codecov.io/gh/TheLarkInn/aipm)
+
 A production-grade package manager for AI plugin primitives (skills, agents, MCP servers, hooks). Think npm/Cargo, but purpose-built for the AI plugin ecosystem.
 
 AIPM ships as **two Rust binaries**:


### PR DESCRIPTION
## Summary

- Add CI build status badge (GitHub Actions)
- Add Codecov coverage badge

Both link to their respective dashboards.