### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1165,7 +1165,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_cmd",
  "cucumber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.6.0" }
+libaipm = { path = "crates/libaipm", version = "0.7.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.7.0] - 2026-03-24
+
 ## [0.6.0] - 2026-03-24
 
 ## [0.5.0] - 2026-03-23

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.7.0] - 2026-03-24
+
+### Features
+- Suppress plugin manifest generation by default ([#59](https://github.com/TheLarkInn/aipm/pull/59)) (10c5aad)
+
 ## [0.6.0] - 2026-03-24
 
 ### Features

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.7.0] - 2026-03-24
+
+### Features
+- Suppress plugin manifest generation by default ([#59](https://github.com/TheLarkInn/aipm/pull/59)) (10c5aad)
+
 ## [0.6.0] - 2026-03-24
 
 ### Breaking changes


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `aipm`: 0.6.0 -> 0.7.0
* `aipm-pack`: 0.6.0 -> 0.7.0

### ⚠ `libaipm` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Options.manifest in /tmp/.tmpTInpGz/aipm/crates/libaipm/src/migrate/mod.rs:78
  field Options.manifest in /tmp/.tmpTInpGz/aipm/crates/libaipm/src/workspace_init/mod.rs:43

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  libaipm::migrate::emitter::emit_plugin now takes 6 parameters instead of 5, in /tmp/.tmpTInpGz/aipm/crates/libaipm/src/migrate/emitter.rs:28
  libaipm::migrate::emitter::emit_package_plugin now takes 5 parameters instead of 4, in /tmp/.tmpTInpGz/aipm/crates/libaipm/src/migrate/emitter.rs:323
  libaipm::migrate::dry_run::generate_report now takes 4 parameters instead of 3, in /tmp/.tmpTInpGz/aipm/crates/libaipm/src/migrate/dry_run.rs:11
  libaipm::migrate::emitter::emit_plugin_with_name now takes 5 parameters instead of 4, in /tmp/.tmpTInpGz/aipm/crates/libaipm/src/migrate/emitter.rs:232
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.7.0] - 2026-03-24

### Features
- Suppress plugin manifest generation by default ([#59](https://github.com/TheLarkInn/aipm/pull/59)) (10c5aad)
</blockquote>

## `aipm`

<blockquote>

## [0.7.0] - 2026-03-24

### Features
- Suppress plugin manifest generation by default ([#59](https://github.com/TheLarkInn/aipm/pull/59)) (10c5aad)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).