### PR TITLE
feat: suppress plugin manifest generation by default

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -10,6 +10,9 @@ single-char-binding-names-threshold = 4
 # Performance: stack size threshold for large_enum_variant
 too-large-for-stack = 200
 
+# Struct bool limit (default 3; workspace_init::Options legitimately uses 4)
+max-struct-bools = 4
+
 # Performance: trivial copy size
 trivial-copy-size-limit = 8
 

--- a/crates/aipm/src/main.rs
+++ b/crates/aipm/src/main.rs
@@ -37,6 +37,10 @@ enum Commands {
         #[arg(long)]
         no_starter: bool,
 
+        /// Generate aipm.toml plugin manifests (opt-in; dependency management not yet available).
+        #[arg(long)]
+        manifest: bool,
+
         /// Directory to initialize (defaults to current directory).
         #[arg(default_value = ".")]
         dir: PathBuf,
@@ -58,6 +62,10 @@ enum Commands {
         #[arg(long)]
         max_depth: Option<usize>,
 
+        /// Generate aipm.toml plugin manifests (opt-in; dependency management not yet available).
+        #[arg(long)]
+        manifest: bool,
+
         /// Project directory.
         #[arg(default_value = ".")]
         dir: PathBuf,
@@ -68,7 +76,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Init { yes, workspace, marketplace, no_starter, dir }) => {
+        Some(Commands::Init { yes, workspace, marketplace, no_starter, manifest, dir }) => {
             let dir = if dir.as_os_str() == "." { std::env::current_dir()? } else { dir };
 
             let interactive = !yes && std::io::stdin().is_terminal();
@@ -83,6 +91,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 workspace: do_workspace,
                 marketplace: do_marketplace,
                 no_starter: do_no_starter,
+                manifest,
             };
 
             let result = libaipm::workspace_init::init(&opts, &adaptors, &libaipm::fs::Real)?;
@@ -108,7 +117,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             }
             Ok(())
         },
-        Some(Commands::Migrate { dry_run, source, max_depth, dir }) => {
+        Some(Commands::Migrate { dry_run, source, max_depth, manifest, dir }) => {
             let dir = if dir.as_os_str() == "." { std::env::current_dir()? } else { dir };
 
             let opts = libaipm::migrate::Options {
@@ -116,6 +125,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 source: source.as_deref(),
                 dry_run,
                 max_depth,
+                manifest,
             };
 
             let result = libaipm::migrate::migrate(&opts, &libaipm::fs::Real)?;

--- a/crates/aipm/tests/init_e2e.rs
+++ b/crates/aipm/tests/init_e2e.rs
@@ -26,9 +26,14 @@ fn init_default_creates_marketplace_only() {
     aipm().args(["init", &dir.display().to_string()]).assert().success();
 
     assert!(!dir.join("aipm.toml").exists(), "aipm.toml should NOT exist");
+    // Starter plugin directory and components exist, but no aipm.toml (no --manifest)
     assert!(
-        dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
-        ".ai/starter-aipm-plugin/aipm.toml should exist"
+        dir.join(".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md").exists(),
+        "starter plugin components should exist"
+    );
+    assert!(
+        !dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
+        "starter aipm.toml should NOT exist without --manifest"
     );
     assert!(dir.join(".claude/settings.json").exists(), ".claude/settings.json should exist");
 }
@@ -58,9 +63,14 @@ fn init_marketplace_only() {
 
     aipm().args(["init", "--marketplace", &dir.display().to_string()]).assert().success();
 
+    // Starter plugin exists but no aipm.toml without --manifest
     assert!(
-        dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
+        dir.join(".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md").exists(),
         ".ai/starter-aipm-plugin should exist"
+    );
+    assert!(
+        !dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
+        "starter aipm.toml should NOT exist without --manifest"
     );
     assert!(!dir.join("aipm.toml").exists(), "aipm.toml should NOT exist");
 }
@@ -141,7 +151,11 @@ fn init_starter_manifest_valid_toml() {
     let tmp = tempfile::TempDir::new().unwrap();
     let dir = tmp.path().join("starter-valid");
 
-    aipm().args(["init", "--marketplace", &dir.display().to_string()]).assert().success();
+    // Use --manifest to generate starter aipm.toml
+    aipm()
+        .args(["init", "--marketplace", "--manifest", &dir.display().to_string()])
+        .assert()
+        .success();
 
     let content = std::fs::read_to_string(dir.join(".ai/starter-aipm-plugin/aipm.toml")).unwrap();
     assert!(content.contains("name = \"starter-aipm-plugin\""));
@@ -376,7 +390,15 @@ fn yes_flag_creates_default_marketplace() {
     aipm().args(["init", "-y", &dir.display().to_string()]).assert().success();
 
     assert!(!dir.join("aipm.toml").exists(), "aipm.toml should NOT exist (marketplace only)");
-    assert!(dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(), "starter plugin should exist");
+    // Starter plugin exists but no aipm.toml without --manifest
+    assert!(
+        dir.join(".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md").exists(),
+        "starter plugin components should exist"
+    );
+    assert!(
+        !dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
+        "starter aipm.toml should NOT exist without --manifest"
+    );
 }
 
 #[test]
@@ -413,4 +435,43 @@ fn yes_flag_marketplace_only_no_workspace() {
     // Default is marketplace only, no workspace manifest
     assert!(!dir.join("aipm.toml").exists(), "default -y should NOT create aipm.toml");
     assert!(dir.join(".ai").exists(), ".ai should exist");
+}
+
+// =========================================================================
+// --manifest flag tests
+// =========================================================================
+
+#[test]
+fn init_manifest_flag_generates_starter_toml() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("manifest-flag");
+
+    aipm()
+        .args(["init", "--marketplace", "--manifest", &dir.display().to_string()])
+        .assert()
+        .success();
+
+    assert!(
+        dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
+        "starter aipm.toml should exist with --manifest"
+    );
+    let content = std::fs::read_to_string(dir.join(".ai/starter-aipm-plugin/aipm.toml")).unwrap();
+    assert!(content.contains("name = \"starter-aipm-plugin\""));
+}
+
+#[test]
+fn init_without_manifest_flag_skips_starter_toml() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("no-manifest-flag");
+
+    aipm().args(["init", "--marketplace", &dir.display().to_string()]).assert().success();
+
+    assert!(
+        dir.join(".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md").exists(),
+        "components should exist"
+    );
+    assert!(
+        !dir.join(".ai/starter-aipm-plugin/aipm.toml").exists(),
+        "aipm.toml should NOT exist without --manifest"
+    );
 }

--- a/crates/aipm/tests/migrate_e2e.rs
+++ b/crates/aipm/tests/migrate_e2e.rs
@@ -47,10 +47,16 @@ fn migrate_skill_creates_plugin() {
 
     aipm().args(["migrate", &dir.display().to_string()]).assert().success();
 
-    assert!(dir.join(".ai/deploy/aipm.toml").exists(), "aipm.toml should exist");
-    let toml_content = std::fs::read_to_string(dir.join(".ai/deploy/aipm.toml")).unwrap();
-    assert!(toml_content.contains("name = \"deploy\""));
-    assert!(toml_content.contains("type = \"skill\""));
+    // Plugin directory and components exist, but no aipm.toml (no --manifest)
+    assert!(dir.join(".ai/deploy/skills/deploy/SKILL.md").exists(), "SKILL.md should exist");
+    assert!(
+        !dir.join(".ai/deploy/aipm.toml").exists(),
+        "aipm.toml should NOT exist without --manifest"
+    );
+    assert!(
+        dir.join(".ai/deploy/.claude-plugin/plugin.json").exists(),
+        "plugin.json should still exist"
+    );
 }
 
 // =========================================================================
@@ -259,9 +265,11 @@ fn migrate_multiple_skills() {
 
     aipm().args(["migrate", &dir.display().to_string()]).assert().success();
 
-    assert!(dir.join(".ai/deploy/aipm.toml").exists());
-    assert!(dir.join(".ai/lint/aipm.toml").exists());
+    // No aipm.toml without --manifest
+    assert!(!dir.join(".ai/deploy/aipm.toml").exists());
+    assert!(!dir.join(".ai/lint/aipm.toml").exists());
 
+    // But plugins are registered in marketplace.json
     let mp = std::fs::read_to_string(dir.join(".ai/.claude-plugin/marketplace.json")).unwrap();
     assert!(mp.contains("\"deploy\""));
     assert!(mp.contains("\"lint\""));
@@ -303,5 +311,50 @@ fn migrate_help_output() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--dry-run"))
-        .stdout(predicate::str::contains("--source"));
+        .stdout(predicate::str::contains("--source"))
+        .stdout(predicate::str::contains("--manifest"));
+}
+
+// =========================================================================
+// --manifest flag tests
+// =========================================================================
+
+#[test]
+fn migrate_with_manifest_flag_generates_toml() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("project");
+    init_workspace(&dir);
+    create_skill(
+        &dir,
+        "deploy",
+        "---\nname: deploy\ndescription: Deploy app\n---\nDeploy instructions",
+    );
+
+    aipm().args(["migrate", "--manifest", &dir.display().to_string()]).assert().success();
+
+    assert!(dir.join(".ai/deploy/aipm.toml").exists(), "aipm.toml should exist with --manifest");
+    let toml_content = std::fs::read_to_string(dir.join(".ai/deploy/aipm.toml")).unwrap();
+    assert!(toml_content.contains("name = \"deploy\""));
+    assert!(toml_content.contains("type = \"skill\""));
+}
+
+#[test]
+fn migrate_without_manifest_flag_skips_toml() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("project");
+    init_workspace(&dir);
+    create_skill(&dir, "deploy", "---\nname: deploy\n---\nDeploy");
+
+    aipm().args(["migrate", &dir.display().to_string()]).assert().success();
+
+    assert!(
+        !dir.join(".ai/deploy/aipm.toml").exists(),
+        "aipm.toml should NOT exist without --manifest"
+    );
+    // But plugin.json and components should exist
+    assert!(dir.join(".ai/deploy/.claude-plugin/plugin.json").exists());
+    assert!(dir.join(".ai/deploy/skills/deploy/SKILL.md").exists());
+    // And registration still works
+    let mp = std::fs::read_to_string(dir.join(".ai/.claude-plugin/marketplace.json")).unwrap();
+    assert!(mp.contains("\"deploy\""));
 }

--- a/crates/libaipm/src/migrate/dry_run.rs
+++ b/crates/libaipm/src/migrate/dry_run.rs
@@ -12,6 +12,7 @@ pub fn generate_report<S: BuildHasher>(
     artifacts: &[Artifact],
     existing_plugins: &HashSet<String, S>,
     source_name: &str,
+    manifest: bool,
 ) -> String {
     let mut report = String::new();
 
@@ -39,6 +40,7 @@ pub fn generate_report<S: BuildHasher>(
                 &mut rename_counter,
                 &mut total_conflicts,
                 &mut total_hooks,
+                manifest,
             );
         }
     }
@@ -53,6 +55,7 @@ pub fn generate_report<S: BuildHasher>(
                 &mut rename_counter,
                 &mut total_conflicts,
                 &mut total_hooks,
+                manifest,
             );
         }
     }
