### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1165,7 +1165,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "cucumber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.4.3" }
+libaipm = { path = "crates/libaipm", version = "0.5.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.5.0] - 2026-03-23
+
 ## [0.4.3] - 2026-03-23
 
 ### Refactoring

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.5.0] - 2026-03-23
+
+### Features
+- Add aipm migrate command ([#55](https://github.com/TheLarkInn/aipm/pull/55)) (237f240)
+
 ## [0.4.3] - 2026-03-23
 
 ### Refactoring

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.5.0] - 2026-03-23
+
+### Features
+- Add aipm migrate command ([#55](https://github.com/TheLarkInn/aipm/pull/55)) (237f240)
+
 ## [0.4.3] - 2026-03-23
 
 ## [0.4.2] - 2026-03-23


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.4.3 -> 0.5.0 (⚠ API breaking changes)
* `aipm`: 0.4.3 -> 0.5.0
* `aipm-pack`: 0.4.3 -> 0.5.0

### ⚠ `libaipm` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_added.ron

Failed in:
  trait method libaipm::fs::Fs::read_dir in file /tmp/.tmpMtUoAS/aipm/crates/libaipm/src/fs.rs:33
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.5.0] - 2026-03-23

### Features
- Add aipm migrate command ([#55](https://github.com/TheLarkInn/aipm/pull/55)) (237f240)
</blockquote>

## `aipm`

<blockquote>

## [0.5.0] - 2026-03-23

### Features
- Add aipm migrate command ([#55](https://github.com/TheLarkInn/aipm/pull/55)) (237f240)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).