@@ -182,6 +185,7 @@ fn write_artifact_section(
     rename_counter: &mut u32,
     total_conflicts: &mut u32,
     total_hooks: &mut u32,
+    manifest: bool,
 ) {
     let _ = writeln!(report, "### {}\n", artifact.name);
     let _ = writeln!(report, "- **Source:** {}", artifact.source_path.display());
@@ -209,8 +213,15 @@ fn write_artifact_section(
 
     // Manifest changes
     let _ = writeln!(report, "- **Manifest changes:**");
-    let _ =
-        writeln!(report, "  - New aipm.toml with type = \"{}\"", artifact.kind.to_type_string());
+    if manifest {
+        let _ = writeln!(
+            report,
+            "  - New aipm.toml with type = \"{}\"",
+            artifact.kind.to_type_string()
+        );
+    } else {
+        let _ = writeln!(report, "  - No aipm.toml (pass --manifest to generate)");
+    }
     let _ = writeln!(report, "  - New .claude-plugin/plugin.json");
 
     // Marketplace entry
@@ -266,7 +277,7 @@ mod tests {
             make_artifact("lint", ArtifactKind::Skill),
         ];
         let existing = HashSet::new();
-        let report = generate_report(&artifacts, &existing, ".claude");
+        let report = generate_report(&artifacts, &existing, ".claude", true);
 
         assert!(report.contains("### deploy"));
         assert!(report.contains("### lint"));
@@ -277,7 +288,7 @@ mod tests {
         let artifacts = vec![make_artifact("deploy", ArtifactKind::Skill)];
         let mut existing = HashSet::new();
         existing.insert("deploy".to_string());
-        let report = generate_report(&artifacts, &existing, ".claude");
+        let report = generate_report(&artifacts, &existing, ".claude", true);
 
         assert!(report.contains("deploy-renamed-1"));
         assert!(report.contains("Name conflicts (auto-renamed) | 1"));
@@ -289,7 +300,7 @@ mod tests {
         artifact.files = vec![PathBuf::from("SKILL.md"), PathBuf::from("scripts/run.sh")];
         let artifacts = vec![artifact];
         let existing = HashSet::new();
-        let report = generate_report(&artifacts, &existing, ".claude");
+        let report = generate_report(&artifacts, &existing, ".claude", true);
 
         assert!(report.contains("SKILL.md"));
         assert!(report.contains("scripts/run.sh"));
@@ -302,7 +313,7 @@ mod tests {
             make_artifact("review", ArtifactKind::Command),
         ];
         let existing = HashSet::new();
-        let report = generate_report(&artifacts, &existing, ".claude");
+        let report = generate_report(&artifacts, &existing, ".claude", true);
 
         assert!(report.contains("## Summary"));
         assert!(report.contains("Plugins to create | 2"));
@@ -313,7 +324,7 @@ mod tests {
     fn dry_run_report_empty_artifacts() {
         let artifacts: Vec<Artifact> = Vec::new();
         let existing = HashSet::new();
-        let report = generate_report(&artifacts, &existing, ".claude");
+        let report = generate_report(&artifacts, &existing, ".claude", true);
 
         assert!(report.contains("**Artifacts found:** 0"));
         assert!(report.contains("Plugins to create | 0"));
@@ -325,7 +336,7 @@ mod tests {
         artifact.metadata.hooks = Some("PreToolUse: check".to_string());
         let artifacts = vec![artifact];
         let existing = HashSet::new();
-        let report = generate_report(&artifacts, &existing, ".claude");
+        let report = generate_report(&artifacts, &existing, ".claude", true);
 
         assert!(report.contains("**Hooks extracted:** yes"));
         assert!(report.contains("Hooks to extract | 1"));
@@ -337,7 +348,7 @@ mod tests {
         artifact.referenced_scripts = vec![PathBuf::from("scripts/run.sh")];
         let artifacts = vec![artifact];
         let existing = HashSet::new();
-        let report = generate_report(&artifacts, &existing, ".claude");
+        let report = generate_report(&artifacts, &existing, ".claude", true);
 
         assert!(report.contains("**Path rewrites:**"));
     }
@@ -346,7 +357,7 @@ mod tests {
     fn dry_run_report_commands_section() {
         let artifacts = vec![make_artifact("review", ArtifactKind::Command)];
         let existing = HashSet::new();
-        let report = generate_report(&artifacts, &existing, ".claude");
+        let report = generate_report(&artifacts, &existing, ".claude", true);
 
         assert!(report.contains("## Legacy Commands"));
     }
@@ -449,5 +460,25 @@ mod tests {
 
         assert!(report.contains("Plugin: `api`"));
         assert!(report.contains("Type: skill"));
+    }
+
+    #[test]
+    fn dry_run_report_no_manifest_shows_hint() {
+        let artifacts = vec![make_artifact("deploy", ArtifactKind::Skill)];
+        let existing = HashSet::new();
+        let report = generate_report(&artifacts, &existing, ".claude", false);
+
+        assert!(report.contains("No aipm.toml (pass --manifest to generate)"));
+        assert!(!report.contains("New aipm.toml with type"));
+    }
+
+    #[test]
+    fn dry_run_report_with_manifest_shows_aipm_toml() {
+        let artifacts = vec![make_artifact("deploy", ArtifactKind::Skill)];
+        let existing = HashSet::new();
+        let report = generate_report(&artifacts, &existing, ".claude", true);
+
+        assert!(report.contains("New aipm.toml with type"));
+        assert!(!report.contains("No aipm.toml (pass --manifest to generate)"));
     }
 }

--- a/crates/libaipm/src/migrate/emitter.rs
+++ b/crates/libaipm/src/migrate/emitter.rs
@@ -30,6 +30,7 @@ pub fn emit_plugin<S: BuildHasher>(
     ai_dir: &Path,
     existing_names: &HashSet<String, S>,
     rename_counter: &mut u32,
+    manifest: bool,
     fs: &dyn Fs,
 ) -> Result<(String, Vec<Action>), Error> {
     let mut actions = Vec::new();
@@ -94,9 +95,11 @@ pub fn emit_plugin<S: BuildHasher>(
         write_file(&hooks_dir.join("hooks.json"), &hooks_json, fs)?;
     }
 
-    // 6. Generate aipm.toml
-    let manifest = generate_plugin_manifest(artifact, &plugin_name);
-    write_file(&plugin_dir.join("aipm.toml"), &manifest, fs)?;
+    // 6. Generate aipm.toml (only when --manifest is requested)
+    if manifest {
+        let manifest_toml = generate_plugin_manifest(artifact, &plugin_name);
+        write_file(&plugin_dir.join("aipm.toml"), &manifest_toml, fs)?;
+    }
 
     // 7. Generate .claude-plugin/plugin.json
     let plugin_json = generate_plugin_json(&plugin_name, &artifact.metadata);
@@ -230,6 +233,7 @@ pub fn emit_plugin_with_name(
     artifact: &Artifact,
     plugin_name: &str,
     ai_dir: &Path,
+    manifest: bool,
     fs: &dyn Fs,
 ) -> Result<Vec<Action>, Error> {
     let mut actions = Vec::new();
@@ -294,8 +298,10 @@ pub fn emit_plugin_with_name(
         write_file(&hooks_dir.join("hooks.json"), &hooks_json, fs)?;
     }
 
-    let manifest = generate_plugin_manifest(artifact, plugin_name);
-    write_file(&plugin_dir.join("aipm.toml"), &manifest, fs)?;
+    if manifest {
+        let manifest_toml = generate_plugin_manifest(artifact, plugin_name);
+        write_file(&plugin_dir.join("aipm.toml"), &manifest_toml, fs)?;
+    }
 
     let plugin_json = generate_plugin_json(plugin_name, &artifact.metadata);
     write_file(&plugin_dir.join(".claude-plugin").join("plugin.json"), &plugin_json, fs)?;
@@ -318,6 +324,7 @@ pub fn emit_package_plugin(
     plugin_name: &str,
     artifacts: &[Artifact],
     ai_dir: &Path,
+    manifest: bool,
     fs: &dyn Fs,
 ) -> Result<Vec<Action>, Error> {
     let mut actions = Vec::new();
@@ -413,15 +420,17 @@ pub fn emit_package_plugin(
         write_file(&hooks_dir.join("hooks.json"), &hooks_json, fs)?;
     }
 
-    // Generate aipm.toml for the package plugin
-    let manifest = generate_package_manifest(
-        plugin_name,
-        artifacts,
-        &all_component_paths,
-        has_multiple_types,
-        !merged_hooks_parts.is_empty(),
-    );
-    write_file(&plugin_dir.join("aipm.toml"), &manifest, fs)?;
+    // Generate aipm.toml for the package plugin (only when --manifest is requested)
+    if manifest {
+        let manifest_toml = generate_package_manifest(
+            plugin_name,
+            artifacts,
+            &all_component_paths,
+            has_multiple_types,
+            !merged_hooks_parts.is_empty(),
+        );
+        write_file(&plugin_dir.join("aipm.toml"), &manifest_toml, fs)?;
+    }
 
     // Generate plugin.json
     let first_metadata =
@@ -729,7 +738,7 @@ mod tests {
         let existing = HashSet::new();
         let mut counter = 0;
         let artifact = make_skill_artifact();
-        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
         assert!(result.is_ok());
         // Check that aipm.toml was written
         assert!(fs.get_written(Path::new("/ai/deploy/aipm.toml")).is_some());
@@ -745,7 +754,7 @@ mod tests {
         let existing = HashSet::new();
         let mut counter = 0;
         let artifact = make_skill_artifact();
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let toml_content = fs.get_written(Path::new("/ai/deploy/aipm.toml"));
         assert!(toml_content.is_some());
@@ -764,7 +773,7 @@ mod tests {
         let existing = HashSet::new();
         let mut counter = 0;
         let artifact = make_skill_artifact();
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let json_content = fs.get_written(Path::new("/ai/deploy/.claude-plugin/plugin.json"));
         assert!(json_content.is_some());
@@ -782,7 +791,7 @@ mod tests {
         let existing = HashSet::new();
         let mut counter = 0;
         let artifact = make_skill_artifact();
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let skill_content = fs.get_written(Path::new("/ai/deploy/skills/deploy/SKILL.md"));
         assert!(skill_content.is_some_and(|c| c == "Deploy content"));
@@ -805,7 +814,7 @@ mod tests {
         let mut counter = 0;
         let mut artifact = make_skill_artifact();
         artifact.referenced_scripts = vec![PathBuf::from("scripts/deploy.sh")];
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let script_content = fs.get_written(Path::new("/ai/deploy/scripts/deploy.sh"));
         assert!(script_content.is_some());
@@ -822,7 +831,7 @@ mod tests {
         let existing = HashSet::new();
         let mut counter = 0;
         let artifact = make_skill_artifact();
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let content = fs.get_written(Path::new("/ai/deploy/skills/deploy/SKILL.md"));
         assert!(content.as_ref().is_some_and(|c| c.contains("${CLAUDE_SKILL_DIR}/../../scripts/")));
@@ -838,7 +847,7 @@ mod tests {
         let mut counter = 0;
         let mut artifact = make_skill_artifact();
         artifact.metadata.hooks = Some("PreToolUse: check_deploy".to_string());
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let hooks_content = fs.get_written(Path::new("/ai/deploy/hooks/hooks.json"));
         assert!(hooks_content.is_some());
@@ -858,7 +867,7 @@ mod tests {
         let existing = HashSet::new();
         let mut counter = 0;
         let artifact = make_command_artifact();
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let skill_content = fs.get_written(Path::new("/ai/review/skills/review/SKILL.md"));
         assert!(skill_content
@@ -875,7 +884,7 @@ mod tests {
         let existing = HashSet::new();
         let mut counter = 0;
         let artifact = make_command_artifact();
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let skill_content = fs.get_written(Path::new("/ai/review/skills/review/SKILL.md"));
         assert!(skill_content.as_ref().is_some_and(|c| c.starts_with("---\n")));
@@ -1052,7 +1061,7 @@ mod tests {
         let existing = HashSet::new();
         let mut counter = 0;
         let artifact = make_command_artifact();
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         let skill_content = fs.get_written(Path::new("/ai/review/skills/review/SKILL.md"));
         assert!(skill_content
@@ -1095,7 +1104,7 @@ mod tests {
         let mut counter = 0;
         let mut artifact = make_skill_artifact();
         artifact.referenced_scripts = vec![PathBuf::from("scripts/missing.sh")];
-        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
         assert!(result.is_ok());
         // Script should not be written
         assert!(fs.get_written(Path::new("/ai/deploy/scripts/missing.sh")).is_none());
@@ -1117,7 +1126,7 @@ mod tests {
         let mut counter = 0;
         let mut artifact = make_skill_artifact();
         artifact.name = "../etc".to_string();
-        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
         assert!(result.is_ok());
         if let Some((_, actions)) = result.ok() {
             assert!(actions.iter().any(|a| matches!(a, Action::Skipped { .. })));
@@ -1133,7 +1142,7 @@ mod tests {
         let mut counter = 0;
         let mut artifact = make_skill_artifact();
         artifact.name = "a/b".to_string();
-        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
         assert!(result.is_ok());
         if let Some((_, actions)) = result.ok() {
             assert!(actions.iter().any(|a| matches!(a, Action::Skipped { .. })));
@@ -1190,7 +1199,7 @@ mod tests {
         let mut artifact = make_skill_artifact();
         artifact.files = vec![PathBuf::from("SKILL.md"), PathBuf::from("scripts/deploy.sh")];
         artifact.referenced_scripts = vec![PathBuf::from("scripts/deploy.sh")];
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         // SKILL.md should be copied to skill dir
         assert!(fs.get_written(Path::new("/ai/deploy/skills/deploy/SKILL.md")).is_some());
@@ -1214,7 +1223,7 @@ mod tests {
         let mut artifact = make_skill_artifact();
         artifact.files = vec![PathBuf::from("SKILL.md"), PathBuf::from("scripts/helper.sh")];
         // helper.sh is NOT in referenced_scripts
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         // Unreferenced scripts stay in the skill dir
         assert!(fs.get_written(Path::new("/ai/deploy/skills/deploy/scripts/helper.sh")).is_some());
@@ -1234,7 +1243,7 @@ mod tests {
         let mut counter = 0;
         let mut artifact = make_skill_artifact();
         artifact.referenced_scripts = vec![PathBuf::from("scripts/tools/deploy.sh")];
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         // Nested path should be preserved under scripts/
         assert!(fs.get_written(Path::new("/ai/deploy/scripts/tools/deploy.sh")).is_some());
@@ -1253,7 +1262,7 @@ mod tests {
         let mut counter = 0;
         let mut artifact = make_skill_artifact();
         artifact.files = vec![PathBuf::from("SKILL.md"), PathBuf::from("README.md")];
-        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, &fs);
+        let _result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, true, &fs);
 
         // SKILL.md should have rewritten paths
         let skill = fs.get_written(Path::new("/ai/deploy/skills/deploy/SKILL.md"));
@@ -1269,7 +1278,7 @@ mod tests {
         fs.files.insert(PathBuf::from("/src/skills/deploy/SKILL.md"), "Deploy content".to_string());
 
         let artifact = make_skill_artifact();
-        let result = emit_plugin_with_name(&artifact, "my-plugin", Path::new("/ai"), &fs);
+        let result = emit_plugin_with_name(&artifact, "my-plugin", Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         // Check that files were written at the specified plugin name
@@ -1284,7 +1293,7 @@ mod tests {
         fs.files.insert(PathBuf::from("/src/commands/review.md"), "Review code".to_string());
 
         let artifact = make_command_artifact();
-        let result = emit_plugin_with_name(&artifact, "review-plugin", Path::new("/ai"), &fs);
+        let result = emit_plugin_with_name(&artifact, "review-plugin", Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         let skill = fs.get_written(Path::new("/ai/review-plugin/skills/review/SKILL.md"));
@@ -1301,7 +1310,7 @@ mod tests {
 
         let mut artifact = make_skill_artifact();
         artifact.referenced_scripts = vec![PathBuf::from("scripts/run.sh")];
-        let result = emit_plugin_with_name(&artifact, "deploy", Path::new("/ai"), &fs);
+        let result = emit_plugin_with_name(&artifact, "deploy", Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         assert!(fs.get_written(Path::new("/ai/deploy/scripts/run.sh")).is_some());
@@ -1314,7 +1323,7 @@ mod tests {
 
         let mut artifact = make_skill_artifact();
         artifact.metadata.hooks = Some("PreToolUse: check".to_string());
-        let result = emit_plugin_with_name(&artifact, "deploy", Path::new("/ai"), &fs);
+        let result = emit_plugin_with_name(&artifact, "deploy", Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         assert!(fs.get_written(Path::new("/ai/deploy/hooks/hooks.json")).is_some());
@@ -1326,7 +1335,7 @@ mod tests {
         fs.files.insert(PathBuf::from("/src/skills/deploy/SKILL.md"), "Deploy content".to_string());
 
         let artifact = make_skill_artifact();
-        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), &fs);
+        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         // Check plugin structure
@@ -1348,7 +1357,7 @@ mod tests {
 
         let skill = make_skill_artifact();
         let cmd = make_command_artifact();
-        let result = emit_package_plugin("auth", &[skill, cmd], Path::new("/ai"), &fs);
+        let result = emit_package_plugin("auth", &[skill, cmd], Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         // Both artifacts should be present
@@ -1368,7 +1377,7 @@ mod tests {
         let mut artifact = make_skill_artifact();
         artifact.metadata.hooks = Some("PreToolUse: check_deploy".to_string());
 
-        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), &fs);
+        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         let hooks = fs.get_written(Path::new("/ai/auth/hooks/hooks.json"));
@@ -1390,7 +1399,7 @@ mod tests {
         let mut artifact = make_skill_artifact();
         artifact.referenced_scripts = vec![PathBuf::from("scripts/run.sh")];
 
-        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), &fs);
+        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         assert!(fs.get_written(Path::new("/ai/auth/scripts/run.sh")).is_some());
@@ -1406,7 +1415,7 @@ mod tests {
 
         let mut artifact = make_skill_artifact();
         artifact.referenced_scripts = vec![PathBuf::from("scripts/missing.sh")];
-        let result = emit_plugin_with_name(&artifact, "deploy", Path::new("/ai"), &fs);
+        let result = emit_plugin_with_name(&artifact, "deploy", Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
         assert!(fs.get_written(Path::new("/ai/deploy/scripts/missing.sh")).is_none());
     }
@@ -1417,7 +1426,7 @@ mod tests {
         fs.files.insert(PathBuf::from("/src/commands/review.md"), "Review code".to_string());
 
         let cmd = make_command_artifact();
-        let result = emit_package_plugin("auth", &[cmd], Path::new("/ai"), &fs);
+        let result = emit_package_plugin("auth", &[cmd], Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
 
         // Should be skill type (command converts to skill)
@@ -1434,7 +1443,7 @@ mod tests {
         let mut artifact = make_skill_artifact();
         artifact.referenced_scripts = vec![PathBuf::from("scripts/missing.sh")];
 
-        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), &fs);
+        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
         // Missing script should not be written
         assert!(fs.get_written(Path::new("/ai/auth/scripts/missing.sh")).is_none());
@@ -1443,9 +1452,46 @@ mod tests {
     #[test]
     fn emit_package_plugin_empty_artifacts() {
         let fs = MockFs::new();
-        let result = emit_package_plugin("empty", &[], Path::new("/ai"), &fs);
+        let result = emit_package_plugin("empty", &[], Path::new("/ai"), true, &fs);
         assert!(result.is_ok());
         let actions = result.ok().unwrap_or_default();
         assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn emit_plugin_no_manifest_skips_aipm_toml() {
+        let mut fs = MockFs::new();
+        fs.files.insert(PathBuf::from("/src/skills/deploy/SKILL.md"), "Deploy content".to_string());
+        let artifact = make_skill_artifact();
+        let existing = HashSet::new();
+        let mut counter = 0;
+        let result = emit_plugin(&artifact, Path::new("/ai"), &existing, &mut counter, false, &fs);
+        assert!(result.is_ok());
+        // aipm.toml should NOT be written
+        assert!(fs.get_written(Path::new("/ai/deploy/aipm.toml")).is_none());
+        // plugin.json should still be written
+        assert!(fs.get_written(Path::new("/ai/deploy/.claude-plugin/plugin.json")).is_some());
+    }
+
+    #[test]
+    fn emit_plugin_with_name_no_manifest_skips_aipm_toml() {
+        let mut fs = MockFs::new();
+        fs.files.insert(PathBuf::from("/src/skills/deploy/SKILL.md"), "Deploy content".to_string());
+        let artifact = make_skill_artifact();
+        let result = emit_plugin_with_name(&artifact, "deploy", Path::new("/ai"), false, &fs);
+        assert!(result.is_ok());
+        assert!(fs.get_written(Path::new("/ai/deploy/aipm.toml")).is_none());
+        assert!(fs.get_written(Path::new("/ai/deploy/.claude-plugin/plugin.json")).is_some());
+    }
+
+    #[test]
+    fn emit_package_plugin_no_manifest_skips_aipm_toml() {
+        let mut fs = MockFs::new();
+        fs.files.insert(PathBuf::from("/src/skills/deploy/SKILL.md"), "Deploy content".to_string());
+        let artifact = make_skill_artifact();
+        let result = emit_package_plugin("auth", &[artifact], Path::new("/ai"), false, &fs);
+        assert!(result.is_ok());
+        assert!(fs.get_written(Path::new("/ai/auth/aipm.toml")).is_none());
+        assert!(fs.get_written(Path::new("/ai/auth/.claude-plugin/plugin.json")).is_some());
     }
 }

--- a/crates/libaipm/src/migrate/mod.rs
+++ b/crates/libaipm/src/migrate/mod.rs
@@ -74,6 +74,8 @@ pub struct Options<'a> {
     /// Maximum directory traversal depth for recursive discovery.
     /// `None` means unlimited. Ignored when `source` is `Some`.
     pub max_depth: Option<usize>,
+    /// Generate `aipm.toml` plugin manifests (opt-in).
+    pub manifest: bool,
 }
 
 /// A single action taken (or planned) during migration.
@@ -187,8 +189,8 @@ pub fn migrate(opts: &Options<'_>, fs: &dyn Fs) -> Result<Outcome, Error> {
     }
 
     opts.source.map_or_else(
-        || migrate_recursive(opts.dir, opts.max_depth, opts.dry_run, &ai_dir, fs),
-        |source| migrate_single_source(opts.dir, source, opts.dry_run, &ai_dir, fs),
+        || migrate_recursive(opts.dir, opts.max_depth, opts.dry_run, opts.manifest, &ai_dir, fs),
+        |source| migrate_single_source(opts.dir, source, opts.dry_run, opts.manifest, &ai_dir, fs),
     )
 }
 
@@ -197,6 +199,7 @@ fn migrate_single_source(
     dir: &Path,
     source: &str,
     dry_run: bool,
+    manifest: bool,
     ai_dir: &Path,
     fs: &dyn Fs,
 ) -> Result<Outcome, Error> {
@@ -220,7 +223,7 @@ fn migrate_single_source(
     let existing_plugins = collect_existing_plugin_names(ai_dir, fs)?;
 
     if dry_run {
-        let report = dry_run::generate_report(&all_artifacts, &existing_plugins, source);
+        let report = dry_run::generate_report(&all_artifacts, &existing_plugins, source, manifest);
         let report_path = dir.join("aipm-migrate-dryrun-report.md");
         fs.write_file(&report_path, report.as_bytes())?;
         return Ok(Outcome { actions: vec![Action::DryRunReport { path: report_path }] });
@@ -232,8 +235,14 @@ fn migrate_single_source(
     let mut rename_counter = 0u32;
 
     for artifact in &all_artifacts {
-        let (plugin_name, emit_actions) =
-            emitter::emit_plugin(artifact, ai_dir, &known_names, &mut rename_counter, fs)?;
+        let (plugin_name, emit_actions) = emitter::emit_plugin(
+            artifact,
+            ai_dir,
+            &known_names,
+            &mut rename_counter,
+            manifest,
+            fs,
+        )?;
         actions.extend(emit_actions);
         known_names.insert(plugin_name.clone());
         registered_names.push(plugin_name);
@@ -252,6 +261,7 @@ fn migrate_recursive(
     dir: &Path,
     max_depth: Option<usize>,
     dry_run: bool,
+    manifest: bool,
     ai_dir: &Path,
     fs: &dyn Fs,
 ) -> Result<Outcome, Error> {
@@ -339,13 +349,18 @@ fn migrate_recursive(
             let mut actions = Vec::new();
 
             if plan.is_package_scoped {
-                let emit_actions =
-                    emitter::emit_package_plugin(final_name, &plan.artifacts, ai_dir, fs)?;
+                let emit_actions = emitter::emit_package_plugin(
+                    final_name,
+                    &plan.artifacts,
+                    ai_dir,
+                    manifest,
+                    fs,
+                )?;
                 actions.extend(emit_actions);
             } else if let Some(artifact) = plan.artifacts.first() {
                 // Single artifact — use existing emit logic but with pre-resolved name
                 let emit_actions =
-                    emitter::emit_plugin_with_name(artifact, final_name, ai_dir, fs)?;
+                    emitter::emit_plugin_with_name(artifact, final_name, ai_dir, manifest, fs)?;
                 actions.extend(emit_actions);
             }
 
@@ -444,6 +459,7 @@ mod tests {
             source: Some(".claude"),
             dry_run: false,
             max_depth: None,
+            manifest: true,
         };
         let result = migrate(&opts, &fs);
         assert!(result.is_err());
@@ -460,6 +476,7 @@ mod tests {
             source: Some(".claude"),
             dry_run: false,
             max_depth: None,
+            manifest: true,
         };
         let result = migrate(&opts, &fs);
         assert!(result.is_err());
@@ -482,6 +499,7 @@ mod tests {
             source: Some(".claude"),
             dry_run: true,
             max_depth: None,
+            manifest: true,
         };
         let result = migrate(&opts, &fs);
         assert!(result.is_ok());
@@ -516,6 +534,7 @@ mod tests {
             source: Some(".claude"),
             dry_run: false,
             max_depth: None,
+            manifest: true,
         };
         let result = migrate(&opts, &fs);
         assert!(result.is_ok());
@@ -579,6 +598,7 @@ mod tests {
             source: Some(".claude"),
             dry_run: false,
             max_depth: None,
+            manifest: true,
         };
         let result = migrate(&opts, &fs);
         assert!(result.is_ok());

--- a/crates/libaipm/src/workspace_init/mod.rs
+++ b/crates/libaipm/src/workspace_init/mod.rs
@@ -39,6 +39,8 @@ pub struct Options<'a> {
     pub marketplace: bool,
     /// Skip the starter plugin (bare `.ai/` directory only).
     pub no_starter: bool,
+    /// Generate `aipm.toml` plugin manifests (opt-in).
+    pub manifest: bool,
 }
 
 /// Actions taken during initialization — used for user feedback.
@@ -108,7 +110,7 @@ pub fn init(
     }
 
     if opts.marketplace {
-        scaffold_marketplace(opts.dir, opts.no_starter, fs)?;
+        scaffold_marketplace(opts.dir, opts.no_starter, opts.manifest, fs)?;
         actions.push(InitAction::MarketplaceCreated);
 
         for adaptor in adaptors {
@@ -168,7 +170,12 @@ fn generate_workspace_manifest() -> String {
 // Marketplace scaffolding
 // =============================================================================
 
-fn scaffold_marketplace(dir: &Path, no_starter: bool, fs: &dyn Fs) -> Result<(), Error> {
+fn scaffold_marketplace(
+    dir: &Path,
+    no_starter: bool,
+    manifest: bool,
+    fs: &dyn Fs,
+) -> Result<(), Error> {
     let ai_dir = dir.join(".ai");
     if fs.exists(&ai_dir) {
         return Err(Error::MarketplaceAlreadyExists(dir.to_path_buf()));
@@ -220,13 +227,15 @@ fn scaffold_marketplace(dir: &Path, no_starter: bool, fs: &dyn Fs) -> Result<(),
     )?;
     fs.write_file(&starter.join("hooks").join("hooks.json"), generate_hook_template().as_bytes())?;
 
-    // .ai/starter-aipm-plugin/aipm.toml
-    let starter_manifest = generate_starter_manifest();
-    fs.write_file(&starter.join("aipm.toml"), starter_manifest.as_bytes())?;
+    // .ai/starter-aipm-plugin/aipm.toml (only when --manifest is requested)
+    if manifest {
+        let starter_manifest = generate_starter_manifest();
+        fs.write_file(&starter.join("aipm.toml"), starter_manifest.as_bytes())?;
 
-    // Validate starter manifest round-trips (with base_dir so component paths are checked)
-    crate::manifest::parse_and_validate(&starter_manifest, Some(&starter))
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        // Validate starter manifest round-trips (with base_dir so component paths are checked)
+        crate::manifest::parse_and_validate(&starter_manifest, Some(&starter))
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    }
 
     // .ai/starter-aipm-plugin/.claude-plugin/plugin.json
     fs.write_file(
@@ -544,7 +553,13 @@ mod tests {
     fn init_workspace_creates_manifest() {
         let (tmp, _guard) = make_temp_dir("ws-create");
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: true, marketplace: false, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: true,
+            marketplace: false,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
         assert!(result.is_ok_and(|r| r.actions.contains(&InitAction::WorkspaceCreated)));
@@ -560,7 +575,13 @@ mod tests {
     fn init_marketplace_creates_tree() {
         let (tmp, _guard) = make_temp_dir("mp-create");
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
         assert!(result.is_ok_and(|r| r.actions.contains(&InitAction::MarketplaceCreated)));
@@ -584,7 +605,13 @@ mod tests {
         std::fs::File::create(tmp.join("aipm.toml")).ok();
 
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: true, marketplace: false, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: true,
+            marketplace: false,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_err());
         let err = result.err();
@@ -599,7 +626,13 @@ mod tests {
         std::fs::create_dir_all(tmp.join(".ai")).ok();
 
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_err());
         let err = result.err();
@@ -612,7 +645,13 @@ mod tests {
     fn init_both_creates_everything() {
         let (tmp, _guard) = make_temp_dir("both");
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: true, marketplace: true, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: true,
+            marketplace: true,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
         let r = result.ok();
@@ -628,7 +667,13 @@ mod tests {
     fn init_with_no_adaptors() {
         let (tmp, _guard) = make_temp_dir("no-adaptors");
         let adaptors: Vec<Box<dyn ToolAdaptor>> = vec![];
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
         assert!(tmp.join(".ai").is_dir());
@@ -642,7 +687,13 @@ mod tests {
     fn gitignore_has_managed_markers() {
         let (tmp, _guard) = make_temp_dir("gitignore");
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
 
@@ -772,7 +823,13 @@ mod tests {
     fn init_marketplace_no_starter() {
         let (tmp, _guard) = make_temp_dir("no-starter");
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: true };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: true,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
         assert!(result.is_ok_and(|r| r.actions.contains(&InitAction::MarketplaceCreated)));
@@ -828,7 +885,13 @@ mod tests {
     fn init_marketplace_creates_marketplace_json() {
         let (tmp, _guard) = make_temp_dir("mp-json");
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
 
@@ -858,7 +921,13 @@ mod tests {
     fn init_no_starter_creates_marketplace_json_with_empty_plugins() {
         let (tmp, _guard) = make_temp_dir("mp-json-nostarter");
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: true };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: true,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
 
@@ -881,7 +950,13 @@ mod tests {
     fn init_no_starter_still_configures_tools() {
         let (tmp, _guard) = make_temp_dir("no-starter-tools");
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: true };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: true,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
 
@@ -904,7 +979,13 @@ mod tests {
         ).is_ok());
 
         let adaptors = default_adaptors();
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &crate::fs::Real);
         assert!(result.is_ok());
         // ToolConfigured should NOT be in actions (adaptor returned false)
@@ -976,7 +1057,13 @@ mod tests {
     fn init_workspace_fails_on_create_dir_error() {
         let tmp = std::path::PathBuf::from("/tmp/fake-ws-dir");
         let adaptors: Vec<Box<dyn ToolAdaptor>> = vec![];
-        let opts = Options { dir: &tmp, workspace: true, marketplace: false, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: true,
+            marketplace: false,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &FailDirFs);
         assert!(result.is_err());
         let err = result.err();
@@ -987,7 +1074,13 @@ mod tests {
     fn init_workspace_fails_on_write_file_error() {
         let tmp = std::path::PathBuf::from("/tmp/fake-ws-write");
         let adaptors: Vec<Box<dyn ToolAdaptor>> = vec![];
-        let opts = Options { dir: &tmp, workspace: true, marketplace: false, no_starter: false };
+        let opts = Options {
+            dir: &tmp,
+            workspace: true,
+            marketplace: false,
+            no_starter: false,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &FailWriteFs);
         assert!(result.is_err());
         let err = result.err();
@@ -998,7 +1091,13 @@ mod tests {
     fn scaffold_marketplace_fails_on_create_dir_error() {
         let tmp = std::path::PathBuf::from("/tmp/fake-mp-dir");
         let adaptors: Vec<Box<dyn ToolAdaptor>> = vec![];
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: true };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: true,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &FailDirFs);
         assert!(result.is_err());
     }
@@ -1007,8 +1106,56 @@ mod tests {
     fn scaffold_marketplace_fails_on_write_file_error() {
         let tmp = std::path::PathBuf::from("/tmp/fake-mp-write");
         let adaptors: Vec<Box<dyn ToolAdaptor>> = vec![];
-        let opts = Options { dir: &tmp, workspace: false, marketplace: true, no_starter: true };
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: true,
+            manifest: true,
+        };
         let result = init(&opts, &adaptors, &FailWriteFs);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn init_marketplace_no_manifest_skips_aipm_toml() {
+        let (tmp, _guard) = make_temp_dir("no-manifest");
+        let adaptors = default_adaptors();
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: false,
+            manifest: false,
+        };
+        let result = init(&opts, &adaptors, &crate::fs::Real);
+        assert!(result.is_ok());
+
+        // Components should exist
+        assert!(tmp.join(".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/hooks/hooks.json").exists());
+        assert!(tmp.join(".ai/starter-aipm-plugin/.claude-plugin/plugin.json").exists());
+        // aipm.toml should NOT exist
+        assert!(!tmp.join(".ai/starter-aipm-plugin/aipm.toml").exists());
+
+        cleanup(&tmp);
+    }
+
+    #[test]
+    fn init_marketplace_with_manifest_creates_aipm_toml() {
+        let (tmp, _guard) = make_temp_dir("with-manifest");
+        let adaptors = default_adaptors();
+        let opts = Options {
+            dir: &tmp,
+            workspace: false,
+            marketplace: true,
+            no_starter: false,
+            manifest: true,
+        };
+        let result = init(&opts, &adaptors, &crate::fs::Real);
+        assert!(result.is_ok());
+        assert!(tmp.join(".ai/starter-aipm-plugin/aipm.toml").exists());
+
+        cleanup(&tmp);
     }
 }

--- a/research/docs/2026-03-24-aipm-toml-generation-in-init-and-migrate.md
+++ b/research/docs/2026-03-24-aipm-toml-generation-in-init-and-migrate.md
@@ -1,0 +1,341 @@
+---
+date: 2026-03-24 07:27:06 PDT
+researcher: Claude
+git_commit: 732c72b2ad574f48808a89236e624c5a2650053f
+branch: main
+repository: aipm
+topic: "How and where are aipm.toml plugin manifest files generated during aipm init and aipm migrate commands?"
+tags: [research, codebase, aipm-toml, manifest, init, migrate, workspace-init, emitter]
+status: complete
+last_updated: 2026-03-24
+last_updated_by: Claude
+---
+
+# Research: `aipm.toml` Generation in Init and Migrate Commands
+
+## Research Question
+
+How and where are `aipm.toml` plugin manifest files generated during `aipm init` and `aipm migrate` commands? Document the full code paths, template logic, and trigger conditions for `aipm.toml` creation so we can design a flag/mechanism to suppress manifest generation when marketplace linking/dependency management is not yet available.
+
+## Summary
+
+There are **five distinct `aipm.toml` generation paths** across two binaries (`aipm` and `aipm-pack`). All five use hardcoded `format!()` string templates — none serialize the `Manifest` struct via serde. The migrate command **always** generates per-plugin `aipm.toml` files with no flag or conditional to suppress them. The init commands have partial control via `--no-starter` (suppresses the starter plugin manifest) but no general "skip manifest" option.
+
+| Path | Binary | Trigger | Output Location | Can Be Suppressed? |
+|------|--------|---------|-----------------|-------------------|
+| Workspace manifest | `aipm` | `--workspace` flag | `{dir}/aipm.toml` | Yes — don't pass `--workspace` |
+| Starter plugin manifest | `aipm` | `--marketplace` (default) | `{dir}/.ai/starter-aipm-plugin/aipm.toml` | Yes — pass `--no-starter` |
+| Package init manifest | `aipm-pack` | Always on `init` | `{dir}/aipm.toml` | No |
+| Single-artifact migrate | `aipm` | Each detected artifact | `{dir}/.ai/{name}/aipm.toml` | Only via `--dry-run` (no files written) |
+| Package-scoped migrate | `aipm` | Multiple artifacts in sub-package | `{dir}/.ai/{name}/aipm.toml` | Only via `--dry-run` (no files written) |
+
+## Detailed Findings
+
+### 1. Consumer CLI: `aipm init`
+
+#### Entry Point
+
+[`crates/aipm/src/main.rs:71`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/aipm/src/main.rs#L71) — `Commands::Init` match arm dispatches to `libaipm::workspace_init::init()`.
+
+CLI flags (declared at lines 22-43):
+- `--yes` / `-y` — skip interactive prompts
+- `--workspace` — generate workspace `aipm.toml`
+- `--marketplace` — generate `.ai/` directory (this is the default when no flags given)
+- `--no-starter` — skip starter plugin within marketplace
+- `dir` — positional argument, defaults to `"."`
+
+#### Path A: Workspace Manifest (`--workspace`)
+
+**Code path**: `main.rs:71` → wizard resolution → [`workspace_init::init()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/workspace_init/mod.rs#L98) → [`init_workspace()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/workspace_init/mod.rs#L106) → [`generate_workspace_manifest()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/workspace_init/mod.rs#L146)
+
+**Guard**: If `aipm.toml` already exists at the target dir, returns `Error::WorkspaceAlreadyInitialized` (line 129-131).
+
+**Generated content** (lines 147-164):
+```toml
+# AI Plugin Manager — Workspace Configuration
+# Docs: https://github.com/thelarkinn/aipm
+
+[workspace]
+members = [".ai/*"]
+plugins_dir = ".ai"
+
+# Shared dependency versions for all workspace members.
+# Members reference these via: dep = { workspace = "^" }
+# [workspace.dependencies]
+
+# Direct registry installs (available project-wide).
+# [dependencies]
+
+# Environment requirements for all plugins in this workspace.
+# [environment]
+# requires = ["git"]
+```
+
+**Validation**: Round-trip validated via `crate::manifest::parse_and_validate(&content, None)` at line 137.
+
+**Write**: `fs.write_file(&manifest_path, content.as_bytes())` at line 141.
+
+#### Path B: Starter Plugin Manifest (`--marketplace`, default)
+
+**Code path**: `main.rs:71` → wizard resolution → [`workspace_init::init()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/workspace_init/mod.rs#L98) → [`scaffold_marketplace()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/workspace_init/mod.rs#L171) → [`generate_starter_manifest()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/workspace_init/mod.rs#L243)
+
+**Guard**: If `.ai/` directory already exists, returns `Error::MarketplaceAlreadyExists` (line 172-175).
+
+**Suppression**: If `no_starter == true`, function returns early at line 195-197 after creating `.ai/.gitignore` and `.ai/.claude-plugin/marketplace.json`, **without** creating the starter plugin or its `aipm.toml`.
+
+**Generated content** (lines 244-260):
+```toml
+[package]
+name = "starter-aipm-plugin"
+version = "0.1.0"
+type = "composite"
+edition = "2024"
+description = "Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage"
+
+# [dependencies]
+# Add registry dependencies here, e.g.:
+# shared-skill = "^1.0"
+
+[components]
+skills = ["skills/scaffold-plugin/SKILL.md"]
+agents = ["agents/marketplace-scanner.md"]
+hooks = ["hooks/hooks.json"]
+scripts = ["scripts/scaffold-plugin.ts"]
+```
+
+**Validation**: Round-trip validated with component path checking via `crate::manifest::parse_and_validate(&starter_manifest, Some(&starter))` at line 228.
+
+**Write**: `fs.write_file(&starter.join("aipm.toml"), ...)` at line 225. Component files (SKILL.md, marketplace-scanner.md, hooks.json, scaffold-plugin.ts) are written before validation (lines 209-221).
+
+#### Default Behavior (no flags)
+
+When neither `--workspace` nor `--marketplace` is explicitly set, the wizard defaults to `(false, true, false)` — marketplace only ([`wizard.rs:150-157`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/aipm/src/wizard.rs#L150)). This means:
+- **No** root `aipm.toml` is created
+- **Yes**, starter plugin `aipm.toml` is created at `.ai/starter-aipm-plugin/aipm.toml`
+
+---
+
+### 2. Author CLI: `aipm-pack init`
+
+#### Entry Point
+
+[`crates/aipm-pack/src/main.rs:48`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/aipm-pack/src/main.rs#L48) — `Commands::Init` match arm dispatches to `libaipm::init::init()`.
+
+CLI flags (declared at lines 23-41):
+- `--yes` / `-y` — skip interactive prompts
+- `--name` — package name (optional)
+- `--type` — plugin type: skill, agent, mcp, hook, lsp, composite (optional, defaults to composite)
+- `dir` — positional argument, defaults to `"."`
+
+**Code path**: `main.rs:48` → wizard resolution → [`init::init()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/init.rs#L57) → [`generate_manifest()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/init.rs#L187)
+
+**Guard**: If `aipm.toml` already exists, returns `Error::AlreadyInitialized` (line 61-64).
+
+**Name resolution**: Uses `--name` if provided, otherwise extracts from directory name (lines 67-74). Validated via `is_valid_package_name()` (lines 99-128).
+
+**Generated content** (lines 197-203):
+```toml
+[package]
+name = "{name}"
+version = "0.1.0"
+type = "{type_str}"
+edition = "2024"
+```
+
+**No round-trip validation**: Unlike the consumer CLI, this path does NOT call `parse_and_validate()`.
+
+**Write**: `fs.write_file(&manifest_path, toml_content.as_bytes())` at line 93.
+
+**Cannot be suppressed**: There is no flag or condition to skip `aipm.toml` generation in `aipm-pack init`.
+
+---
+
+### 3. `aipm migrate`
+
+#### Entry Point
+
+[`crates/aipm/src/main.rs:111`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/aipm/src/main.rs#L111) — `Commands::Migrate` match arm dispatches to `libaipm::migrate::migrate()`.
+
+CLI flags (declared at lines 46-64):
+- `--dry-run` — preview without writing files
+- `--source` — specific source directory (e.g., `.claude`)
+- `--max-depth` — limit recursive directory walk depth
+- `dir` — positional argument, defaults to `"."`
+
+#### Prerequisite
+
+The `.ai/` directory **must already exist** ([`migrate/mod.rs:182-185`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/mod.rs#L182)). If absent, returns `Error::MarketplaceNotFound`. This means `aipm init` (which creates `.ai/`) must run before `aipm migrate`.
+
+#### Two Migration Modes
+
+**Single-source mode** (`--source` provided): [`migrate_single_source()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/mod.rs#L196) — scans a single `.claude/` directory.
+
+**Recursive mode** (default, no `--source`): [`migrate_recursive()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/mod.rs#L250) — uses the `ignore` crate to walk the project tree, discovering all `.claude/` directories (including in monorepo sub-packages).
+
+#### Discovery Pipeline
+
+1. [`discovery::discover_claude_dirs()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/discovery.rs#L33) — gitignore-aware walk, finds `.claude/` dirs, extracts package names from parent dirs
+2. Detectors run against each source dir:
+   - [`SkillDetector`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/skill_detector.rs#L11) — scans `skills/` for `SKILL.md` files
+   - [`CommandDetector`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/command_detector.rs#L12) — scans `commands/` for `.md` files
+3. Artifacts grouped into `PluginPlan`s — package-scoped (merged) or individual
+
+#### Manifest Generation in Migrate
+
+**Single-artifact plugins**: [`generate_plugin_manifest()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/emitter.rs#L567) — called from [`emit_plugin()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/emitter.rs#L28) (line 99) and [`emit_plugin_with_name()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/emitter.rs#L229) (line 298).
+
+Generated template (lines 600-609):
+```toml
+[package]
+name = "{plugin_name}"
+version = "0.1.0"
+type = "{type_str}"
+edition = "2024"
+description = "{description}"
+
+[components]
+{components_section}
+```
+
+Where:
+- `type` is always `"skill"` (both `Skill` and `Command` artifact kinds map to `"skill"` via `ArtifactKind::to_type_string()` at `mod.rs:29`)
+- `description` comes from artifact metadata or defaults to `"Migrated from .claude/ configuration"`
+- `[components]` always includes `skills = [...]`, conditionally adds `scripts = [...]` and `hooks = [...]`
+
+**Package-scoped plugins** (multiple artifacts from same sub-package): [`generate_package_manifest()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/emitter.rs#L446) — called from [`emit_package_plugin()`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/migrate/emitter.rs#L317) (line 424).
+
+Same template structure. `type` is `"composite"` when artifacts span both skills and commands, otherwise `"skill"`.
+
+**No validation**: Neither `generate_plugin_manifest()` nor `generate_package_manifest()` calls `parse_and_validate()`.
+
+**Write locations**:
+- Single-source: `{ai_dir}/{plugin_name}/aipm.toml` (emitter.rs:99)
+- Recursive single-artifact: `{ai_dir}/{final_name}/aipm.toml` (emitter.rs:298)
+- Recursive package-scoped: `{ai_dir}/{plugin_name}/aipm.toml` (emitter.rs:424)
+
+#### Suppression in Migrate
+
+The **only** way to prevent `aipm.toml` creation during migrate is `--dry-run`, which writes a markdown report instead of files (checked at `mod.rs:222-227` for single-source, `mod.rs:311-317` for recursive). There is no flag to migrate plugin files without generating manifests.
+
+---
+
+### 4. Manifest Module (Schema & Validation)
+
+The manifest module at [`crates/libaipm/src/manifest/`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/manifest/mod.rs) provides:
+
+- **Deserialization** via `toml::from_str()` into the `Manifest` struct
+- **Validation** of name format, semver, dependency versions, plugin types, component paths
+- **No serialization** — no `Serialize` derive, no `toml::to_string()`
+
+All five generation paths use `format!()` string templates, independent of the type system. This means generated manifests are structurally guaranteed by the template strings, not by the type definitions.
+
+Key types in [`manifest/types.rs`](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/manifest/types.rs):
+- `Manifest` — top-level, all-`Option` fields, `deny_unknown_fields`
+- `Package` — `[package]` section with `name`, `version`, `description`, `type`, `edition`, `files`
+- `Workspace` — `[workspace]` section with `members`, `plugins_dir`, `dependencies`
+- `Components` — nine `Option<Vec<String>>` fields for component declarations
+- `PluginType` — enum: Skill, Agent, Mcp, Hook, Lsp, Composite
+
+---
+
+### 5. Cross-Cutting Patterns
+
+#### No Constant for `"aipm.toml"`
+The filename `"aipm.toml"` appears as a string literal in every location — there is no shared constant. This affects **18 production/test files** across the codebase.
+
+#### Filesystem Abstraction
+All file I/O goes through the [`Fs` trait](https://github.com/TheLarkInn/aipm/blob/732c72b2ad574f48808a89236e624c5a2650053f/crates/libaipm/src/fs.rs#L21) (except `manifest::load()` which uses `std::fs` directly), enabling mock-based testing.
+
+#### Hardcoded String Templates
+All five generators use `format!()` with inline TOML strings. Version is always `"0.1.0"`, edition is always `"2024"`.
+
+## Code References
+
+### Init paths
+- `crates/aipm/src/main.rs:71` — Consumer CLI init dispatch
+- `crates/aipm/src/wizard.rs:150-157` — Default flag resolution (marketplace only)
+- `crates/libaipm/src/workspace_init/mod.rs:98-122` — Core init orchestrator
+- `crates/libaipm/src/workspace_init/mod.rs:125-142` — `init_workspace()` — workspace manifest
+- `crates/libaipm/src/workspace_init/mod.rs:146-165` — `generate_workspace_manifest()`
+- `crates/libaipm/src/workspace_init/mod.rs:171-230` — `scaffold_marketplace()` — starter plugin
+- `crates/libaipm/src/workspace_init/mod.rs:243-261` — `generate_starter_manifest()`
+- `crates/aipm-pack/src/main.rs:48` — Author CLI init dispatch
+- `crates/libaipm/src/init.rs:57-96` — Package init core
+- `crates/libaipm/src/init.rs:187-204` — `generate_manifest()`
+
+### Migrate paths
+- `crates/aipm/src/main.rs:111-151` — Migrate CLI dispatch
+- `crates/libaipm/src/migrate/mod.rs:181-193` — Migrate orchestrator
+- `crates/libaipm/src/migrate/mod.rs:196-248` — `migrate_single_source()`
+- `crates/libaipm/src/migrate/mod.rs:250-371` — `migrate_recursive()`
+- `crates/libaipm/src/migrate/discovery.rs:33-96` — `discover_claude_dirs()`
+- `crates/libaipm/src/migrate/emitter.rs:28` — `emit_plugin()` (single-source)
+- `crates/libaipm/src/migrate/emitter.rs:229` — `emit_plugin_with_name()` (recursive single)
+- `crates/libaipm/src/migrate/emitter.rs:317` — `emit_package_plugin()` (recursive package)
+- `crates/libaipm/src/migrate/emitter.rs:446-491` — `generate_package_manifest()`
+- `crates/libaipm/src/migrate/emitter.rs:567-610` — `generate_plugin_manifest()`
+
+### Manifest module
+- `crates/libaipm/src/manifest/mod.rs:21` — `parse()`
+- `crates/libaipm/src/manifest/mod.rs:33` — `parse_and_validate()`
+- `crates/libaipm/src/manifest/types.rs:10-42` — `Manifest` struct
+- `crates/libaipm/src/manifest/types.rs:45-65` — `Package` struct
+- `crates/libaipm/src/manifest/validate.rs:76-111` — `validate()` entry point
+
+## Architecture Documentation
+
+### Manifest Generation Decision Tree
+
+```
+aipm init
+├── --workspace → generate_workspace_manifest() → {dir}/aipm.toml
+├── --marketplace (default)
+│   ├── --no-starter → NO aipm.toml (only .ai/.gitignore + marketplace.json)
+│   └── (default) → generate_starter_manifest() → {dir}/.ai/starter-aipm-plugin/aipm.toml
+└── --workspace --marketplace → BOTH of the above
+
+aipm-pack init
+└── always → generate_manifest() → {dir}/aipm.toml
+
+aipm migrate
+├── --dry-run → NO aipm.toml (markdown report only)
+├── --source .claude → emit_plugin() per artifact → {dir}/.ai/{name}/aipm.toml
+└── (default recursive)
+    ├── single-artifact plans → emit_plugin_with_name() → {dir}/.ai/{name}/aipm.toml
+    └── package-scoped plans → emit_package_plugin() → {dir}/.ai/{name}/aipm.toml
+```
+
+### Key Observation for the Design Task
+
+The migrate command has **no mechanism** to skip `aipm.toml` generation other than `--dry-run` (which skips ALL file creation). The emit functions (`emit_plugin`, `emit_plugin_with_name`, `emit_package_plugin`) unconditionally generate and write `aipm.toml` as part of plugin directory creation. The manifest generation is tightly coupled to the emission step — there is no intermediate representation that separates "create plugin directory with files" from "write manifest".
+
+Similarly, the starter plugin in `scaffold_marketplace()` couples the `aipm.toml` generation with the rest of the plugin scaffolding. The `--no-starter` flag suppresses the entire starter plugin (directory, components, AND manifest), but there is no option to create the starter plugin directory/components without the manifest.
+
+## Historical Context (from research/)
+
+- `research/docs/2026-03-23-aipm-migrate-command.md` — Research backing the migrate command design. Documents the Scanner-Detector-Emitter architecture and all `.claude/` artifact types.
+- `research/docs/2026-03-23-recursive-claude-discovery-parallel-migrate.md` — Research on recursive discovery and parallel emission for monorepos.
+- `research/docs/2026-03-16-aipm-init-workspace-marketplace.md` — Research backing the init command. Documents the decision to use `.ai/` as the plugin directory.
+- `research/docs/2026-03-20-30-better-default-plugin.md` — Research on the starter plugin design with scaffold, scanner, and logging components.
+- `specs/2026-03-23-aipm-migrate-command.md` — Primary spec for the migrate command.
+- `specs/2026-03-23-recursive-migrate-discovery.md` — Spec extending migrate with recursive `.claude/` discovery.
+- `specs/2026-03-16-aipm-init-workspace-marketplace.md` — Primary spec for `aipm init`.
+- `specs/2026-03-20-better-default-plugin.md` — Spec for the starter plugin replacement.
+
+## Related Research
+
+- `research/docs/2026-03-09-manifest-format-comparison.md` — TOML format justification for `aipm.toml`
+- `research/docs/2026-03-09-cargo-core-principles.md` — Cargo's workspace/manifest model (informing aipm's design)
+- `research/docs/2026-03-09-pnpm-core-principles.md` — pnpm's workspace protocol and catalogs (informing aipm's dependency model)
+
+## Open Questions
+
+1. **Scope of suppression**: Should a `--no-manifest` flag suppress only the per-plugin `aipm.toml`, or also the workspace root `aipm.toml`? The workspace manifest and plugin manifests serve different purposes.
+
+2. **Migrate-specific or global**: Should the flag live only on `aipm migrate`, or also on `aipm init` (for the starter plugin) and `aipm-pack init`?
+
+3. **Partial migration**: If manifests are suppressed during migrate, how will the migrated plugins be registered in `marketplace.json`? The registrar (`registrar.rs:10-47`) currently runs after emission and depends on the plugin directory existing — but it does not read `aipm.toml`.
+
+4. **Future reconciliation**: When marketplace linking/dependency management is implemented, will there be a command to retroactively generate `aipm.toml` files for plugins that were migrated without them? Or will users re-run `migrate`?
+
+5. **Plugin validity without manifest**: Claude Code's plugin discovery (via `marketplace.json` + `extraKnownMarketplaces`) does not require `aipm.toml` — it reads `plugin.json` and component files directly. The `aipm.toml` is an aipm-specific concern for dependency management and publishing. This suggests suppression during migrate is safe for local-only use.

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -1,209 +1,181 @@
 [
   {
     "category": "refactor",
-    "description": "Add Send + Sync supertraits to Fs trait and migrate MockFs from RefCell to Mutex",
+    "description": "Add --manifest CLI flag to Init and Migrate commands in crates/aipm/src/main.rs",
     "steps": [
-      "Open crates/libaipm/src/fs.rs and add Send + Sync bounds to the Fs trait definition",
-      "Verify the Real unit struct already auto-derives Send + Sync (no changes needed)",
-      "Find all MockFs implementations across the test suite that use RefCell",
-      "Replace RefCell with std::sync::Mutex (or parking_lot::Mutex) in MockFs fields",
-      "Update all .borrow() calls to .lock() and .borrow_mut() to .lock()",
-      "Add compile-time assertion tests: fn _assert_send_sync<T: Send + Sync>() {} with Real and MockFs",
-      "Run cargo build --workspace and cargo test --workspace to verify compilation",
+      "Open crates/aipm/src/main.rs and locate Commands::Init variant (line ~23)",
+      "Add `manifest: bool` field with `#[arg(long)]` after the `no_starter` field (line ~38)",
+      "Add doc comment: `/// Generate aipm.toml plugin manifests (opt-in; dependency management not yet available).`",
+      "Locate Commands::Migrate variant (line ~46)",
+      "Add `manifest: bool` field with `#[arg(long)]` after the `max_depth` field (line ~59)",
+      "Add same doc comment as Init variant",
+      "In the Init match arm (line ~81-86), add `manifest` to the workspace_init::Options struct construction",
+      "In the Migrate match arm (line ~114-118), add `manifest` to the migrate::Options struct construction",
+      "Run cargo build --workspace to verify compilation",
+      "Run cargo clippy --workspace -- -D warnings"
+    ],
+    "passes": true
+  },
+  {
+    "category": "refactor",
+    "description": "Add manifest: bool field to workspace_init::Options and migrate::Options structs",
+    "steps": [
+      "Open crates/libaipm/src/workspace_init/mod.rs and locate Options struct (line ~33-42)",
+      "Add `pub manifest: bool` field after `no_starter`",
+      "Open crates/libaipm/src/migrate/mod.rs and locate Options struct (line ~65-77)",
+      "Add `pub manifest: bool` field after `max_depth`",
+      "Find all call sites that construct workspace_init::Options (unit tests, bdd.rs) and add `manifest: true` to preserve existing behavior temporarily",
+      "Find all call sites that construct migrate::Options (unit tests, bdd.rs) and add `manifest: true` to preserve existing behavior temporarily",
+      "Run cargo build --workspace to verify all references compile",
+      "Run cargo test --workspace to verify existing tests still pass with manifest: true"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Suppress starter plugin aipm.toml in scaffold_marketplace() based on manifest flag",
+    "steps": [
+      "Open crates/libaipm/src/workspace_init/mod.rs and locate scaffold_marketplace() (line ~171)",
+      "Add `manifest: bool` parameter to the function signature",
+      "Wrap the generate_starter_manifest() call (line ~224) and its write_file + parse_and_validate (lines ~225-229) in `if manifest { ... }`",
+      "Update the call site in init() (line ~111) to pass `opts.manifest`",
+      "Verify that when manifest is false: all component files (SKILL.md, hooks.json, scripts, agents, plugin.json) are still created but aipm.toml is NOT created",
+      "Verify that when manifest is true: behavior is identical to current (aipm.toml + validation)",
+      "Run cargo build --workspace",
+      "Run cargo test --workspace"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Add manifest: bool parameter to all three emitter emit functions and guard aipm.toml writes",
+    "steps": [
+      "Open crates/libaipm/src/migrate/emitter.rs",
+      "Add `manifest: bool` parameter to emit_plugin() signature (line ~28), before the `fs` parameter",
+      "Guard the generate_plugin_manifest() call and write_file at lines ~97-99 with `if manifest { ... }`",
+      "Add `manifest: bool` parameter to emit_plugin_with_name() signature (line ~229), before the `fs` parameter",
+      "Guard the manifest write at line ~298 with `if manifest { ... }`",
+      "Add `manifest: bool` parameter to emit_package_plugin() signature (line ~317), before the `fs` parameter",
+      "Guard the generate_package_manifest() call and write at lines ~416-424 with `if manifest { ... }`",
+      "Ensure plugin.json generation (generate_plugin_json) is NOT guarded — it is required for Claude Code discovery",
+      "Run cargo build --workspace to verify compilation"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Thread manifest flag through migrate orchestrator (migrate, migrate_single_source, migrate_recursive)",
+    "steps": [
+      "Open crates/libaipm/src/migrate/mod.rs",
+      "Add `manifest: bool` parameter to migrate_single_source() (line ~196)",
+      "Pass manifest to emitter::emit_plugin() call at line ~236",
+      "Add `manifest: bool` parameter to migrate_recursive() (line ~250)",
+      "Pass manifest to emitter::emit_package_plugin() call at line ~343",
+      "Pass manifest to emitter::emit_plugin_with_name() call at line ~348",
+      "In migrate() (line ~181), pass opts.manifest to both migrate_single_source and migrate_recursive",
+      "Run cargo build --workspace",
+      "Run cargo test --workspace to verify all existing tests still pass (they should since manifest: true was set in feature 2)"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update dry-run report to conditionally show aipm.toml line based on manifest flag",
+    "steps": [
+      "Open crates/libaipm/src/migrate/dry_run.rs",
+      "Thread `manifest: bool` into the report generation function(s)",
+      "Locate the line writing `New aipm.toml with type = ...` (line ~213)",
+      "When manifest is true: keep existing behavior (show the aipm.toml line)",
+      "When manifest is false: replace with `  - No aipm.toml (pass --manifest to generate)`",
+      "Update call sites in mod.rs that call dry_run functions to pass the manifest flag",
+      "Write unit test: dry-run with manifest=false shows the educational message",
+      "Write unit test: dry-run with manifest=true shows the existing aipm.toml line",
+      "Run cargo test --workspace"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Flip default: change all test Options constructors from manifest: true to manifest: false",
+    "steps": [
+      "In crates/libaipm/src/workspace_init/mod.rs unit tests: change manifest: true to manifest: false for tests that verify default behavior",
+      "Split tests that assert starter aipm.toml existence: one variant with manifest: false (asserts NOT exists), one with manifest: true (asserts exists)",
+      "In crates/libaipm/src/migrate/emitter.rs unit tests: change manifest: true to manifest: false for default-behavior tests",
+      "Split emitter tests: manifest: false variants assert aipm.toml NOT written, manifest: true variants assert it IS written",
+      "In crates/libaipm/tests/bdd.rs: update Options construction for default BDD scenarios to use manifest: false",
+      "For BDD scenarios that test --manifest flag: use manifest: true",
+      "Run cargo test --workspace — expect some test failures from the split tests (they need matching BDD scenarios, done in next feature)",
       "Run cargo clippy --workspace -- -D warnings"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Add ignore and rayon workspace dependencies",
-    "steps": [
-      "Add ignore = \"0.4\" to [workspace.dependencies] in root Cargo.toml",
-      "Add rayon = \"1\" to [workspace.dependencies] in root Cargo.toml",
-      "Add ignore = { workspace = true } to [dependencies] in crates/libaipm/Cargo.toml",
-      "Add rayon = { workspace = true } to [dependencies] in crates/libaipm/Cargo.toml",
-      "Run cargo build --workspace to verify dependencies resolve correctly"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Modify Options struct to support recursive mode: source becomes Option, add max_depth",
-    "steps": [
-      "Open crates/libaipm/src/migrate/mod.rs and locate the Options struct",
-      "Change source field from &str to Option<&str>",
-      "Add max_depth: Option<usize> field to Options",
-      "Update all call sites that construct Options to pass source as Some(...) or None",
-      "Update the CLI Migrate command in crates/aipm/src/main.rs: remove default_value from --source, add --max-depth flag",
-      "Update the migrate() orchestrator to branch on opts.source: Some -> legacy single-path, None -> recursive mode (stub for now)",
-      "Run cargo build --workspace to ensure all references compile",
-      "Run cargo test --workspace to verify existing tests still pass with Some(...) source"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Create discovery module with discover_claude_dirs() and DiscoveredSource",
-    "steps": [
-      "Create new file crates/libaipm/src/migrate/discovery.rs",
-      "Define DiscoveredSource struct with fields: claude_dir (PathBuf), package_name (Option<String>), relative_path (PathBuf)",
-      "Implement discover_claude_dirs(project_root: &Path, max_depth: Option<usize>) -> Result<Vec<DiscoveredSource>, Error>",
-      "Use ignore::WalkBuilder::new(project_root) with .hidden(false) to find hidden .claude dirs",
-      "Set .max_depth(max_depth) when provided",
-      "Filter for directory entries named .claude",
-      "Skip any .claude/ found inside .ai/ directory",
-      "Derive package_name: None for root .claude, Some(parent_dir_name) for nested .claude",
-      "Sort results by claude_dir path for deterministic ordering",
-      "Add DiscoveryFailed error variant to the Error enum",
-      "Register the discovery module in crates/libaipm/src/migrate/mod.rs",
-      "Write unit tests: finds root .claude, finds nested .claude, correct package_name assignment, respects max_depth, excludes .ai/ subdirs, empty result when no .claude dirs, sorted results",
-      "Run cargo test --workspace"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement PluginPlan struct and package-scoped artifact merging logic",
-    "steps": [
-      "Define PluginPlan struct in crates/libaipm/src/migrate/mod.rs with fields: name (String), artifacts (Vec<Artifact>), is_package_scoped (bool)",
-      "Implement logic in migrate() recursive branch: for each DiscoveredSource, run detectors and group artifacts",
-      "For package_name Some(pkg): create one PluginPlan with all artifacts merged under the package name",
-      "For package_name None (root): create individual PluginPlans per artifact (existing behavior)",
-      "Add unit tests: root artifacts become individual plugins, sub-package artifacts merge into one plugin",
-      "Run cargo test --workspace"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement parallel detection across discovered .claude directories using rayon",
-    "steps": [
-      "Import rayon::prelude::* in crates/libaipm/src/migrate/mod.rs",
-      "In the recursive branch of migrate(), use discovered.par_iter() to run detectors concurrently",
-      "Each thread creates its own claude_detectors() and runs them against the DiscoveredSource's claude_dir",
-      "Collect results into Vec<PluginPlan> using .collect()",
-      "Ensure Fs trait Send + Sync bounds allow &dyn Fs to be shared across threads",
-      "Add test verifying parallel detection produces same results as serial (deterministic ordering via sort)",
-      "Run cargo test --workspace"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement emit_package_plugin() in emitter for package-scoped plugins",
-    "steps": [
-      "Open crates/libaipm/src/migrate/emitter.rs",
-      "Add emit_package_plugin() function with signature matching the spec",
-      "Resolve plugin name using existing rename counter mechanism",
-      "Create .ai/<plugin_name>/ directory structure",
-      "For each artifact, copy files into the plugin under skills/<artifact.name>/",
-      "Merge hooks from all artifacts into a single hooks/hooks.json",
-      "Generate aipm.toml with all component paths in [components]",
-      "Set type = composite when multiple component types exist, otherwise type = skill",
-      "Generate .claude-plugin/plugin.json with the package name",
-      "Write unit tests: correct directory structure, hook merging, aipm.toml generation, composite type handling, command-to-skill conversion",
-      "Run cargo test --workspace"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement parallel emission of plugins via rayon",
-    "steps": [
-      "In the recursive branch of migrate(), after sequential name resolution, use resolved_plans.par_iter() for file writes",
-      "Each thread calls emit_plugin or emit_package_plugin depending on is_package_scoped",
-      "Collect all Action results into a flat Vec<Action>",
-      "Ensure no shared mutable state between parallel plugin emissions",
-      "Add test verifying parallel emission produces correct file structure",
-      "Run cargo test --workspace"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement sequential name resolution for duplicate package names",
-    "steps": [
-      "Before parallel emission, iterate plugin plans sequentially to resolve final names",
-      "Use existing rename counter and known_names set for conflict resolution",
-      "When two packages have the same name (e.g., auth from different paths), apply rename-counter suffix (auth-renamed-1)",
-      "Store resolved names back into plugin plans for emission phase",
-      "Write unit test: duplicate package names trigger rename counter correctly",
-      "Run cargo test --workspace"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Wire up the full recursive migrate() orchestrator flow",
-    "steps": [
-      "In migrate() when opts.source is None: call discover_claude_dirs with opts.dir and opts.max_depth",
-      "Handle empty discovery result by returning Ok(Outcome { actions: [] })",
-      "Run parallel detection over discovered dirs",
-      "Run sequential name resolution",
-      "Run parallel emission",
-      "Call register_plugins for all emitted plugins (unchanged sequential call)",
-      "Write integration test: full recursive migrate with monorepo layout produces correct .ai/ structure",
-      "Write test: recursive migrate with no .claude dirs returns empty outcome",
-      "Run cargo test --workspace"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Update dry-run report to show recursive discovery information",
-    "steps": [
-      "Open crates/libaipm/src/migrate/dry_run.rs",
-      "Add Discovery section to report when in recursive mode",
-      "Show table of discovered .claude/ directories with Location, Package Name, Skills count, Commands count",
-      "Add Planned Plugins section showing each plugin's type, components, and source",
-      "Add Name Conflicts section when rename counter is triggered",
-      "Write unit test: dry-run output includes discovery table and planned plugins",
-      "Run cargo test --workspace"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add BDD feature tests for recursive discovery scenarios",
+    "description": "Update BDD feature files for migrate.feature — flip defaults and add --manifest scenarios",
     "steps": [
       "Open tests/features/manifest/migrate.feature",
-      "Add Scenario: Recursive discovery finds .claude/ in sub-packages",
-      "Add Scenario: Package-scoped plugin merges skills and commands",
-      "Add Scenario: Explicit --source uses legacy single-path behavior",
-      "Add Scenario: --max-depth 1 limits discovery to root .claude only",
-      "Add Scenario: Dry-run report shows discovered directories and planned plugins",
-      "Add Scenario: Duplicate package names trigger rename",
-      "Add Scenario: .gitignored directories are skipped during discovery",
-      "Implement step definitions for new scenarios as needed",
-      "Run cargo test --workspace to verify all scenarios pass"
+      "Update Scenario 'Migrate a single skill' (line ~6): remove aipm.toml content assertions, add `And there is no file \".ai/deploy/aipm.toml\" in \"my-project\"`",
+      "Update Scenario 'Recursive discovery finds skill in sub-package' (line ~64): remove aipm.toml content assertion, add non-existence assertion",
+      "Add new Scenario: 'Migrate with --manifest generates aipm.toml' — runs `aipm migrate --manifest` and asserts `.ai/deploy/aipm.toml` contains name and type",
+      "Add new Scenario: 'Recursive migrate with --manifest generates aipm.toml' — runs `aipm migrate --manifest` and asserts `.ai/auth/aipm.toml` contains name",
+      "Add new Scenario: 'Default migrate does not generate aipm.toml' — explicit test of the new default",
+      "Add new Scenario: 'Recursive migrate without --manifest skips aipm.toml' — explicit test with registration still working",
+      "Ensure the BDD step `there is no file ... in ...` exists in bdd.rs (check workspace-init.feature line 108 for existing usage)",
+      "If step does not exist, add it to bdd.rs as a Then step asserting !path.join(filename).exists()",
+      "Run cargo test --workspace"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Handle edge cases: no .claude dirs, .claude inside .ai, symlinks, empty artifacts",
+    "description": "Update BDD feature files for workspace-init.feature — flip defaults and add --manifest scenarios",
     "steps": [
-      "Verify discover_claude_dirs returns empty vec when no .claude dirs exist anywhere",
-      "Verify .claude/ directories found under .ai/ are excluded from discovery results",
-      "Verify symlinked .claude/ directories are not followed (ignore crate default: follow_links=false)",
-      "Verify root .claude/ with no skills or commands produces no plugin (empty artifacts not emitted)",
-      "Verify package .claude/ with only commands produces a single skill-type plugin",
-      "Verify deeply nested .claude/ (e.g., a/b/c/d/.claude) uses immediate parent d as package name",
-      "Write unit tests for each edge case",
+      "Open tests/features/manifest/workspace-init.feature",
+      "Update Scenario 'Marketplace generates a valid starter plugin manifest' (line ~30): change to assert `.ai/starter-aipm-plugin/aipm.toml` does NOT exist by default",
+      "Update Scenario 'Starter plugin manifest is valid TOML' (line ~131): change command to use `--manifest` flag",
+      "Add new Scenario: 'Default init does not generate starter aipm.toml' — runs `aipm init --marketplace` and asserts component files exist but aipm.toml does NOT",
+      "Add new Scenario: 'Init with --manifest generates starter aipm.toml' — runs `aipm init --marketplace --manifest` and asserts aipm.toml exists with correct content",
+      "Add new Scenario: 'Workspace flag is independent of --manifest' — runs `aipm init --workspace` and asserts root aipm.toml exists (unaffected)",
+      "Verify scenarios testing --workspace (lines 8, 15, 81, 116) are NOT changed",
+      "Run cargo test --workspace"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update E2E tests for init and migrate to reflect new defaults and --manifest flag",
+    "steps": [
+      "Open crates/aipm/tests/migrate_e2e.rs",
+      "In migrate_skill_creates_plugin (line ~38): assert `.ai/deploy/aipm.toml` does NOT exist",
+      "In migrate_command_creates_plugin (line ~60): assert aipm.toml does NOT exist",
+      "In migrate_multiple_skills (line ~253): assert aipm.toml does NOT exist for either plugin",
+      "In migrate_skill_with_scripts (line ~274): assert aipm.toml does NOT exist",
+      "Add new test: migrate_with_manifest_flag_generates_toml — pass --manifest, assert aipm.toml exists with correct content",
+      "Add new test: migrate_manifest_flag_with_recursive_discovery — pass --manifest with recursive, verify manifests",
+      "Open crates/aipm/tests/init_e2e.rs",
+      "In init_default_creates_marketplace_only (line ~22): assert starter aipm.toml does NOT exist",
+      "In init_marketplace_only (line ~54): assert starter aipm.toml does NOT exist",
+      "In init_starter_manifest_valid_toml (line ~140): change to pass --manifest flag",
+      "In yes_flag_creates_default_marketplace (line ~372): assert starter aipm.toml does NOT exist",
+      "Add new test: init_manifest_flag_generates_starter_toml — pass --manifest, assert starter aipm.toml exists",
       "Run cargo test --workspace"
     ],
     "passes": true
   },
   {
     "category": "performance",
-    "description": "Verify coverage meets 89% branch threshold for all new code",
+    "description": "Verify all four gates pass and coverage meets 89% branch threshold",
     "steps": [
+      "Run cargo build --workspace",
+      "Run cargo test --workspace — all tests must pass (0 failures)",
+      "Run cargo clippy --workspace -- -D warnings — 0 warnings",
+      "Run cargo fmt --check — no formatting issues",
       "Run cargo +nightly llvm-cov clean --workspace",
       "Run cargo +nightly llvm-cov --no-report --workspace --branch",
       "Run cargo +nightly llvm-cov --no-report --doc",
       "Run cargo +nightly llvm-cov report --doctests --branch --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\\.rs)'",
       "Verify TOTAL line branch column shows >= 89%",
-      "If below threshold, identify uncovered branches and add targeted tests",
+      "If below threshold, identify uncovered branches in changed files and add targeted tests",
       "Re-run coverage until threshold is met"
     ],
     "passes": true

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -1,42 +1,34 @@
-2026-03-23: Recursive .claude/ Discovery for aipm migrate — Implementation Complete
+2026-03-24: Suppress Plugin Manifest Generation — Implementation Complete
 
-ALL 14 FEATURES IMPLEMENTED AND PASSING:
+ALL 11 FEATURES IMPLEMENTED AND PASSING:
 
-1. [DONE] Add Send + Sync supertraits to Fs trait, migrate MockFs from RefCell to Mutex
-2. [DONE] Add ignore and rayon workspace dependencies
-3. [DONE] Modify Options struct: source -> Option, add max_depth
-4. [DONE] Create discovery module with discover_claude_dirs()
-5. [DONE] Implement PluginPlan struct and package-scoped merging
-6. [DONE] Parallel detection via rayon
-7. [DONE] Implement emit_package_plugin() in emitter
-8. [DONE] Parallel emission via rayon
-9. [DONE] Sequential name resolution for duplicate package names
-10. [DONE] Wire up full recursive migrate() orchestrator
-11. [DONE] Update dry-run report for recursive discovery
-12. [DONE] Add BDD feature tests (4 new scenarios, 62 total)
-13. [DONE] Handle edge cases (no dirs, .ai exclusion, symlinks, empty artifacts, deep nesting)
-14. [DONE] Coverage verified at 89.05% branch coverage (threshold: 89%)
+1. [DONE] Add --manifest CLI flag to Init and Migrate commands
+2. [DONE] Add manifest: bool to workspace_init::Options and migrate::Options
+3. [DONE] Suppress starter plugin aipm.toml in scaffold_marketplace()
+4. [DONE] Add manifest: bool to emitter emit functions (emit_plugin, emit_plugin_with_name, emit_package_plugin)
+5. [DONE] Thread manifest flag through migrate orchestrator
+6. [DONE] Update dry-run report for manifest flag
+7. [DONE] Add manifest: false unit tests (workspace_init + emitter + dry_run)
+8. [DONE] Update BDD migrate.feature (2 scenarios updated, 2 new scenarios added)
+9. [DONE] Update BDD workspace-init.feature (2 scenarios updated, 1 new scenario added)
+10. [DONE] Update E2E tests for init and migrate (4 tests updated, 4 new tests added)
+11. [DONE] Coverage verified at 89.63% branch coverage (threshold: 89%)
 
 VALIDATION:
 - cargo build --workspace: PASS
-- cargo test --workspace: 335 tests pass (0 failures)
+- cargo test --workspace: 346 tests pass + 65 BDD scenarios (0 failures)
 - cargo clippy --workspace -- -D warnings: PASS (0 warnings)
 - cargo fmt --check: PASS
-- Branch coverage: 89.05% (484 branches, 53 missed)
+- Branch coverage: 89.63% (492 branches, 51 missed)
 
 FILES CHANGED:
-- Cargo.toml: Added ignore and rayon workspace dependencies
-- crates/libaipm/Cargo.toml: Added ignore and rayon
-- crates/libaipm/src/fs.rs: Added Send + Sync to Fs trait
-- crates/libaipm/src/init.rs: Cell -> AtomicU32 in CountingFs
-- crates/libaipm/src/migrate/mod.rs: Options struct, PluginPlan, recursive orchestrator
-- crates/libaipm/src/migrate/discovery.rs: NEW — discover_claude_dirs()
-- crates/libaipm/src/migrate/emitter.rs: emit_package_plugin(), emit_plugin_with_name()
-- crates/libaipm/src/migrate/dry_run.rs: generate_recursive_report()
-- crates/libaipm/src/migrate/command_detector.rs: RefCell -> Mutex
-- crates/libaipm/src/migrate/skill_detector.rs: RefCell -> Mutex
-- crates/libaipm/src/migrate/registrar.rs: RefCell -> Mutex
-- crates/aipm/src/main.rs: --source optional, --max-depth flag
-- crates/aipm/tests/migrate_e2e.rs: Updated for recursive behavior
-- crates/libaipm/tests/bdd.rs: Added sub-package step definitions
-- tests/features/manifest/migrate.feature: 4 new BDD scenarios
+- clippy.toml: Raised max-struct-bools to 4
+- crates/aipm/src/main.rs: Added --manifest flag to Init and Migrate commands
+- crates/libaipm/src/workspace_init/mod.rs: Added manifest field to Options, guarded aipm.toml in scaffold_marketplace(), added 2 new unit tests
+- crates/libaipm/src/migrate/mod.rs: Added manifest field to Options, threaded through orchestrator
+- crates/libaipm/src/migrate/emitter.rs: Added manifest param to all 3 emit functions, added 3 new unit tests
+- crates/libaipm/src/migrate/dry_run.rs: Added manifest param to report functions, conditional aipm.toml line, added 2 new unit tests
+- crates/aipm/tests/init_e2e.rs: Updated 4 existing tests, added 2 new --manifest tests
+- crates/aipm/tests/migrate_e2e.rs: Updated 2 existing tests, added 2 new --manifest tests
+- tests/features/manifest/migrate.feature: Updated 2 scenarios, added 2 new --manifest scenarios
+- tests/features/manifest/workspace-init.feature: Updated 2 scenarios, added 1 new scenario

--- a/specs/2026-03-24-suppress-plugin-manifest-generation.md
+++ b/specs/2026-03-24-suppress-plugin-manifest-generation.md
@@ -1,0 +1,551 @@
+# Suppress Plugin Manifest Generation
+
+| Document Metadata      | Details                              |
+| ---------------------- | ------------------------------------ |
+| Author(s)              | selarkin                             |
+| Status                 | Draft (WIP)                          |
+| Team / Owner           | aipm                                 |
+| Created / Last Updated | 2026-03-24                           |
+
+## 1. Executive Summary
+
+Today, `aipm init` and `aipm migrate` unconditionally generate `aipm.toml` plugin manifest files for every plugin they create or discover. Since the local marketplace linking and dependency management system is not yet implemented, these manifests create user confusion — they imply a dependency resolution system that does not exist. This spec flips the default: **plugin-level `aipm.toml` files are no longer generated unless the user passes `--manifest`**. Workspace root manifests (`[workspace]` section) and `aipm-pack init` manifests are unaffected. Plugin registration in `marketplace.json` continues to work without manifests, and a future `aipm manifest generate` command will retroactively create manifests when the dependency system ships.
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+There are five distinct `aipm.toml` generation paths across two binaries (`aipm` and `aipm-pack`). All use hardcoded `format!()` string templates in `libaipm` (see [research](../research/docs/2026-03-24-aipm-toml-generation-in-init-and-migrate.md)):
+
+| # | Path | Binary | Output Location | Generator Function |
+|---|------|--------|-----------------|-------------------|
+| 1 | Workspace manifest | `aipm` | `{dir}/aipm.toml` | `workspace_init::generate_workspace_manifest()` |
+| 2 | Starter plugin manifest | `aipm` | `{dir}/.ai/starter-aipm-plugin/aipm.toml` | `workspace_init::generate_starter_manifest()` |
+| 3 | Package init manifest | `aipm-pack` | `{dir}/aipm.toml` | `init::generate_manifest()` |
+| 4 | Single-artifact migrate | `aipm` | `{dir}/.ai/{name}/aipm.toml` | `migrate::emitter::generate_plugin_manifest()` |
+| 5 | Package-scoped migrate | `aipm` | `{dir}/.ai/{name}/aipm.toml` | `migrate::emitter::generate_package_manifest()` |
+
+Paths 2, 4, and 5 produce **plugin-level** `aipm.toml` files (with `[package]` sections). These are the ones that imply dependency management. Path 1 produces a **workspace root** manifest that is harmless structural config. Path 3 is the **author tool** where manifests are expected.
+
+Claude Code's plugin discovery does not require `aipm.toml` — it reads `marketplace.json` and component files directly via `extraKnownMarketplaces` in `.claude/settings.json` (see [Claude Code defaults research](../research/docs/2026-03-16-claude-code-defaults.md)).
+
+### 2.2 The Problem
+
+- **User confusion**: Running `aipm init` or `aipm migrate` produces `aipm.toml` files with `[dependencies]`, `version`, and `edition` fields that suggest a package management system. Users attempt to add dependencies, set versions, or publish — none of which work yet.
+- **Premature commitment**: Generated manifests lock in schema decisions (hardcoded `version = "0.1.0"`, `edition = "2024"`) before the dependency resolver is built. When the resolver ships, these manifests may need updating.
+- **No functional purpose**: Plugin-level manifests serve no runtime purpose today. Claude Code ignores them entirely.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] `aipm migrate` does NOT generate `aipm.toml` by default
+- [ ] `aipm init --marketplace` does NOT generate `aipm.toml` for the starter plugin by default
+- [ ] Both commands accept `--manifest` flag to opt in to `aipm.toml` generation
+- [ ] Plugin registration in `marketplace.json` works identically with or without manifests
+- [ ] All existing plugin functionality (discovery, component loading, tool settings) is unaffected
+- [ ] BDD and E2E tests updated to reflect the new default behavior
+- [ ] Dry-run reports updated to reflect whether manifests will be generated
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] Workspace root `aipm.toml` (`--workspace` flag) is NOT affected — it remains generated when requested
+- [ ] `aipm-pack init` is NOT affected — the author tool always generates a manifest (it's the whole point)
+- [ ] No `aipm manifest generate` command in this spec — that will come with the dependency management spec
+- [ ] No changes to the manifest module (`manifest/types.rs`, `manifest/validate.rs`) — schema stays the same
+- [ ] No environment variable toggle — the `--manifest` flag is the sole control
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Behavior Change Summary
+
+```
+BEFORE (current):
+  aipm init                     → .ai/starter-aipm-plugin/aipm.toml ✅ generated
+  aipm init --marketplace       → .ai/starter-aipm-plugin/aipm.toml ✅ generated
+  aipm init --no-starter        → no starter plugin at all
+  aipm migrate                  → .ai/{name}/aipm.toml ✅ generated per plugin
+  aipm migrate --dry-run        → no files (report only)
+
+AFTER (proposed):
+  aipm init                     → .ai/starter-aipm-plugin/aipm.toml ❌ NOT generated
+  aipm init --manifest          → .ai/starter-aipm-plugin/aipm.toml ✅ generated
+  aipm init --no-starter        → no starter plugin at all (unchanged)
+  aipm migrate                  → .ai/{name}/aipm.toml ❌ NOT generated
+  aipm migrate --manifest       → .ai/{name}/aipm.toml ✅ generated per plugin
+  aipm migrate --dry-run        → no files (report only, unchanged)
+```
+
+Workspace root manifests are unaffected:
+
+```
+  aipm init --workspace         → {dir}/aipm.toml ✅ generated (unchanged)
+  aipm init --workspace --manifest → {dir}/aipm.toml ✅ + starter aipm.toml ✅
+```
+
+### 4.2 Flag Design
+
+**Flag name**: `--manifest`
+
+**Semantics**: When present, generate `aipm.toml` plugin manifests alongside the plugin directory structure. When absent (the default), skip manifest generation.
+
+**Rationale for opt-in polarity**: The dependency management system does not exist yet. The manifests serve no runtime purpose. Generating them by default creates confusion. Once the dependency system ships, the default can be flipped back (or the flag removed entirely).
+
+### 4.3 Key Components
+
+| Component | Change | File(s) |
+|-----------|--------|---------|
+| CLI argument parsing | Add `--manifest` bool flag to `Init` and `Migrate` variants | `crates/aipm/src/main.rs` |
+| Wizard resolution | Thread `manifest` flag through wizard defaults | `crates/aipm/src/wizard.rs` |
+| Workspace init Options | Add `manifest: bool` field | `crates/libaipm/src/workspace_init/mod.rs` |
+| Migrate Options | Add `manifest: bool` field | `crates/libaipm/src/migrate/mod.rs` |
+| `scaffold_marketplace()` | Conditionally skip `generate_starter_manifest()` and its write | `crates/libaipm/src/workspace_init/mod.rs` |
+| `emit_plugin()` | Conditionally skip `generate_plugin_manifest()` and its write | `crates/libaipm/src/migrate/emitter.rs` |
+| `emit_plugin_with_name()` | Conditionally skip `generate_plugin_manifest()` and its write | `crates/libaipm/src/migrate/emitter.rs` |
+| `emit_package_plugin()` | Conditionally skip `generate_package_manifest()` and its write | `crates/libaipm/src/migrate/emitter.rs` |
+| Dry-run report | Indicate whether `--manifest` would generate manifests | `crates/libaipm/src/migrate/dry_run.rs` |
+| BDD features | Update scenarios asserting `aipm.toml` existence/non-existence | `tests/features/manifest/` |
+| E2E tests | Update tests checking for `aipm.toml` files | `crates/aipm/tests/` |
+
+## 5. Detailed Design
+
+### 5.1 CLI Changes (`crates/aipm/src/main.rs`)
+
+Add `manifest` field to both `Commands::Init` and `Commands::Migrate`:
+
+```rust
+// Inside Commands::Init (after line 38, the no_starter field)
+/// Generate aipm.toml plugin manifests (opt-in; dependency management not yet available).
+#[arg(long)]
+manifest: bool,
+
+// Inside Commands::Migrate (after line 59, the max_depth field)
+/// Generate aipm.toml plugin manifests (opt-in; dependency management not yet available).
+#[arg(long)]
+manifest: bool,
+```
+
+**Help text rationale**: The parenthetical explains *why* this is opt-in, reducing confusion for users who read `--help`.
+
+Thread the flag to the Options struct in each match arm:
+
+```rust
+// Init match arm (around line 81-86):
+let opts = libaipm::workspace_init::Options {
+    dir: &dir,
+    workspace: do_workspace,
+    marketplace: do_marketplace,
+    no_starter: do_no_starter,
+    manifest,           // NEW
+};
+
+// Migrate match arm (around line 114-118):
+let opts = libaipm::migrate::Options {
+    dir: &dir,
+    source: source.as_deref(),
+    dry_run,
+    max_depth,
+    manifest,           // NEW
+};
+```
+
+### 5.2 Wizard Changes (`crates/aipm/src/wizard.rs`)
+
+The `manifest` flag is a CLI-only concern — it does not participate in the interactive wizard. The wizard resolves `(workspace, marketplace, no_starter)` but `manifest` is always passed through directly from the CLI flag. No wizard prompt for "generate manifests?" is needed.
+
+The `resolve_defaults()` function (line 150) and `resolve_workspace_answers()` function (line 100) do not need modification. The `manifest` value flows from `main.rs` directly into `Options.manifest`, bypassing the wizard entirely.
+
+### 5.3 Library Options Changes
+
+#### `workspace_init::Options` (`crates/libaipm/src/workspace_init/mod.rs`)
+
+Add field at line ~41:
+
+```rust
+pub struct Options<'a> {
+    pub dir: &'a Path,
+    pub workspace: bool,
+    pub marketplace: bool,
+    pub no_starter: bool,
+    pub manifest: bool,         // NEW
+}
+```
+
+#### `migrate::Options` (`crates/libaipm/src/migrate/mod.rs`)
+
+Add field at line ~76:
+
+```rust
+pub struct Options<'a> {
+    pub dir: &'a Path,
+    pub source: Option<&'a str>,
+    pub dry_run: bool,
+    pub max_depth: Option<usize>,
+    pub manifest: bool,         // NEW
+}
+```
+
+### 5.4 Starter Plugin Manifest Suppression (`crates/libaipm/src/workspace_init/mod.rs`)
+
+In `scaffold_marketplace()` (line 171), the `no_starter` flag currently gates the *entire* starter plugin. The `manifest` flag is different — it gates only the `aipm.toml` file within the starter plugin, while all other files (SKILL.md, hooks.json, scripts, agents, `.claude-plugin/plugin.json`) are still created.
+
+The `manifest` flag must be threaded from `init()` into `scaffold_marketplace()`. Change the function signature:
+
+```rust
+fn scaffold_marketplace(dir: &Path, no_starter: bool, manifest: bool, fs: &dyn Fs) -> Result<(), Error>
+```
+
+Inside `scaffold_marketplace()`, after writing component files (around line 221) and before the manifest write (line 224-225), add a conditional:
+
+```rust
+// Generate and write aipm.toml only if --manifest was requested
+if manifest {
+    let starter_manifest = generate_starter_manifest();
+    fs.write_file(&starter.join("aipm.toml"), starter_manifest.as_bytes())?;
+
+    let parsed = crate::manifest::parse_and_validate(&starter_manifest, Some(&starter))
+        .map_err(|e| /* existing error conversion */)?;
+}
+```
+
+When `manifest` is `false`, the starter plugin directory is created with all components and `plugin.json`, but no `aipm.toml`. The `generate_starter_manifest()` function is not called. The round-trip validation is also skipped (nothing to validate).
+
+Update the call site in `init()` at line 111:
+
+```rust
+scaffold_marketplace(opts.dir, opts.no_starter, opts.manifest, fs)?;
+```
+
+### 5.5 Migrate Emitter Changes (`crates/libaipm/src/migrate/emitter.rs`)
+
+All three emit functions need a `manifest: bool` parameter.
+
+#### `emit_plugin()` (line 28)
+
+Change signature:
+
+```rust
+pub fn emit_plugin<S: BuildHasher>(
+    artifact: &Artifact,
+    ai_dir: &Path,
+    existing_names: &HashSet<String, S>,
+    rename_counter: &mut u32,
+    manifest: bool,             // NEW
+    fs: &dyn Fs,
+) -> Result<(String, Vec<Action>), Error>
+```
+
+Guard the manifest generation block (lines 97-99):
+
+```rust
+// Generate aipm.toml only if --manifest was requested
+if manifest {
+    let toml = generate_plugin_manifest(artifact, &plugin_name);
+    write_file(&plugin_dir.join("aipm.toml"), &toml, fs)?;
+}
+```
+
+The `plugin.json` generation (lines 102-103) is NOT guarded — it is required for Claude Code plugin discovery.
+
+#### `emit_plugin_with_name()` (line 229)
+
+Change signature:
+
+```rust
+pub fn emit_plugin_with_name(
+    artifact: &Artifact,
+    plugin_name: &str,
+    ai_dir: &Path,
+    manifest: bool,             // NEW
+    fs: &dyn Fs,
+) -> Result<Vec<Action>, Error>
+```
+
+Guard the manifest write at line 298 with `if manifest { ... }`.
+
+#### `emit_package_plugin()` (line 317)
+
+Change signature:
+
+```rust
+pub fn emit_package_plugin(
+    plugin_name: &str,
+    artifacts: &[Artifact],
+    ai_dir: &Path,
+    manifest: bool,             // NEW
+    fs: &dyn Fs,
+) -> Result<Vec<Action>, Error>
+```
+
+Guard the manifest generation block at lines 416-424 with `if manifest { ... }`.
+
+### 5.6 Migrate Orchestrator Changes (`crates/libaipm/src/migrate/mod.rs`)
+
+Thread `manifest` from `Options` to emit function calls.
+
+#### `migrate_single_source()` (line 196)
+
+Change signature to accept `manifest: bool`. At the `emit_plugin()` call site (line 236), pass it through:
+
+```rust
+let (name, mut plugin_actions) = emitter::emit_plugin(
+    artifact,
+    &ai_dir,
+    &known_names,
+    &mut rename_counter,
+    manifest,           // NEW
+    fs,
+)?;
+```
+
+#### `migrate_recursive()` (line 250)
+
+Change signature to accept `manifest: bool`. At the emission parallel block (lines 336-354), pass it to both emit functions:
+
+```rust
+// Package-scoped path (line 343):
+emitter::emit_package_plugin(&plan.name, &plan.artifacts, &ai_dir, manifest, fs)
+
+// Single-artifact path (line 348):
+emitter::emit_plugin_with_name(first, &plan.name, &ai_dir, manifest, fs)
+```
+
+#### `migrate()` (line 181)
+
+Pass `opts.manifest` to the internal functions:
+
+```rust
+opts.source.map_or_else(
+    || migrate_recursive(opts.dir, opts.max_depth, opts.dry_run, opts.manifest, &ai_dir, fs),
+    |source| migrate_single_source(opts.dir, source, opts.dry_run, opts.manifest, &ai_dir, fs),
+)
+```
+
+### 5.7 Dry-Run Report Changes (`crates/libaipm/src/migrate/dry_run.rs`)
+
+The dry-run report currently includes a line per artifact showing `New aipm.toml with type = "..."` (line 213). This line should be conditionally included based on the `manifest` flag.
+
+Thread `manifest: bool` into the report generation function. When `manifest` is `false`, either:
+- Omit the `aipm.toml` line entirely, or
+- Replace it with: `  - No aipm.toml (pass --manifest to generate)`
+
+The latter is preferred as it educates the user about the flag.
+
+### 5.8 Registration Behavior (No Changes)
+
+The registrar (`registrar.rs:10-47`) appends entries to `marketplace.json` based on the plugin directory existing. It does NOT read `aipm.toml`. Therefore, plugin registration works identically with or without manifests. **No changes needed in `registrar.rs`.**
+
+### 5.9 Action Enum (No Changes)
+
+The `Action::PluginCreated` variant (mod.rs:83-90) reports `plugin_type: String`. This type is derived from the artifact kind, not from the manifest. It works the same with or without manifest generation. **No changes needed in the Action enum.**
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Reason for Rejection |
+|--------|------|------|---------------------|
+| **`--no-manifest` (opt-out)** | Backward compatible; no test changes for default path | Confusing default when dependency management doesn't exist; double-negative flag name | Users shouldn't need to know about a system that doesn't work yet |
+| **Environment variable toggle** | CI-friendly; global override | Hidden behavior; harder to discover; another config surface | A CLI flag is discoverable via `--help` and sufficient |
+| **Remove manifest generation entirely** | Simplest change | Loses the ability to generate manifests for users who want them (e.g., testing, early adoption) | Too aggressive; some users may want manifests for experimentation |
+| **Suppress only during migrate** | Smaller change surface | `aipm init` starter plugin has the same confusion problem | Inconsistent — same confusing manifest appears in both commands |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Backward Compatibility
+
+This is a **behavioral breaking change** for the default path. Users who previously relied on `aipm migrate` or `aipm init` generating `aipm.toml` files will no longer get them unless they pass `--manifest`.
+
+**Mitigation**: Since `aipm.toml` serves no runtime purpose today (Claude Code ignores it), no existing workflows should break. Users who have already generated manifests keep them — this change only affects *future* invocations.
+
+### 7.2 Documentation
+
+The `--help` text for `--manifest` should explain why it's opt-in: `"Generate aipm.toml plugin manifests (opt-in; dependency management not yet available)."` When the dependency system ships, this help text should be updated or the flag removed.
+
+### 7.3 Future Reconciliation
+
+When marketplace linking/dependency management is implemented, a separate `aipm manifest generate` command will scan `.ai/` for plugin directories without `aipm.toml` and generate manifests from their component files. This is explicitly out of scope for this spec but noted here for design continuity.
+
+At that point, the `--manifest` flag default may also flip back to opt-out (`--no-manifest`) or the flag may be removed entirely.
+
+## 8. Test Plan
+
+### 8.1 BDD Feature Changes (`tests/features/manifest/`)
+
+#### `migrate.feature`
+
+**Scenarios asserting `aipm.toml` existence** (lines 6, 64) — these must be updated:
+
+- **Scenario "Migrate a single skill"** (line 6): Currently asserts `.ai/deploy/aipm.toml` contains `name = "deploy"`. Change to:
+  1. Assert `.ai/deploy/aipm.toml` does **NOT** exist (default behavior)
+  2. Add a new scenario: "Migrate a single skill with --manifest" that runs `aipm migrate --manifest` and asserts `.ai/deploy/aipm.toml` exists with correct content
+
+- **Scenario "Recursive discovery finds skill in sub-package"** (line 64): Currently asserts `.ai/auth/aipm.toml` contains `name = "auth"`. Change to:
+  1. Assert `.ai/auth/aipm.toml` does **NOT** exist (default behavior)
+  2. Add a new scenario: "Recursive discovery with --manifest" that asserts the manifest is generated when the flag is passed
+
+**New BDD scenarios to add:**
+
+```gherkin
+Scenario: Default migrate does not generate aipm.toml
+  Given an empty directory "my-project"
+  And a workspace initialized in "my-project"
+  And a skill "deploy" exists in "my-project"
+  When the user runs "aipm migrate" in "my-project"
+  Then the command succeeds
+  And a plugin directory exists at ".ai/deploy/" in "my-project"
+  And there is no file ".ai/deploy/aipm.toml" in "my-project"
+  And a file ".ai/deploy/skills/deploy/SKILL.md" exists in "my-project"
+  And the marketplace.json in "my-project" contains plugin "deploy"
+
+Scenario: Migrate with --manifest generates aipm.toml
+  Given an empty directory "my-project"
+  And a workspace initialized in "my-project"
+  And a skill "deploy" exists in "my-project"
+  When the user runs "aipm migrate --manifest" in "my-project"
+  Then the command succeeds
+  And the file ".ai/deploy/aipm.toml" in "my-project" contains 'name = "deploy"'
+  And the file ".ai/deploy/aipm.toml" in "my-project" contains 'type = "skill"'
+
+Scenario: Recursive migrate without --manifest skips aipm.toml
+  Given an empty directory "my-project"
+  And a workspace initialized in "my-project"
+  And a skill "deploy" exists in sub-package "auth" of "my-project"
+  When the user runs "aipm migrate" in "my-project"
+  Then the command succeeds
+  And a plugin directory exists at ".ai/auth/" in "my-project"
+  And there is no file ".ai/auth/aipm.toml" in "my-project"
+  And the marketplace.json in "my-project" contains plugin "auth"
+
+Scenario: Recursive migrate with --manifest generates aipm.toml
+  Given an empty directory "my-project"
+  And a workspace initialized in "my-project"
+  And a skill "deploy" exists in sub-package "auth" of "my-project"
+  When the user runs "aipm migrate --manifest" in "my-project"
+  Then the command succeeds
+  And the file ".ai/auth/aipm.toml" in "my-project" contains 'name = "auth"'
+```
+
+#### `workspace-init.feature`
+
+**Scenarios asserting starter `aipm.toml` existence** (lines 30, 131) — update:
+
+- **Scenario "Marketplace generates a valid starter plugin manifest"** (line 30): Change to assert `.ai/starter-aipm-plugin/aipm.toml` does NOT exist by default. Add a new scenario with `--manifest` flag that asserts it does.
+
+- **Scenario "Starter plugin manifest is valid TOML"** (line 131): Move under `--manifest` flag variant.
+
+**Scenarios asserting root `aipm.toml`** (lines 8, 15, 81, 116) — **NO CHANGES**. These test `--workspace` which is unaffected.
+
+**New BDD scenarios to add:**
+
+```gherkin
+Scenario: Default init does not generate starter aipm.toml
+  Given an empty directory "my-project"
+  When the user runs "aipm init --marketplace" in "my-project"
+  Then a file ".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md" exists in "my-project"
+  And there is no file ".ai/starter-aipm-plugin/aipm.toml" in "my-project"
+
+Scenario: Init with --manifest generates starter aipm.toml
+  Given an empty directory "my-project"
+  When the user runs "aipm init --marketplace --manifest" in "my-project"
+  Then a file ".ai/starter-aipm-plugin/aipm.toml" exists in "my-project"
+  And the starter plugin manifest contains the package name "starter-aipm-plugin"
+  And the starter plugin manifest is valid according to aipm schema
+
+Scenario: Workspace flag is independent of --manifest
+  Given an empty directory "my-project"
+  When the user runs "aipm init --workspace" in "my-project"
+  Then a file "aipm.toml" is created in "my-project"
+  And there is no directory ".ai/starter-aipm-plugin" in "my-project"
+```
+
+#### `init.feature` — **NO CHANGES**
+
+The `aipm-pack init` command is unaffected. All existing scenarios remain as-is.
+
+### 8.2 E2E Test Changes (`crates/aipm/tests/`)
+
+#### `migrate_e2e.rs`
+
+| Test Function | Change |
+|--------------|--------|
+| `migrate_skill_creates_plugin` (line 38) | Assert `aipm.toml` does NOT exist; add separate `_with_manifest` variant |
+| `migrate_command_creates_plugin` (line 60) | Assert `aipm.toml` does NOT exist |
+| `migrate_multiple_skills` (line 253) | Assert `aipm.toml` does NOT exist for either plugin |
+| `migrate_skill_with_scripts` (line 274) | Assert `aipm.toml` does NOT exist |
+| `migrate_dry_run_no_side_effects` (line 177) | No change (already asserts no files) |
+
+**New E2E tests:**
+
+```rust
+#[test]
+fn migrate_with_manifest_flag_generates_toml() { ... }
+
+#[test]
+fn migrate_without_manifest_flag_skips_toml() { ... }
+
+#[test]
+fn migrate_manifest_flag_with_recursive_discovery() { ... }
+```
+
+#### `init_e2e.rs`
+
+| Test Function | Change |
+|--------------|--------|
+| `init_default_creates_marketplace_only` (line 22) | Assert starter `aipm.toml` does NOT exist |
+| `init_marketplace_only` (line 54) | Assert starter `aipm.toml` does NOT exist |
+| `init_starter_manifest_valid_toml` (line 140) | Change to use `--manifest` flag |
+| `yes_flag_creates_default_marketplace` (line 372) | Assert starter `aipm.toml` does NOT exist |
+
+**New E2E tests:**
+
+```rust
+#[test]
+fn init_manifest_flag_generates_starter_toml() { ... }
+
+#[test]
+fn init_without_manifest_flag_skips_starter_toml() { ... }
+```
+
+### 8.3 Unit Test Changes (`crates/libaipm/src/`)
+
+#### `workspace_init/mod.rs` (unit tests section)
+
+Tests that assert `aipm.toml` existence for the starter plugin must be updated to pass `manifest: true` in the `Options` struct, or split into two variants (one with, one without).
+
+Key tests to update:
+- Test asserting `.ai/starter-aipm-plugin/aipm.toml` exists (line ~569)
+- Test asserting both root and starter `aipm.toml` exist (line ~621)
+
+#### `migrate/emitter.rs` (unit tests section)
+
+All emitter unit tests use `MockFs`. Tests that assert `aipm.toml` was written must be updated:
+- Tests checking `fs.get_written(Path::new("/ai/deploy/aipm.toml")).is_some()` should be split: one variant with `manifest: true` (asserts written), one with `manifest: false` (asserts NOT written).
+
+Key tests to update (by line):
+- Line ~734: `emit_plugin` basic test
+- Line ~750: `emit_plugin` content assertion
+- Line ~1276: `emit_plugin_with_name` test
+- Line ~1333: `emit_package_plugin` test
+- Line ~1359: composite type assertion
+- Line ~1378: hooks merge test
+- Line ~1397: scripts test
+- Line ~1424: command-to-skill conversion
+
+### 8.4 Snapshot Tests
+
+The scaffold script snapshot (`workspace_init/snapshots/libaipm__workspace_init__tests__scaffold_script_snapshot.snap`) contains the generated `scaffold-plugin.ts` which writes `aipm.toml` when creating new plugins via the TypeScript scaffold script. This snapshot is **not affected** — the scaffold script is a *user-facing tool* that creates new plugins at runtime, and its behavior is independent of the `--manifest` CLI flag.
+
+### 8.5 BDD Step Definitions (`crates/libaipm/tests/bdd.rs`)
+
+A new step definition is needed:
+
+```gherkin
+And there is no file "{filename}" in "{dir}"
+```
+
+Check if this step already exists (it is used in `workspace-init.feature` line 108). If so, reuse it. If not, add it as a `Then` step that asserts `!path.join(filename).exists()`.
+
+## 9. Open Questions / Unresolved Issues
+
+- [ ] **Dry-run wording**: Exact text for the dry-run report line when `--manifest` is not set. Proposed: `"  - No aipm.toml (pass --manifest to generate)"`. Review during implementation.
+- [ ] **Future default flip**: When the dependency system ships, should `--manifest` become the default and `--no-manifest` be added? Or should the flag be removed entirely? Deferred to the dependency management spec.
+- [ ] **`aipm manifest generate` command**: The reconciliation path for plugins migrated without manifests. Deferred to a separate spec when dependency management is implemented.

--- a/tests/features/manifest/migrate.feature
+++ b/tests/features/manifest/migrate.feature
@@ -10,10 +10,18 @@ Feature: Migrate AI tool configurations into marketplace plugins
       When the user runs "aipm migrate" in "my-project"
       Then the command succeeds
       And a plugin directory exists at ".ai/deploy/" in "my-project"
-      And the file ".ai/deploy/aipm.toml" in "my-project" contains 'name = "deploy"'
-      And the file ".ai/deploy/aipm.toml" in "my-project" contains 'type = "skill"'
+      And there is no file ".ai/deploy/aipm.toml" in "my-project"
       And a file ".ai/deploy/skills/deploy/SKILL.md" exists in "my-project"
       And the marketplace.json in "my-project" contains plugin "deploy"
+
+    Scenario: Migrate with --manifest generates aipm.toml
+      Given an empty directory "my-project"
+      And a workspace initialized in "my-project"
+      And a skill "deploy" exists in "my-project"
+      When the user runs "aipm migrate --manifest" in "my-project"
+      Then the command succeeds
+      And the file ".ai/deploy/aipm.toml" in "my-project" contains 'name = "deploy"'
+      And the file ".ai/deploy/aipm.toml" in "my-project" contains 'type = "skill"'
 
     Scenario: Original skill files are preserved after migration
       Given an empty directory "my-project"
@@ -69,8 +77,16 @@ Feature: Migrate AI tool configurations into marketplace plugins
       Then the command succeeds
       And a plugin directory exists at ".ai/auth/" in "my-project"
       And a file ".ai/auth/skills/deploy/SKILL.md" exists in "my-project"
-      And the file ".ai/auth/aipm.toml" in "my-project" contains 'name = "auth"'
+      And there is no file ".ai/auth/aipm.toml" in "my-project"
       And the marketplace.json in "my-project" contains plugin "auth"
+
+    Scenario: Recursive migrate with --manifest generates aipm.toml
+      Given an empty directory "my-project"
+      And a workspace initialized in "my-project"
+      And a skill "deploy" exists in sub-package "auth" of "my-project"
+      When the user runs "aipm migrate --manifest" in "my-project"
+      Then the command succeeds
+      And the file ".ai/auth/aipm.toml" in "my-project" contains 'name = "auth"'
 
     Scenario: Package-scoped plugin merges skills and commands
       Given an empty directory "my-project"

--- a/tests/features/manifest/workspace-init.feature
+++ b/tests/features/manifest/workspace-init.feature
@@ -27,13 +27,19 @@ Feature: Workspace initialization
       | .ai/starter-aipm-plugin/.claude-plugin/      |
     And a file ".ai/.gitignore" exists in "my-project"
 
-  Scenario: Marketplace generates a valid starter plugin manifest
+  Scenario: Marketplace generates a valid starter plugin manifest with --manifest
     Given an empty directory "my-project"
-    When the user runs "aipm init --workspace --marketplace" in "my-project"
+    When the user runs "aipm init --workspace --marketplace --manifest" in "my-project"
     Then a file ".ai/starter-aipm-plugin/aipm.toml" exists in "my-project"
     And the starter plugin manifest contains the package name "starter-aipm-plugin"
     And the starter plugin manifest contains a version of "0.1.0"
     And the starter plugin manifest contains the plugin type "composite"
+
+  Scenario: Default marketplace does not generate starter aipm.toml
+    Given an empty directory "my-project"
+    When the user runs "aipm init --marketplace" in "my-project"
+    Then a file ".ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md" exists in "my-project"
+    And there is no file ".ai/starter-aipm-plugin/aipm.toml" in "my-project"
 
   Scenario: Marketplace generates a Claude Code plugin structure
     Given an empty directory "my-project"
@@ -130,7 +136,7 @@ Feature: Workspace initialization
 
   Scenario: Starter plugin manifest is valid TOML that round-trips through parser
     Given an empty directory "my-project"
-    When the user runs "aipm init --marketplace" in "my-project"
+    When the user runs "aipm init --marketplace --manifest" in "my-project"
     Then a file ".ai/starter-aipm-plugin/aipm.toml" exists in "my-project"
     And the starter plugin manifest is valid according to aipm schema
 


### PR DESCRIPTION
## Summary

- Plugin-level `aipm.toml` files are no longer generated by default in `aipm init` and `aipm migrate`
- Users opt in via `--manifest` flag when they need manifests (dependency management not yet available)
- Workspace root manifests (`--workspace`) and `aipm-pack init` are unaffected
- Plugin registration in `marketplace.json` and Claude Code discovery continue working without manifests

## Changes

- **CLI**: Added `--manifest` flag to both `Init` and `Migrate` commands with help text explaining opt-in rationale
- **Library**: Threaded `manifest: bool` through `Options` structs, orchestrator functions, and all three emitter functions (`emit_plugin`, `emit_plugin_with_name`, `emit_package_plugin`)
- **Starter plugin**: `scaffold_marketplace()` now guards `aipm.toml` write with `if manifest { ... }` — component files (SKILL.md, hooks.json, scripts, agents, plugin.json) are still created
- **Dry-run report**: Shows `"No aipm.toml (pass --manifest to generate)"` when `--manifest` is absent
- **Clippy**: Raised `max-struct-bools` from 3 to 4 in `clippy.toml` for `workspace_init::Options`

## Test plan

- [x] 247 unit tests pass (7 new: 2 workspace_init, 3 emitter, 2 dry_run)
- [x] 24 init E2E tests pass (4 updated, 2 new `--manifest` tests)
- [x] 16 migrate E2E tests pass (2 updated, 2 new `--manifest` tests)
- [x] 65 BDD scenarios pass (4 updated, 3 new `--manifest` scenarios)
- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings
- [x] `cargo fmt --check` — clean
- [x] 89.63% branch coverage (threshold: 89%)