### PR TITLE
fix: prevent double-double-quotes in aipm migrate output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ inquire = { version = "0.9", default-features = false, features = ["crossterm", 
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 toml = "0.8"
 
 # Semver

--- a/crates/aipm/tests/migrate_e2e.rs
+++ b/crates/aipm/tests/migrate_e2e.rs
@@ -564,3 +564,36 @@ fn migrate_agent_with_manifest() {
     assert!(toml.contains("type = \"agent\""), "manifest type should be agent");
     assert!(toml.contains("agents = [\"agents/writer.md\"]"), "manifest should list agent file");
 }
+
+// =========================================================================
+// Scenario: Migrate skill with quoted description produces valid JSON
+// =========================================================================
+#[test]
+fn migrate_skill_with_quoted_description_produces_valid_json() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let dir = tmp.path().join("project");
+    init_workspace(&dir);
+    create_skill(
+        &dir,
+        "analyze-bug",
+        "---\nname: analyze-bug\ndescription: \"Analyze bugs by reading bug reports.\"\n---\nBody",
+    );
+
+    aipm().args(["migrate", &dir.display().to_string()]).assert().success();
+
+    let plugin_json_path = dir.join(".ai/analyze-bug/.claude-plugin/plugin.json");
+    assert!(plugin_json_path.exists(), "plugin.json should exist");
+    let content = std::fs::read_to_string(&plugin_json_path).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).expect("plugin.json should be valid JSON");
+    assert_eq!(
+        parsed.get("description").and_then(serde_json::Value::as_str),
+        Some("Analyze bugs by reading bug reports."),
+        "description should not have extra quotes"
+    );
+    assert_eq!(
+        parsed.get("name").and_then(serde_json::Value::as_str),
+        Some("analyze-bug"),
+        "name should match"
+    );
+}

--- a/crates/libaipm/src/migrate/agent_detector.rs
+++ b/crates/libaipm/src/migrate/agent_detector.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::fs::Fs;
 
 use super::detector::Detector;
-use super::{Artifact, ArtifactKind, ArtifactMetadata, Error};
+use super::{strip_yaml_quotes, Artifact, ArtifactKind, ArtifactMetadata, Error};
 
 /// Scans `.claude/agents/` for `.md` files (subagent definitions).
 pub struct AgentDetector;
@@ -85,9 +85,9 @@ fn parse_agent_frontmatter(content: &str, path: &Path) -> Result<ArtifactMetadat
     for line in yaml_block.lines() {
         let trimmed_line = line.trim();
         if let Some(value) = trimmed_line.strip_prefix("name:") {
-            metadata.name = Some(value.trim().to_string());
+            metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());
         } else if let Some(value) = trimmed_line.strip_prefix("description:") {
-            metadata.description = Some(value.trim().to_string());
+            metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());
         }
     }
 
@@ -296,5 +296,25 @@ mod tests {
         let result = detector.detect(Path::new("/src"), &fs);
         let artifacts = result.ok().unwrap_or_default();
         assert_eq!(artifacts.first().map(|a| a.name.as_str()), Some("my-agent"));
+    }
+
+    #[test]
+    fn detect_agent_strips_quoted_description() {
+        let mut fs = MockFs::new();
+        fs.exists.insert(PathBuf::from("/src/agents"));
+        fs.dirs.insert(PathBuf::from("/src/agents"), vec![de("reviewer.md", false)]);
+        fs.files.insert(
+            PathBuf::from("/src/agents/reviewer.md"),
+            "---\nname: \"reviewer\"\ndescription: \"Reviews code\"\n---\nBody.".to_string(),
+        );
+
+        let detector = AgentDetector;
+        let result = detector.detect(Path::new("/src"), &fs);
+        let artifacts = result.ok().unwrap_or_default();
+        assert_eq!(artifacts.first().map(|a| a.name.as_str()), Some("reviewer"));
+        assert_eq!(
+            artifacts.first().and_then(|a| a.metadata.description.as_deref()),
+            Some("Reviews code")
+        );
     }
 }

--- a/crates/libaipm/src/migrate/command_detector.rs
+++ b/crates/libaipm/src/migrate/command_detector.rs
@@ -6,7 +6,7 @@ use crate::fs::Fs;
 
 use super::detector::Detector;
 use super::skill_detector::extract_script_references;
-use super::{Artifact, ArtifactKind, ArtifactMetadata, Error};
+use super::{strip_yaml_quotes, Artifact, ArtifactKind, ArtifactMetadata, Error};
 
 /// Scans `.claude/commands/` for `.md` files (legacy command format).
 pub struct CommandDetector;
@@ -83,9 +83,9 @@ fn parse_command_frontmatter(content: &str) -> ArtifactMetadata {
     for line in yaml_block.lines() {
         let trimmed_line = line.trim();
         if let Some(value) = trimmed_line.strip_prefix("name:") {
-            metadata.name = Some(value.trim().to_string());
+            metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());
         } else if let Some(value) = trimmed_line.strip_prefix("description:") {
-            metadata.description = Some(value.trim().to_string());
+            metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());
         }
     }
 
@@ -249,5 +249,24 @@ mod tests {
         let result = detector.detect(Path::new("/src"), &fs);
         assert!(result.is_ok());
         assert_eq!(result.ok().unwrap_or_default().len(), 0);
+    }
+
+    #[test]
+    fn detect_command_strips_quoted_description() {
+        let mut fs = MockFs::new();
+        fs.exists.insert(PathBuf::from("/src/commands"));
+        fs.dirs.insert(PathBuf::from("/src/commands"), vec![de("review.md", false)]);
+        fs.files.insert(
+            PathBuf::from("/src/commands/review.md"),
+            "---\nname: \"review\"\ndescription: \"Code review\"\n---\nBody".to_string(),
+        );
+
+        let detector = CommandDetector;
+        let result = detector.detect(Path::new("/src"), &fs);
+        let artifacts = result.ok().unwrap_or_default();
+        assert_eq!(
+            artifacts.first().and_then(|a| a.metadata.description.as_deref()),
+            Some("Code review")
+        );
     }
 }

--- a/crates/libaipm/src/migrate/emitter.rs
+++ b/crates/libaipm/src/migrate/emitter.rs
@@ -7,6 +7,8 @@ use std::path::Path;
 use crate::fs::Fs;
 use crate::workspace_init::write_file;
 
+use serde::Serialize;
+
 use super::{Action, Artifact, ArtifactKind, ArtifactMetadata, Error};
 
 use std::path::PathBuf;
@@ -583,8 +585,6 @@ fn generate_package_manifest(
     has_multiple_types: bool,
     has_hooks_yaml: bool,
 ) -> String {
-    use std::fmt::Write;
-
     let type_str = if has_multiple_types {
         "composite"
     } else {
@@ -595,17 +595,18 @@ fn generate_package_manifest(
         .and_then(|a| a.metadata.description.as_deref())
         .unwrap_or("Migrated from .claude/ configuration");
 
-    let mut components_section = String::new();
+    let mut components = PluginComponents::default();
 
     // Group component paths by type
-    let skill_paths: Vec<&String> =
-        component_paths.iter().filter(|p| p.starts_with("skills/")).collect();
-    let agent_paths: Vec<&String> =
-        component_paths.iter().filter(|p| p.starts_with("agents/")).collect();
-    let mcp_paths: Vec<&String> = component_paths.iter().filter(|p| *p == ".mcp.json").collect();
-    let hook_paths: Vec<&String> =
-        component_paths.iter().filter(|p| p.starts_with("hooks/")).collect();
-    let style_paths: Vec<&String> = component_paths
+    let skill_paths: Vec<String> =
+        component_paths.iter().filter(|p| p.starts_with("skills/")).cloned().collect();
+    let agent_paths: Vec<String> =
+        component_paths.iter().filter(|p| p.starts_with("agents/")).cloned().collect();
+    let mcp_paths: Vec<String> =
+        component_paths.iter().filter(|p| *p == ".mcp.json").cloned().collect();
+    let hook_paths: Vec<String> =
+        component_paths.iter().filter(|p| p.starts_with("hooks/")).cloned().collect();
+    let style_paths: Vec<String> = component_paths
         .iter()
         .filter(|p| {
             !p.starts_with("skills/")
@@ -613,39 +614,23 @@ fn generate_package_manifest(
                 && *p != ".mcp.json"
                 && !p.starts_with("hooks/")
         })
+        .cloned()
         .collect();
 
     if !skill_paths.is_empty() {
-        let list: Vec<String> = skill_paths.iter().map(|p| format!("\"{p}\"")).collect();
-        let _ = write!(components_section, "skills = [{}]", list.join(", "));
+        components.skills = Some(skill_paths);
     }
     if !agent_paths.is_empty() {
-        if !components_section.is_empty() {
-            components_section.push('\n');
-        }
-        let list: Vec<String> = agent_paths.iter().map(|p| format!("\"{p}\"")).collect();
-        let _ = write!(components_section, "agents = [{}]", list.join(", "));
+        components.agents = Some(agent_paths);
     }
     if !mcp_paths.is_empty() {
-        if !components_section.is_empty() {
-            components_section.push('\n');
-        }
-        let list: Vec<String> = mcp_paths.iter().map(|p| format!("\"{p}\"")).collect();
-        let _ = write!(components_section, "mcp_servers = [{}]", list.join(", "));
+        components.mcp_servers = Some(mcp_paths);
     }
     if !hook_paths.is_empty() {
-        if !components_section.is_empty() {
-            components_section.push('\n');
-        }
-        let list: Vec<String> = hook_paths.iter().map(|p| format!("\"{p}\"")).collect();
-        let _ = write!(components_section, "hooks = [{}]", list.join(", "));
+        components.hooks = Some(hook_paths.clone());
     }
     if !style_paths.is_empty() {
-        if !components_section.is_empty() {
-            components_section.push('\n');
-        }
-        let list: Vec<String> = style_paths.iter().map(|p| format!("\"{p}\"")).collect();
-        let _ = write!(components_section, "output_styles = [{}]", list.join(", "));
+        components.output_styles = Some(style_paths);
     }
 
     let all_scripts: Vec<String> = artifacts
@@ -654,35 +639,30 @@ fn generate_package_manifest(
             let scripts_root = Path::new("scripts");
             a.referenced_scripts.iter().map(move |p| {
                 let relative = p.strip_prefix(scripts_root).unwrap_or(p);
-                format!("\"scripts/{}\"", relative.to_string_lossy())
+                format!("scripts/{}", relative.to_string_lossy())
             })
         })
         .collect();
     if !all_scripts.is_empty() {
-        if !components_section.is_empty() {
-            components_section.push('\n');
-        }
-        let _ = write!(components_section, "scripts = [{}]", all_scripts.join(", "));
+        components.scripts = Some(all_scripts);
     }
     // Only append hooks from skill/command frontmatter when no Hook artifact already emitted hooks
     if has_hooks_yaml && hook_paths.is_empty() {
-        if !components_section.is_empty() {
-            components_section.push('\n');
-        }
-        components_section.push_str("hooks = [\"hooks/hooks.json\"]");
+        components.hooks = Some(vec!["hooks/hooks.json".to_string()]);
     }
 
-    format!(
-        "[package]\n\
-         name = \"{plugin_name}\"\n\
-         version = \"0.1.0\"\n\
-         type = \"{type_str}\"\n\
-         edition = \"2024\"\n\
-         description = \"{description}\"\n\
-         \n\
-         [components]\n\
-         {components_section}\n"
-    )
+    let manifest = PluginToml {
+        package: PluginPackage {
+            name: plugin_name.to_string(),
+            version: "0.1.0".to_string(),
+            kind: type_str.to_string(),
+            edition: "2024".to_string(),
+            description: description.to_string(),
+        },
+        components,
+    };
+
+    toml::to_string_pretty(&manifest).unwrap_or_default()
 }
 
 /// Check if a file path refers to a `SKILL.md` file.
@@ -828,6 +808,41 @@ fn convert_hooks_yaml_to_json(hooks_yaml: &str) -> String {
     }
 }
 
+/// Serializable structure for `aipm.toml` generation.
+#[derive(Serialize)]
+struct PluginToml {
+    package: PluginPackage,
+    components: PluginComponents,
+}
+
+/// The `[package]` table of `aipm.toml`.
+#[derive(Serialize)]
+struct PluginPackage {
+    name: String,
+    version: String,
+    #[serde(rename = "type")]
+    kind: String,
+    edition: String,
+    description: String,
+}
+
+/// The `[components]` table of `aipm.toml`.
+#[derive(Default, Serialize)]
+struct PluginComponents {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skills: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agents: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcp_servers: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hooks: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_styles: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scripts: Option<Vec<String>>,
+}
+
 /// Generate `aipm.toml` for a migrated plugin.
 fn generate_plugin_manifest(artifact: &Artifact, plugin_name: &str) -> String {
     let type_str = artifact.kind.to_type_string();
@@ -835,23 +850,23 @@ fn generate_plugin_manifest(artifact: &Artifact, plugin_name: &str) -> String {
     let description =
         artifact.metadata.description.as_deref().unwrap_or("Migrated from .claude/ configuration");
 
-    let mut components = Vec::new();
+    let mut components = PluginComponents::default();
 
     match artifact.kind {
         ArtifactKind::Skill | ArtifactKind::Command => {
-            components.push(format!("skills = [\"skills/{}/SKILL.md\"]", artifact.name));
+            components.skills = Some(vec![format!("skills/{}/SKILL.md", artifact.name)]);
         },
         ArtifactKind::Agent => {
-            components.push(format!("agents = [\"agents/{}.md\"]", artifact.name));
+            components.agents = Some(vec![format!("agents/{}.md", artifact.name)]);
         },
         ArtifactKind::McpServer => {
-            components.push("mcp_servers = [\".mcp.json\"]".to_string());
+            components.mcp_servers = Some(vec![".mcp.json".to_string()]);
         },
         ArtifactKind::Hook => {
-            components.push("hooks = [\"hooks/hooks.json\"]".to_string());
+            components.hooks = Some(vec!["hooks/hooks.json".to_string()]);
         },
         ArtifactKind::OutputStyle => {
-            components.push(format!("output_styles = [\"{}.md\"]", artifact.name));
+            components.output_styles = Some(vec![format!("{}.md", artifact.name)]);
         },
     }
 
@@ -863,30 +878,29 @@ fn generate_plugin_manifest(artifact: &Artifact, plugin_name: &str) -> String {
             .iter()
             .map(|p| {
                 let relative = p.strip_prefix(scripts_root).unwrap_or(p);
-                format!("\"scripts/{}\"", relative.to_string_lossy())
+                format!("scripts/{}", relative.to_string_lossy())
             })
             .collect();
-        components.push(format!("scripts = [{}]", scripts.join(", ")));
+        components.scripts = Some(scripts);
     }
 
     // Hooks component (if extracted from skill/command frontmatter)
     if artifact.metadata.hooks.is_some() && artifact.kind != ArtifactKind::Hook {
-        components.push("hooks = [\"hooks/hooks.json\"]".to_string());
+        components.hooks = Some(vec!["hooks/hooks.json".to_string()]);
     }
 
-    let components_section = components.join("\n");
+    let manifest = PluginToml {
+        package: PluginPackage {
+            name: plugin_name.to_string(),
+            version: "0.1.0".to_string(),
+            kind: type_str.to_string(),
+            edition: "2024".to_string(),
+            description: description.to_string(),
+        },
+        components,
+    };
 
-    format!(
-        "[package]\n\
-         name = \"{plugin_name}\"\n\
-         version = \"0.1.0\"\n\
-         type = \"{type_str}\"\n\
-         edition = \"2024\"\n\
-         description = \"{description}\"\n\
-         \n\
-         [components]\n\
-         {components_section}\n"
-    )
+    toml::to_string_pretty(&manifest).unwrap_or_default()
 }
 
 /// Generate `.claude-plugin/plugin.json` for a migrated plugin.
@@ -906,28 +920,35 @@ fn generate_plugin_json_multi(
     let description =
         metadata.description.as_deref().unwrap_or("Migrated from .claude/ configuration");
 
-    let mut fields = String::new();
+    let mut map = serde_json::Map::new();
+    map.insert("name".to_string(), serde_json::Value::String(name.to_string()));
+    map.insert("version".to_string(), serde_json::Value::String("0.1.0".to_string()));
+    map.insert("description".to_string(), serde_json::Value::String(description.to_string()));
+
     let distinct: HashSet<&ArtifactKind> = kinds.iter().collect();
     if distinct.contains(&ArtifactKind::Skill) || distinct.contains(&ArtifactKind::Command) {
-        fields.push_str(",\n  \"skills\": \"./skills/\"");
+        map.insert("skills".to_string(), serde_json::Value::String("./skills/".to_string()));
     }
     if distinct.contains(&ArtifactKind::Agent) {
-        fields.push_str(",\n  \"agents\": \"./agents/\"");
+        map.insert("agents".to_string(), serde_json::Value::String("./agents/".to_string()));
     }
     if distinct.contains(&ArtifactKind::McpServer) {
-        fields.push_str(",\n  \"mcpServers\": \"./.mcp.json\"");
+        map.insert("mcpServers".to_string(), serde_json::Value::String("./.mcp.json".to_string()));
     }
     if distinct.contains(&ArtifactKind::Hook) {
-        fields.push_str(",\n  \"hooks\": \"./hooks/hooks.json\"");
+        map.insert(
+            "hooks".to_string(),
+            serde_json::Value::String("./hooks/hooks.json".to_string()),
+        );
     }
     if distinct.contains(&ArtifactKind::OutputStyle) {
-        fields.push_str(",\n  \"outputStyles\": \"./\"");
+        map.insert("outputStyles".to_string(), serde_json::Value::String("./".to_string()));
     }
 
-    format!(
-        "{{\n  \"name\": \"{name}\",\n  \"version\": \"0.1.0\",\n  \
-         \"description\": \"{description}\"{fields}\n}}\n"
-    )
+    let obj = serde_json::Value::Object(map);
+    let mut output = serde_json::to_string_pretty(&obj).unwrap_or_default();
+    output.push('\n');
+    output
 }
 
 #[cfg(test)]
@@ -2370,5 +2391,76 @@ mod tests {
         assert!(json.contains("\"mcpServers\""));
         assert!(json.contains("\"hooks\""));
         assert!(json.contains("\"outputStyles\""));
+    }
+
+    #[test]
+    fn generate_plugin_json_valid_json_roundtrip() {
+        let metadata = ArtifactMetadata {
+            description: Some("Deploy app".to_string()),
+            ..ArtifactMetadata::default()
+        };
+        let json = generate_plugin_json("test", &metadata, &ArtifactKind::Skill);
+        let parsed: serde_json::Value = serde_json::from_str(&json).ok().unwrap_or_default();
+        assert_eq!(
+            parsed.get("description").and_then(serde_json::Value::as_str),
+            Some("Deploy app")
+        );
+        assert_eq!(parsed.get("name").and_then(serde_json::Value::as_str), Some("test"));
+    }
+
+    #[test]
+    fn generate_plugin_json_description_with_special_chars() {
+        let metadata = ArtifactMetadata {
+            description: Some("She said \"hello\" and \\backslash".to_string()),
+            ..ArtifactMetadata::default()
+        };
+        let json = generate_plugin_json("test", &metadata, &ArtifactKind::Skill);
+        let parsed: serde_json::Value = serde_json::from_str(&json).ok().unwrap_or_default();
+        assert_eq!(
+            parsed.get("description").and_then(serde_json::Value::as_str),
+            Some("She said \"hello\" and \\backslash")
+        );
+    }
+
+    #[test]
+    fn generate_manifest_valid_toml_roundtrip() {
+        let artifact = Artifact {
+            kind: ArtifactKind::Skill,
+            name: "deploy".to_string(),
+            source_path: PathBuf::from("/src"),
+            files: vec![PathBuf::from("SKILL.md")],
+            referenced_scripts: Vec::new(),
+            metadata: ArtifactMetadata {
+                description: Some("Deploy app".to_string()),
+                ..ArtifactMetadata::default()
+            },
+        };
+        let manifest = generate_plugin_manifest(&artifact, "deploy");
+        let parsed: toml::Value =
+            toml::from_str(&manifest).ok().unwrap_or(toml::Value::Table(Default::default()));
+        let desc =
+            parsed.get("package").and_then(|p| p.get("description")).and_then(toml::Value::as_str);
+        assert_eq!(desc, Some("Deploy app"));
+    }
+
+    #[test]
+    fn generate_manifest_description_with_special_chars() {
+        let artifact = Artifact {
+            kind: ArtifactKind::Agent,
+            name: "reviewer".to_string(),
+            source_path: PathBuf::from("/src"),
+            files: vec![],
+            referenced_scripts: Vec::new(),
+            metadata: ArtifactMetadata {
+                description: Some("She said \"hello\" and \\backslash".to_string()),
+                ..ArtifactMetadata::default()
+            },
+        };
+        let manifest = generate_plugin_manifest(&artifact, "reviewer");
+        let parsed: toml::Value =
+            toml::from_str(&manifest).ok().unwrap_or(toml::Value::Table(Default::default()));
+        let desc =
+            parsed.get("package").and_then(|p| p.get("description")).and_then(toml::Value::as_str);
+        assert_eq!(desc, Some("She said \"hello\" and \\backslash"));
     }
 }

--- a/crates/libaipm/src/migrate/mod.rs
+++ b/crates/libaipm/src/migrate/mod.rs
@@ -64,6 +64,20 @@ pub struct ArtifactMetadata {
     pub raw_content: Option<String>,
 }
 
+/// Strip matching surrounding YAML quote delimiters from a scalar value.
+///
+/// Handles both double-quoted (`"..."`) and single-quoted (`'...'`) YAML scalars.
+/// Returns the inner content if delimiters match, otherwise returns the input unchanged.
+pub(crate) fn strip_yaml_quotes(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    match (bytes.first(), bytes.last()) {
+        (Some(b'"'), Some(b'"')) | (Some(b'\''), Some(b'\'')) if bytes.len() >= 2 => {
+            &s[1..s.len() - 1]
+        },
+        _ => s,
+    }
+}
+
 /// A single detected artifact from a source folder.
 #[derive(Debug, Clone)]
 pub struct Artifact {
@@ -643,5 +657,40 @@ mod tests {
             assert_eq!(plugin_created_count, 2);
             assert_eq!(marketplace_count, 2);
         }
+    }
+
+    #[test]
+    fn strip_yaml_quotes_double() {
+        assert_eq!(strip_yaml_quotes(r#""hello""#), "hello");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_single() {
+        assert_eq!(strip_yaml_quotes("'hello'"), "hello");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_no_quotes() {
+        assert_eq!(strip_yaml_quotes("hello"), "hello");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_mismatched() {
+        assert_eq!(strip_yaml_quotes("\"hello'"), "\"hello'");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_empty_quoted() {
+        assert_eq!(strip_yaml_quotes("\"\""), "");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_single_char() {
+        assert_eq!(strip_yaml_quotes("x"), "x");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_empty() {
+        assert_eq!(strip_yaml_quotes(""), "");
     }
 }

--- a/crates/libaipm/src/migrate/output_style_detector.rs
+++ b/crates/libaipm/src/migrate/output_style_detector.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::fs::Fs;
 
 use super::detector::Detector;
-use super::{Artifact, ArtifactKind, ArtifactMetadata, Error};
+use super::{strip_yaml_quotes, Artifact, ArtifactKind, ArtifactMetadata, Error};
 
 /// Scans `.claude/output-styles/` for `.md` files.
 pub struct OutputStyleDetector;
@@ -79,9 +79,9 @@ fn parse_output_style_frontmatter(content: &str) -> ArtifactMetadata {
     for line in yaml_block.lines() {
         let trimmed_line = line.trim();
         if let Some(value) = trimmed_line.strip_prefix("name:") {
-            metadata.name = Some(value.trim().to_string());
+            metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());
         } else if let Some(value) = trimmed_line.strip_prefix("description:") {
-            metadata.description = Some(value.trim().to_string());
+            metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());
         }
     }
 
@@ -276,6 +276,25 @@ mod tests {
         assert_eq!(
             artifacts.first().and_then(|a| a.metadata.description.as_deref()),
             Some("A fancy style")
+        );
+    }
+
+    #[test]
+    fn detect_output_style_strips_quoted_description() {
+        let mut fs = MockFs::new();
+        fs.exists.insert(PathBuf::from("/src/output-styles"));
+        fs.dirs.insert(PathBuf::from("/src/output-styles"), vec![de("concise.md", false)]);
+        fs.files.insert(
+            PathBuf::from("/src/output-styles/concise.md"),
+            "---\nname: \"concise\"\ndescription: \"Short outputs\"\n---\nBody".to_string(),
+        );
+
+        let detector = OutputStyleDetector;
+        let result = detector.detect(Path::new("/src"), &fs);
+        let artifacts = result.ok().unwrap_or_default();
+        assert_eq!(
+            artifacts.first().and_then(|a| a.metadata.description.as_deref()),
+            Some("Short outputs")
         );
     }
 }

--- a/crates/libaipm/src/migrate/skill_detector.rs
+++ b/crates/libaipm/src/migrate/skill_detector.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::fs::Fs;
 
 use super::detector::Detector;
-use super::{Artifact, ArtifactKind, ArtifactMetadata, Error};
+use super::{strip_yaml_quotes, Artifact, ArtifactKind, ArtifactMetadata, Error};
 
 /// Scans `.claude/skills/` for directories containing `SKILL.md`.
 pub struct SkillDetector;
@@ -104,9 +104,9 @@ fn parse_skill_frontmatter(content: &str, path: &Path) -> Result<ArtifactMetadat
         }
 
         if let Some(value) = trimmed_line.strip_prefix("name:") {
-            metadata.name = Some(value.trim().to_string());
+            metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());
         } else if let Some(value) = trimmed_line.strip_prefix("description:") {
-            metadata.description = Some(value.trim().to_string());
+            metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());
         } else if trimmed_line.starts_with("hooks:") {
             in_hooks = true;
             let value = trimmed_line.strip_prefix("hooks:").unwrap_or_default().trim();
@@ -563,5 +563,28 @@ mod tests {
         let result = detector.detect(Path::new("/src"), &fs);
         assert!(result.is_ok());
         assert_eq!(result.ok().unwrap_or_default().len(), 0);
+    }
+
+    #[test]
+    fn detect_skill_strips_quoted_description() {
+        let mut fs = MockFs::new();
+        fs.exists.insert(PathBuf::from("/src/skills"));
+        fs.exists.insert(PathBuf::from("/src/skills/deploy/SKILL.md"));
+        fs.dirs.insert(PathBuf::from("/src/skills"), vec![de("deploy", true)]);
+        fs.dirs.insert(PathBuf::from("/src/skills/deploy"), vec![de("SKILL.md", false)]);
+        fs.files.insert(
+            PathBuf::from("/src/skills/deploy/SKILL.md"),
+            "---\nname: \"my-deploy\"\ndescription: \"Deploy app\"\n---\nBody".to_string(),
+        );
+
+        let detector = SkillDetector;
+        let result = detector.detect(Path::new("/src"), &fs);
+        assert!(result.is_ok());
+        let artifacts = result.ok().unwrap_or_default();
+        assert_eq!(artifacts.first().map(|a| a.name.as_str()), Some("my-deploy"));
+        assert_eq!(
+            artifacts.first().and_then(|a| a.metadata.description.as_deref()),
+            Some("Deploy app")
+        );
     }
 }

--- a/crates/libaipm/src/workspace_init/mod.rs
+++ b/crates/libaipm/src/workspace_init/mod.rs
@@ -270,12 +270,20 @@ fn generate_starter_manifest() -> String {
 }
 
 fn generate_plugin_json() -> String {
-    "{\n\
-     \x20 \"name\": \"starter-aipm-plugin\",\n\
-     \x20 \"version\": \"0.1.0\",\n\
-     \x20 \"description\": \"Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage\"\n\
-     }\n"
-    .to_string()
+    let mut map = serde_json::Map::new();
+    map.insert("name".to_string(), serde_json::Value::String("starter-aipm-plugin".to_string()));
+    map.insert("version".to_string(), serde_json::Value::String("0.1.0".to_string()));
+    map.insert(
+        "description".to_string(),
+        serde_json::Value::String(
+            "Default starter plugin \u{2014} scaffold new plugins, scan your marketplace, and log tool usage"
+                .to_string(),
+        ),
+    );
+    let obj = serde_json::Value::Object(map);
+    let mut output = serde_json::to_string_pretty(&obj).unwrap_or_default();
+    output.push('\n');
+    output
 }
 
 fn generate_skill_template() -> String {

--- a/research/docs/2026-03-24-migrate-double-quotes-bug.md
+++ b/research/docs/2026-03-24-migrate-double-quotes-bug.md
@@ -1,0 +1,157 @@
+---
+date: 2026-03-24
+researcher: Claude
+git_commit: 7d9847c348c127f697d29f536cb58fddfd5762e7
+branch: main
+repository: aipm
+topic: "Bug: aipm migrate produces double-double-quotes in plugin.json description"
+tags: [research, bug, migrate, plugin-json, frontmatter-parsing]
+status: complete
+last_updated: 2026-03-24
+last_updated_by: Claude
+---
+
+# Research: Double-Double-Quotes Bug in `aipm migrate`
+
+## Research Question
+
+When `aipm migrate` produces a `plugin.json`, the description field contains
+double-double-quotes:
+
+```json
+{
+  "description": ""Analyze bugs by reading bug reports and investigating the codebase to determine root cause.""
+}
+```
+
+Expected output should be:
+
+```json
+{
+  "description": "Analyze bugs by reading bug reports and investigating the codebase to determine root cause."
+}
+```
+
+## Summary
+
+The bug is caused by the YAML frontmatter parsers in all four detectors not
+stripping surrounding quotes from YAML values. When a `.md` file has
+`description: "Some text"`, the parser stores `"Some text"` (with literal quotes)
+in `ArtifactMetadata.description`. The emitter then interpolates this into
+`"description": "{description}"` via `format!()`, producing double-double-quotes.
+
+The same bug also affects `aipm.toml` generation (`description = ""...""`)
+and potentially the `name` field, which uses the identical parsing pattern.
+
+## Detailed Findings
+
+### Component 1: Frontmatter Parsing (Root Cause)
+
+All four detectors parse YAML frontmatter with a simple `strip_prefix` +
+`.trim()` approach. None strip YAML-style surrounding quotes:
+
+**skill_detector.rs:108-109**
+```rust
+} else if let Some(value) = trimmed_line.strip_prefix("description:") {
+    metadata.description = Some(value.trim().to_string());
+}
+```
+
+Identical pattern in:
+- `agent_detector.rs:89-90`
+- `command_detector.rs:87-88`
+- `output_style_detector.rs:83-84`
+
+Given YAML frontmatter `description: "Analyze bugs..."`, after
+`strip_prefix("description:")` the value is ` "Analyze bugs..."`, and after
+`.trim()` it is `"Analyze bugs..."` — the double quotes are preserved as
+literal characters.
+
+The `name:` field uses the same pattern and has the same vulnerability.
+
+### Component 2: JSON Emission (Manifestation in plugin.json)
+
+`emitter.rs:906-931` — `generate_plugin_json_multi()`:
+
+```rust
+let description =
+    metadata.description.as_deref().unwrap_or("Migrated from .claude/ configuration");
+// ...
+format!(
+    "{{\n  \"name\": \"{name}\",\n  \"version\": \"0.1.0\",\n  \
+     \"description\": \"{description}\"{fields}\n}}\n"
+)
+```
+
+When `description` = `"Analyze bugs..."` (with literal quotes), the output is:
+`"description": ""Analyze bugs...""` — invalid JSON.
+
+### Component 3: TOML Emission (Same bug in aipm.toml)
+
+`emitter.rs:835-889` — `generate_plugin_manifest()`:
+
+```rust
+let description =
+    artifact.metadata.description.as_deref().unwrap_or("Migrated from .claude/ configuration");
+// ...
+format!("... description = \"{description}\"\n ...")
+```
+
+Produces `description = ""Analyze bugs...""` — invalid TOML.
+
+`emitter.rs:593-596, 675-685` — `generate_package_manifest()`:
+
+Same pattern, same bug for multi-artifact packages.
+
+### Unaffected Code Paths
+
+- `mcp_detector.rs:45` — constructs description programmatically (no quotes)
+- `hook_detector.rs:52` — hardcoded string (no quotes)
+- `registrar.rs:36-41` — uses `serde_json::json!()` with a hardcoded string
+- `workspace_init/mod.rs:272-279` — hardcoded string literal
+
+### Existing Tests (Gap)
+
+Current tests use unquoted descriptions:
+- `emitter.rs:1336-1343` — `generate_plugin_json_with_description` uses `"Test desc"`
+- `skill_detector.rs:295-317` — test frontmatter uses `description: Deploy app` (no quotes)
+
+No tests exercise quoted YAML values like `description: "Deploy app"`, which is
+why the bug was not caught.
+
+## Code References
+
+- `crates/libaipm/src/migrate/skill_detector.rs:108-109` — description parsing (skill)
+- `crates/libaipm/src/migrate/agent_detector.rs:89-90` — description parsing (agent)
+- `crates/libaipm/src/migrate/command_detector.rs:87-88` — description parsing (command)
+- `crates/libaipm/src/migrate/output_style_detector.rs:83-84` — description parsing (output style)
+- `crates/libaipm/src/migrate/emitter.rs:906-931` — `generate_plugin_json_multi()` (JSON)
+- `crates/libaipm/src/migrate/emitter.rs:835-889` — `generate_plugin_manifest()` (TOML)
+- `crates/libaipm/src/migrate/emitter.rs:579-686` — `generate_package_manifest()` (TOML)
+- `crates/libaipm/src/migrate/mod.rs:52-65` — `ArtifactMetadata` struct definition
+
+## Architecture Documentation
+
+The migrate pipeline has three stages:
+1. **Detection** — detectors parse `.md` frontmatter or config files
+2. **Emission** — emitter generates `plugin.json` and `aipm.toml` via `format!()`
+3. **Registration** — registrar generates workspace plugin list
+
+All output files (JSON and TOML) are generated with raw string interpolation,
+not with serialization libraries (`serde_json`, `toml`). This means any special
+characters in the description (or name) can produce invalid output.
+
+## Scope of the Bug
+
+The bug is triggered when any YAML frontmatter description is wrapped in quotes.
+This is standard YAML practice, especially for descriptions containing special
+characters (colons, commas, etc.). Both `plugin.json` and `aipm.toml` are
+affected. The `name` field has the same vulnerability.
+
+## Open Questions
+
+1. Should the fix also escape characters that are special in JSON/TOML (e.g.,
+   backslashes, newlines) in addition to stripping quotes? The current `format!()`
+   approach has no escaping at all.
+2. Would it be better long-term to switch to `serde_json` / `toml` serialization
+   instead of hand-built string templates?

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -1,217 +1,237 @@
 [
   {
     "category": "refactor",
-    "description": "Extend ArtifactKind enum with Agent, McpServer, Hook, OutputStyle variants",
+    "description": "Add strip_yaml_quotes() helper to migrate/mod.rs for stripping YAML quote delimiters from parsed frontmatter values",
     "steps": [
-      "Open crates/libaipm/src/migrate/mod.rs and locate the ArtifactKind enum",
-      "Add four new variants: Agent, McpServer, Hook, OutputStyle",
-      "Update the to_type_string() method to handle new variants: Agent -> 'agent', McpServer -> 'mcp', Hook -> 'hook', OutputStyle -> 'composite'",
-      "Update all existing match sites on ArtifactKind throughout the codebase (emitter.rs, dry_run.rs, mod.rs) with placeholder arms",
-      "Add raw_content: Option<String> field to ArtifactMetadata struct",
-      "Update ArtifactMetadata::default() or Default impl to include raw_content: None",
-      "Add ConfigParse error variant to the Error enum for JSON parse errors",
-      "Run cargo build --workspace to verify compilation",
-      "Run cargo clippy --workspace -- -D warnings to verify no lint violations",
-      "Run cargo test --workspace to verify existing tests still pass"
+      "Open crates/libaipm/src/migrate/mod.rs",
+      "Add a pub(crate) fn strip_yaml_quotes(s: &str) -> &str function after the ArtifactMetadata struct definition (after line 65)",
+      "The function checks if the input has length >= 2 and starts/ends with matching \" or ' characters",
+      "If matching quotes found, return the inner slice &s[1..s.len()-1]; otherwise return s unchanged",
+      "Add unit tests in the existing #[cfg(test)] mod tests block in mod.rs:",
+      "  - strip_yaml_quotes_double: assert_eq!(strip_yaml_quotes(r#\"\"hello\"\"#), \"hello\")",
+      "  - strip_yaml_quotes_single: assert_eq!(strip_yaml_quotes(\"'hello'\"), \"hello\")",
+      "  - strip_yaml_quotes_no_quotes: assert_eq!(strip_yaml_quotes(\"hello\"), \"hello\")",
+      "  - strip_yaml_quotes_mismatched: assert_eq!(strip_yaml_quotes(\"\\\"hello'\"), \"\\\"hello'\")",
+      "  - strip_yaml_quotes_empty_quoted: assert_eq!(strip_yaml_quotes(\"\\\"\\\"\"), \"\")",
+      "  - strip_yaml_quotes_single_char: assert_eq!(strip_yaml_quotes(\"x\"), \"x\")",
+      "  - strip_yaml_quotes_empty: assert_eq!(strip_yaml_quotes(\"\"), \"\")",
+      "Run: cargo test --workspace -- strip_yaml_quotes to verify"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Implement AgentDetector to scan .claude/agents/ for .md agent definitions",
+    "description": "Update skill_detector.rs frontmatter parser to strip YAML quotes from name and description values",
     "steps": [
-      "Create new file crates/libaipm/src/migrate/agent_detector.rs",
-      "Implement AgentDetector struct with Detector trait",
-      "Implement detect() method: scan .claude/agents/ directory for .md files",
-      "Implement parse_agent_frontmatter() function to extract name and description from YAML frontmatter (same delimiter parsing as parse_skill_frontmatter)",
-      "Return Artifact with kind: ArtifactKind::Agent, source_path, files list, and parsed metadata",
-      "Skip non-.md files and directories",
-      "Fall back to filename stem if frontmatter has no name field",
-      "Add pub mod agent_detector to crates/libaipm/src/migrate/mod.rs",
-      "Add Box::new(super::agent_detector::AgentDetector) to claude_detectors() in detector.rs",
-      "Write unit tests: happy path with valid agent .md, missing agents/ directory returns empty, empty agents/ directory returns empty, malformed frontmatter returns error, non-.md files are skipped, multiple agents detected",
-      "Run cargo build --workspace and cargo test --workspace",
-      "Run cargo clippy --workspace -- -D warnings"
+      "Open crates/libaipm/src/migrate/skill_detector.rs",
+      "Add import: use super::strip_yaml_quotes; at the top of the file (with other imports)",
+      "At line 107, change: metadata.name = Some(value.trim().to_string()); to: metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());",
+      "At line 109, change: metadata.description = Some(value.trim().to_string()); to: metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());",
+      "Add a new unit test detect_skill_strips_quoted_description in the existing #[cfg(test)] mod:",
+      "  - Create MockFs with SKILL.md content: ---\\nname: \"my-deploy\"\\ndescription: \"Deploy app\"\\n---\\nBody",
+      "  - Run detect(), assert metadata.name == Some(\"my-deploy\") (no quotes)",
+      "  - Assert metadata.description == Some(\"Deploy app\") (no quotes)",
+      "Run: cargo test --workspace -- skill_detector to verify"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Implement agent emission in emitter, manifest generation, and dry-run report",
+    "description": "Update agent_detector.rs frontmatter parser to strip YAML quotes from name and description values",
     "steps": [
-      "Add emit_agent_files() function in emitter.rs: copy agent .md file to agents/<name>.md inside plugin directory",
-      "Add ArtifactKind::Agent arm to all match sites in emitter.rs (emit_plugin, emit_plugin_with_name, emit_package_plugin)",
-      "Update generate_plugin_manifest() to produce agents = ['agents/<name>.md'] for Agent kind",
-      "Update generate_plugin_json() to emit 'agents': './agents/' field for Agent kind",
-      "Update generate_package_manifest() to accumulate agents entries when Agent artifacts are present",
-      "Add agent section to dry-run report in dry_run.rs: filter agents, display 'agents/<name>.md' path",
-      "Add agent count column to recursive report discovery table",
-      "Write emitter unit tests: verify agent .md file is copied to correct location, verify manifest contains agents component",
-      "Write dry-run unit tests: verify agent section header appears, verify component path formatting",
-      "Run cargo build --workspace, cargo test --workspace, cargo clippy --workspace -- -D warnings"
+      "Open crates/libaipm/src/migrate/agent_detector.rs",
+      "Add import: use super::strip_yaml_quotes; at the top of the file (with other imports)",
+      "At line 88, change: metadata.name = Some(value.trim().to_string()); to: metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());",
+      "At line 90, change: metadata.description = Some(value.trim().to_string()); to: metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());",
+      "Add a new unit test detect_agent_strips_quoted_description in the existing #[cfg(test)] mod:",
+      "  - Create MockFs with agent .md content: ---\\nname: \"reviewer\"\\ndescription: \"Reviews code\"\\n---\\nBody",
+      "  - Run detect(), assert metadata.name == Some(\"reviewer\") and metadata.description == Some(\"Reviews code\")",
+      "Run: cargo test --workspace -- agent_detector to verify"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Implement OutputStyleDetector to scan .claude/output-styles/ for .md files",
+    "description": "Update command_detector.rs frontmatter parser to strip YAML quotes from name and description values",
     "steps": [
-      "Create new file crates/libaipm/src/migrate/output_style_detector.rs",
-      "Implement OutputStyleDetector struct with Detector trait",
-      "Implement detect() method: scan .claude/output-styles/ directory for .md files",
-      "Implement parse_output_style_frontmatter() function to extract name and description from YAML frontmatter",
-      "Return Artifact with kind: ArtifactKind::OutputStyle, source_path, files list, and parsed metadata",
-      "Skip non-.md files and directories",
-      "Fall back to filename stem if frontmatter has no name field",
-      "Add pub mod output_style_detector to crates/libaipm/src/migrate/mod.rs",
-      "Add Box::new(super::output_style_detector::OutputStyleDetector) to claude_detectors() in detector.rs",
-      "Write unit tests: happy path, missing directory, empty directory, multiple styles, name fallback to filename",
-      "Run cargo build --workspace and cargo test --workspace",
-      "Run cargo clippy --workspace -- -D warnings"
+      "Open crates/libaipm/src/migrate/command_detector.rs",
+      "Add import: use super::strip_yaml_quotes; at the top of the file (with other imports)",
+      "At line 86, change: metadata.name = Some(value.trim().to_string()); to: metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());",
+      "At line 88, change: metadata.description = Some(value.trim().to_string()); to: metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());",
+      "Add a new unit test detect_command_strips_quoted_description in the existing #[cfg(test)] mod:",
+      "  - Create MockFs with command .md content: ---\\nname: \"review\"\\ndescription: \"Code review\"\\n---\\nBody",
+      "  - Run detect(), assert metadata.description == Some(\"Code review\")",
+      "Run: cargo test --workspace -- command_detector to verify"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Implement output style emission in emitter, manifest generation, and dry-run report",
+    "description": "Update output_style_detector.rs frontmatter parser to strip YAML quotes from name and description values",
     "steps": [
-      "Add emit_output_style() function in emitter.rs: copy .md file to plugin root (no subdirectory)",
-      "Add ArtifactKind::OutputStyle arm to all match sites in emitter.rs",
-      "Update generate_plugin_manifest() to produce output_styles = ['<name>.md'] for OutputStyle kind",
-      "Update generate_plugin_json() to emit 'outputStyles': './' field for OutputStyle kind",
-      "Update generate_package_manifest() to accumulate output_styles entries when OutputStyle artifacts are present",
-      "Add output styles section to dry-run report in dry_run.rs: filter output styles, display '<name>.md' path",
-      "Add styles count column to recursive report discovery table",
-      "Write emitter unit tests: verify .md file is copied to plugin root, verify manifest contains output_styles component",
-      "Write dry-run unit tests: verify output styles section header appears, verify component path formatting",
-      "Run cargo build --workspace, cargo test --workspace, cargo clippy --workspace -- -D warnings"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement McpDetector to read .mcp.json at project root and emit bundled MCP plugin",
-    "steps": [
-      "Create new file crates/libaipm/src/migrate/mcp_detector.rs",
-      "Implement McpDetector struct with Detector trait",
-      "Implement detect() method: derive project root from source_dir.parent(), read .mcp.json",
-      "Parse JSON and validate mcpServers key exists and is non-empty object",
-      "Return single Artifact with kind: ArtifactKind::McpServer, name 'project-mcp-servers', raw_content containing full JSON",
-      "Return empty Vec if .mcp.json missing, unparseable, or has no servers",
-      "Use ConfigParse error variant for JSON parse failures",
-      "Add pub mod mcp_detector to crates/libaipm/src/migrate/mod.rs",
-      "Add Box::new(super::mcp_detector::McpDetector) to claude_detectors() in detector.rs",
-      "Write unit tests: happy path with valid .mcp.json, missing file, empty mcpServers, malformed JSON, project-root derivation from source_dir.parent()",
-      "Run cargo build --workspace and cargo test --workspace",
-      "Run cargo clippy --workspace -- -D warnings"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement MCP emission in emitter, manifest generation, and dry-run report",
-    "steps": [
-      "Add emit_mcp_config() function in emitter.rs: write raw_content to .mcp.json at plugin root",
-      "Add ArtifactKind::McpServer arm to all match sites in emitter.rs",
-      "Update generate_plugin_manifest() to produce mcp_servers = ['.mcp.json'] for McpServer kind",
-      "Update generate_plugin_json() to emit 'mcpServers': './.mcp.json' field for McpServer kind",
-      "Update generate_package_manifest() to accumulate mcp_servers entries when McpServer artifacts are present",
-      "Add MCP servers section to dry-run report in dry_run.rs: filter MCP artifacts, display '.mcp.json' path",
-      "Add MCP count column to recursive report discovery table",
-      "Write emitter unit tests: verify .mcp.json written with correct content, verify manifest contains mcp_servers component",
-      "Write dry-run unit tests: verify MCP section header appears, verify component path formatting",
-      "Run cargo build --workspace, cargo test --workspace, cargo clippy --workspace -- -D warnings"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement HookDetector to extract hooks from .claude/settings.json",
-    "steps": [
-      "Create new file crates/libaipm/src/migrate/hook_detector.rs",
-      "Implement HookDetector struct with Detector trait",
-      "Implement detect() method: read .claude/settings.json, parse JSON, extract 'hooks' key",
-      "Build hooks.json format: wrap hooks value in { 'hooks': { ... } } structure",
-      "Implement extract_hook_script_references() function: walk hooks JSON recursively, find 'type': 'command' handlers, extract 'command' values that are relative paths (start with './' or are relative)",
-      "Return single Artifact with kind: ArtifactKind::Hook, name 'project-hooks', raw_content containing hooks JSON, referenced_scripts populated",
-      "Return empty Vec if settings.json missing, no hooks key, or hooks object is empty",
-      "Use ConfigParse error variant for JSON parse failures",
-      "Add pub mod hook_detector to crates/libaipm/src/migrate/mod.rs",
-      "Add Box::new(super::hook_detector::HookDetector) to claude_detectors() in detector.rs",
-      "Write unit tests: happy path with hooks in settings.json, missing settings.json, no hooks key, empty hooks object, script reference extraction from command fields, malformed JSON",
-      "Run cargo build --workspace and cargo test --workspace",
-      "Run cargo clippy --workspace -- -D warnings"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Implement hook emission with script copying and absolute path rewriting",
-    "steps": [
-      "Add emit_hooks_config() function in emitter.rs: write raw_content to hooks/hooks.json inside plugin directory",
-      "Implement script path rewriting: for each command field with relative path, resolve to absolute path against project root at migration time",
-      "Copy referenced scripts to scripts/ directory inside the plugin",
-      "Add ArtifactKind::Hook arm to all match sites in emitter.rs",
-      "Update generate_plugin_manifest() to produce hooks = ['hooks/hooks.json'] for Hook kind",
-      "Update generate_plugin_json() to emit 'hooks': './hooks/hooks.json' field for Hook kind",
-      "Update generate_package_manifest() to accumulate hooks entries when Hook artifacts are present",
-      "Add hooks section to dry-run report in dry_run.rs: filter hooks, display 'hooks/hooks.json' path",
-      "Add hooks count column to recursive report discovery table",
-      "Write emitter unit tests: verify hooks.json written correctly, verify scripts copied, verify path rewriting to absolute paths, verify manifest contains hooks component",
-      "Write dry-run unit tests: verify hooks section header appears, verify component path formatting",
-      "Run cargo build --workspace, cargo test --workspace, cargo clippy --workspace -- -D warnings"
+      "Open crates/libaipm/src/migrate/output_style_detector.rs",
+      "Add import: use super::strip_yaml_quotes; at the top of the file (with other imports)",
+      "At line 82, change: metadata.name = Some(value.trim().to_string()); to: metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());",
+      "At line 84, change: metadata.description = Some(value.trim().to_string()); to: metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());",
+      "Add a new unit test detect_output_style_strips_quoted_description in the existing #[cfg(test)] mod:",
+      "  - Create MockFs with output style .md content: ---\\nname: \"concise\"\\ndescription: \"Short outputs\"\\n---\\nBody",
+      "  - Run detect(), assert metadata.description == Some(\"Short outputs\")",
+      "Run: cargo test --workspace -- output_style_detector to verify"
     ],
     "passes": true
   },
   {
     "category": "refactor",
-    "description": "Generalize composite type detection from skill+command to 2+ distinct artifact kinds",
+    "description": "Enable serde_json preserve_order feature in workspace Cargo.toml to maintain JSON field insertion order",
     "steps": [
-      "Open crates/libaipm/src/migrate/emitter.rs and locate composite type detection logic",
-      "Replace has_skill && has_command check with distinct_kinds: HashSet collecting artifact kinds, then distinct_kinds.len() > 1",
-      "Update emit_package_plugin to use generalized composite detection",
-      "Update generate_package_manifest to use generalized composite detection for type_str",
-      "Open crates/libaipm/src/migrate/dry_run.rs and locate recursive report composite detection",
-      "Update generate_recursive_report planned plugins section to use distinct kinds count instead of has_skill && has_command",
-      "Verify root-level .claude/ still emits separate per-type plugins",
-      "Verify package-scoped .claude/ still emits one composite plugin per package",
-      "Write unit tests: verify composite detection with skill+agent, verify composite detection with hook+mcp, verify single-kind detection remains non-composite",
-      "Run cargo build --workspace, cargo test --workspace, cargo clippy --workspace -- -D warnings"
+      "Open Cargo.toml (workspace root)",
+      "At line 33, change: serde_json = \"1\" to: serde_json = { version = \"1\", features = [\"preserve_order\"] }",
+      "Run: cargo build --workspace to verify the dependency change compiles",
+      "Run: cargo test --workspace to verify no regressions"
+    ],
+    "passes": true
+  },
+  {
+    "category": "refactor",
+    "description": "Add PluginToml, PluginPackage, PluginComponents serializable structs to emitter.rs for TOML generation",
+    "steps": [
+      "Open crates/libaipm/src/migrate/emitter.rs",
+      "Add use serde::Serialize; to the imports at the top of the file",
+      "Add the following structs before the generate_plugin_manifest function (near line 830):",
+      "  - #[derive(Serialize)] struct PluginToml { package: PluginPackage, components: PluginComponents }",
+      "  - #[derive(Serialize)] struct PluginPackage { name: String, version: String, #[serde(rename = \"type\")] kind: String, edition: String, description: String }",
+      "  - #[derive(Default, Serialize)] struct PluginComponents with Optional Vec<String> fields: skills, agents, mcp_servers, hooks, output_styles, scripts — each with #[serde(skip_serializing_if = \"Option::is_none\")]",
+      "Run: cargo build --workspace to verify structs compile (no usage yet)"
+    ],
+    "passes": true
+  },
+  {
+    "category": "refactor",
+    "description": "Rewrite generate_plugin_json_multi() to use serde_json::Map and to_string_pretty() instead of format!()",
+    "steps": [
+      "Open crates/libaipm/src/migrate/emitter.rs",
+      "Locate generate_plugin_json_multi function (around line 901-931)",
+      "Replace the function body: create a serde_json::Map::new()",
+      "Insert fields in order: name, version, description (using serde_json::Value::String)",
+      "Conditionally insert component fields using the same HashSet<&ArtifactKind> logic: skills (./skills/), agents (./agents/), mcpServers (./.mcp.json), hooks (./hooks/hooks.json), outputStyles (./)",
+      "Build serde_json::Value::Object(map) and call serde_json::to_string_pretty(&obj).unwrap_or_default()",
+      "Append a trailing newline to the output string",
+      "Run: cargo test --workspace -- generate_plugin_json to verify existing tests pass",
+      "Verify the output is valid JSON by checking the generate_plugin_json_with_description and generate_plugin_json_no_description tests",
+      "Verify generate_plugin_json_multi_composite and generate_plugin_json_multi_all_kinds tests pass",
+      "Verify generate_plugin_json_agent_kind, generate_plugin_json_mcp_kind, generate_plugin_json_hook_kind, generate_plugin_json_output_style_kind tests pass"
+    ],
+    "passes": true
+  },
+  {
+    "category": "refactor",
+    "description": "Rewrite generate_plugin_manifest() to use PluginToml struct and toml::to_string_pretty() instead of format!()",
+    "steps": [
+      "Open crates/libaipm/src/migrate/emitter.rs",
+      "Locate generate_plugin_manifest function (around line 831-889)",
+      "Replace the function body: build PluginComponents::default() and populate fields based on artifact.kind match",
+      "Handle Skill|Command -> skills, Agent -> agents, McpServer -> mcp_servers, Hook -> hooks, OutputStyle -> output_styles",
+      "Handle referenced_scripts: if non-empty, strip scripts/ prefix and build scripts field",
+      "Handle hooks from frontmatter: if artifact.metadata.hooks.is_some() && kind != Hook, set hooks field",
+      "Build PluginToml { package: PluginPackage { name, version: 0.1.0, kind: type_str, edition: 2024, description }, components }",
+      "Return toml::to_string_pretty(&manifest).unwrap_or_default()",
+      "Run: cargo test --workspace -- generate_manifest to verify existing tests",
+      "Update test assertions if toml crate formatting differs from hand-built format (e.g. array formatting)",
+      "Verify generate_manifest_no_description, generate_manifest_with_scripts_and_hooks, generate_manifest_agent_kind, generate_manifest_mcp_kind, generate_manifest_hook_kind, generate_manifest_output_style_kind tests pass"
+    ],
+    "passes": true
+  },
+  {
+    "category": "refactor",
+    "description": "Rewrite generate_package_manifest() to use PluginToml struct and toml::to_string_pretty() instead of format!()",
+    "steps": [
+      "Open crates/libaipm/src/migrate/emitter.rs",
+      "Locate generate_package_manifest function (around line 578-686)",
+      "Replace the function body: keep the existing logic for grouping component_paths by type (skill_paths, agent_paths, mcp_paths, hook_paths, style_paths)",
+      "Instead of writing to a String via write!(), populate PluginComponents fields from the grouped paths",
+      "Handle all_scripts collection the same way (flat_map over artifacts' referenced_scripts)",
+      "Handle has_hooks_yaml && hook_paths.is_empty() case for hooks component",
+      "Build PluginToml { package: PluginPackage { name: plugin_name, version: 0.1.0, kind: type_str, edition: 2024, description }, components }",
+      "Return toml::to_string_pretty(&manifest).unwrap_or_default()",
+      "Run: cargo test --workspace -- emit_package_plugin to verify existing tests pass",
+      "Update test assertions if toml crate formatting differs from hand-built format"
+    ],
+    "passes": true
+  },
+  {
+    "category": "refactor",
+    "description": "Migrate workspace_init::generate_plugin_json() to use serde_json for consistency with the migrate emitter",
+    "steps": [
+      "Open crates/libaipm/src/workspace_init/mod.rs",
+      "Locate generate_plugin_json function (around line 272-279)",
+      "Replace the hand-built string with serde_json::Map construction:",
+      "  - Insert name: starter-aipm-plugin, version: 0.1.0, description: (existing description text)",
+      "  - Build serde_json::Value::Object(map), call serde_json::to_string_pretty().unwrap_or_default()",
+      "  - Append trailing newline",
+      "Run: cargo test --workspace -- workspace_init to verify existing tests pass",
+      "Run the E2E tests to verify init still produces valid plugin.json"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Add E2E integration tests for all new artifact types",
+    "description": "Update existing emitter unit tests to accommodate serde_json and toml crate output formatting differences",
     "steps": [
-      "Open crates/aipm/tests/migrate_e2e.rs and review existing E2E test patterns",
-      "Add E2E test: project with .claude/agents/ directory containing agent .md files",
-      "Add E2E test: project with .mcp.json at root containing mcpServers",
-      "Add E2E test: project with .claude/settings.json containing hooks key",
-      "Add E2E test: project with .claude/output-styles/ directory containing .md files",
-      "Add E2E test: mixed project (skills + agents + hooks + MCP) producing separate root plugins",
-      "Add E2E test: package-scoped .claude/ with multiple artifact types producing composite plugin",
-      "Add E2E test: dry-run mode shows all new artifact types with correct sections",
-      "Add E2E test: recursive discovery finds new artifact types across packages",
-      "Verify all tests pass with cargo test --workspace",
-      "Run cargo clippy --workspace -- -D warnings",
-      "Run cargo fmt --check"
+      "Open crates/libaipm/src/migrate/emitter.rs test module (starts around line 933)",
+      "Review all tests that use .contains() assertions on generated plugin.json or aipm.toml content",
+      "For plugin.json tests: serde_json::to_string_pretty uses 2-space indent — existing .contains() checks should still pass since field values are preserved",
+      "For aipm.toml tests: toml::to_string_pretty may produce different whitespace or array formatting than the hand-built format!() strings",
+      "Specifically check tests that assert contains(\"skills = [\\\"skills/deploy/SKILL.md\\\"]\") — toml crate may format as multi-line array or with different quoting",
+      "Update any failing assertions to either: (a) parse the TOML/JSON output and check values programmatically, or (b) adjust the expected string to match toml crate output",
+      "Run: cargo test --workspace to verify all existing tests pass after adjustments"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Verify branch coverage gate at 89% for all new code",
+    "description": "Add new unit tests for quoted description handling in emitter JSON and TOML generation",
     "steps": [
-      "Run cargo +nightly llvm-cov clean --workspace to reset coverage data",
-      "Run cargo +nightly llvm-cov --no-report --workspace --branch to collect test coverage",
-      "Run cargo +nightly llvm-cov --no-report --doc to collect doctest coverage",
-      "Run cargo +nightly llvm-cov report --doctests --branch --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\\.rs)' to generate report",
-      "Verify TOTAL line branch column shows >= 89%",
-      "If coverage is below 89%, identify uncovered branches in new detector/emitter/dry-run code",
-      "Add targeted tests to cover missing branches (error paths, edge cases, empty inputs)",
-      "Re-run coverage until >= 89% threshold is met",
-      "Run all four cargo gates: build, test, clippy, fmt to confirm final green state"
+      "Open crates/libaipm/src/migrate/emitter.rs test module",
+      "Add test generate_plugin_json_quoted_description: create ArtifactMetadata with description containing pre-stripped value (e.g. 'Deploy app'), generate JSON, parse with serde_json::from_str, verify description == 'Deploy app' and the JSON is valid",
+      "Add test generate_plugin_json_description_with_special_chars: description with backslash and internal quotes (e.g. 'She said \\\"hello\\\"'), generate JSON, parse it, verify it round-trips correctly",
+      "Add test generate_manifest_quoted_description: similar for TOML — create artifact with description, generate manifest, parse with toml::from_str, verify description value",
+      "Add test generate_manifest_description_with_special_chars: description with backslash/newline, generate TOML, parse it, verify round-trip",
+      "Run: cargo test --workspace -- emitter to verify"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Add E2E test for migrating a skill with quoted description and verifying valid JSON output",
+    "steps": [
+      "Open crates/aipm/tests/migrate_e2e.rs",
+      "Add test migrate_skill_with_quoted_description_produces_valid_json:",
+      "  - Create tempdir, init workspace",
+      "  - Create skill with content: ---\\nname: analyze-bug\\ndescription: \\\"Analyze bugs by reading bug reports.\\\"\\n---\\nBody",
+      "  - Run aipm migrate",
+      "  - Read the generated .ai/analyze-bug/.claude-plugin/plugin.json",
+      "  - Parse it with serde_json::from_str::<serde_json::Value>() — assert it succeeds (valid JSON)",
+      "  - Extract the description field, assert it equals 'Analyze bugs by reading bug reports.' (no extra quotes)",
+      "  - Extract the name field, assert it equals 'analyze-bug'",
+      "Run: cargo test --workspace -- migrate_skill_with_quoted_description to verify"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Run full build pipeline (build, test, clippy, fmt, coverage) to verify all changes pass with zero warnings and >= 89% branch coverage",
+    "steps": [
+      "Run: cargo fmt --check — verify no formatting issues",
+      "Run: cargo clippy --workspace -- -D warnings — verify no clippy warnings",
+      "Run: cargo build --workspace — verify clean build",
+      "Run: cargo test --workspace — verify all tests pass",
+      "Run coverage pipeline:",
+      "  - cargo +nightly llvm-cov clean --workspace",
+      "  - cargo +nightly llvm-cov --no-report --workspace --branch",
+      "  - cargo +nightly llvm-cov --no-report --doc",
+      "  - cargo +nightly llvm-cov report --doctests --branch --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\\.rs)'",
+      "Verify TOTAL branch column shows >= 89%",
+      "If coverage is below 89%, add additional tests targeting uncovered branches in the changed functions"
     ],
     "passes": true
   }

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -1,19 +1,29 @@
-All 12 features implemented and passing (2026-03-24):
+2026-03-24: Implemented all 15 features from feature-list.json
 
-1. [DONE] Extend ArtifactKind enum with Agent, McpServer, Hook, OutputStyle variants
-2. [DONE] Implement AgentDetector to scan .claude/agents/ for .md agent definitions
-3. [DONE] Implement agent emission in emitter, manifest generation, and dry-run report
-4. [DONE] Implement OutputStyleDetector to scan .claude/output-styles/ for .md files
-5. [DONE] Implement output style emission in emitter, manifest generation, and dry-run report
-6. [DONE] Implement McpDetector to read .mcp.json at project root and emit bundled MCP plugin
-7. [DONE] Implement MCP emission in emitter, manifest generation, and dry-run report
-8. [DONE] Implement HookDetector to extract hooks from .claude/settings.json
-9. [DONE] Implement hook emission with script copying and absolute path rewriting
-10. [DONE] Generalize composite type detection from skill+command to 2+ distinct artifact kinds
-11. [DONE] Add E2E integration tests for all new artifact types
-12. [DONE] Verify branch coverage gate at 89% for all new code
+Feature 1:  DONE - Added strip_yaml_quotes() helper to migrate/mod.rs with 7 unit tests
+Feature 2:  DONE - Updated skill_detector.rs to strip YAML quotes + new test
+Feature 3:  DONE - Updated agent_detector.rs to strip YAML quotes + new test
+Feature 4:  DONE - Updated command_detector.rs to strip YAML quotes + new test
+Feature 5:  DONE - Updated output_style_detector.rs to strip YAML quotes + new test
+Feature 6:  DONE - Enabled serde_json preserve_order feature in workspace Cargo.toml
+Feature 7:  DONE - Added PluginToml, PluginPackage, PluginComponents structs to emitter.rs
+Feature 8:  DONE - Rewrote generate_plugin_json_multi() to use serde_json::Map
+Feature 9:  DONE - Rewrote generate_plugin_manifest() to use PluginToml + toml::to_string_pretty()
+Feature 10: DONE - Rewrote generate_package_manifest() to use PluginToml + toml::to_string_pretty()
+Feature 11: DONE - Migrated workspace_init::generate_plugin_json() to serde_json
+Feature 12: DONE - All existing tests pass (no formatting changes needed)
+Feature 13: DONE - Added 4 new unit tests for JSON/TOML roundtrip with special chars
+Feature 14: DONE - Added E2E test for quoted description producing valid JSON
+Feature 15: DONE - Full pipeline passes:
+  - cargo fmt --check: clean
+  - cargo clippy --workspace -- -D warnings: clean
+  - cargo build --workspace: clean
+  - cargo test --workspace: 457 tests pass (0 failures)
+  - Branch coverage: 90.26% (>= 89% threshold)
 
-Final metrics:
-- 429 tests passing (0 failures)
-- Branch coverage: 89.55% (threshold: 89%)
-- All 4 cargo gates green: build, test, clippy, fmt
+Summary of changes:
+- 10 files modified
+- serde_json dependency updated to include preserve_order feature
+- 12 new tests added
+- All 457 tests pass
+- 90.26% branch coverage

--- a/specs/2026-03-24-fix-migrate-double-quotes-bug.md
+++ b/specs/2026-03-24-fix-migrate-double-quotes-bug.md
@@ -1,0 +1,495 @@
+# Fix Double-Quotes Bug in `aipm migrate` Emission
+
+| Document Metadata      | Details                    |
+| ---------------------- | -------------------------- |
+| Author(s)              | selarkin                   |
+| Status                 | Draft (WIP)                |
+| Team / Owner           | aipm                       |
+| Created / Last Updated | 2026-03-24 / 2026-03-24   |
+
+## 1. Executive Summary
+
+`aipm migrate` produces invalid `plugin.json` and `aipm.toml` files when YAML
+frontmatter descriptions contain quotes (e.g., `description: "Deploy app"`).
+The hand-built `format!()` string interpolation passes raw strings into JSON/TOML
+templates without escaping, producing `"description": ""Deploy app""`. This spec
+replaces the `format!()`-based emission with `serde_json` and `toml` crate
+serialization, and also strips YAML quotes in the frontmatter parsers to keep
+stored values clean.
+
+**Research reference:** [research/docs/2026-03-24-migrate-double-quotes-bug.md](../research/docs/2026-03-24-migrate-double-quotes-bug.md)
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+The migrate emitter in `crates/libaipm/src/migrate/emitter.rs` generates
+`plugin.json` and `aipm.toml` via `format!()` string interpolation. User-supplied
+values (name, description) are spliced into templates without any escaping:
+
+```rust
+// plugin.json (emitter.rs:927-929)
+format!(
+    "{{\n  \"name\": \"{name}\",\n  \"version\": \"0.1.0\",\n  \
+     \"description\": \"{description}\"{fields}\n}}\n"
+)
+
+// aipm.toml (emitter.rs:879-885)
+format!(
+    "[package]\nname = \"{plugin_name}\"\n...\ndescription = \"{description}\"\n..."
+)
+```
+
+The frontmatter parsers in all four detectors (`skill_detector.rs`,
+`agent_detector.rs`, `command_detector.rs`, `output_style_detector.rs`) parse
+YAML values with `strip_prefix("description:") + .trim()` but do not strip
+surrounding quotes. YAML `description: "Deploy app"` is stored as
+`"Deploy app"` (with literal quote characters).
+
+### 2.2 The Problem
+
+- **User Impact:** Migrated `plugin.json` files contain invalid JSON that will
+  fail to parse. Migrated `aipm.toml` files contain invalid TOML.
+- **Root Cause (parser):** Frontmatter parsers preserve YAML quote delimiters as
+  literal characters in the stored `description` and `name` values.
+- **Root Cause (emitter):** The emitter uses `format!()` string interpolation
+  instead of proper serialization, so any special characters (quotes, backslashes,
+  newlines) in user-provided values produce invalid output.
+- **Scope:** Both `plugin.json` and `aipm.toml` are affected. The `name` field
+  uses the same parsing pattern and has the same vulnerability.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [x] `plugin.json` output is always valid JSON, regardless of what characters
+  appear in the frontmatter description or name.
+- [x] `aipm.toml` output is always valid TOML, regardless of what characters
+  appear in the frontmatter description or name.
+- [x] YAML-quoted values in frontmatter are stored without surrounding quote
+  delimiters in `ArtifactMetadata`.
+- [x] Output format (field order, indentation) is visually comparable to the
+  current output for common cases (no regressions in readability).
+- [x] All existing tests continue to pass after the change.
+- [x] New tests cover quoted descriptions, descriptions with special characters
+  (backslashes, newlines, colons), and the `name` field with quotes.
+- [x] Branch coverage remains >= 89%.
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [x] We will NOT switch the frontmatter parsers to a full YAML library — the
+  simple line-by-line parser is adequate for the frontmatter format used.
+- [x] We will NOT change the `workspace_init` plugin.json generation — it uses
+  hardcoded string literals that cannot contain user input.
+- [x] We will NOT refactor the `registrar.rs` emission — it already uses
+  `serde_json::json!()` correctly.
+- [x] We will NOT add `Serialize` derives to `ArtifactMetadata` or `Artifact` —
+  the emitter functions build small purpose-built serializable structs internally.
+
+## 4. Proposed Solution (High-Level Design)
+
+Two complementary changes:
+
+1. **Frontmatter parsers** — Add a `strip_yaml_quotes()` helper that strips
+   matching surrounding `"..."` or `'...'` delimiters from parsed values. Apply
+   it to both `name:` and `description:` in all four detectors.
+
+2. **Emitter functions** — Replace `format!()` string interpolation with
+   `serde_json` (for `plugin.json`) and `toml` (for `aipm.toml`) serialization.
+
+### 4.1 Key Components
+
+| Component | Change | Files |
+|-----------|--------|-------|
+| YAML quote stripping | New `strip_yaml_quotes()` helper | `emitter.rs` or new shared util |
+| Frontmatter parsers | Apply `strip_yaml_quotes()` to `name:` and `description:` | `skill_detector.rs`, `agent_detector.rs`, `command_detector.rs`, `output_style_detector.rs` |
+| JSON emission | Replace `format!()` with `serde_json::json!()` + `to_string_pretty()` | `emitter.rs` (`generate_plugin_json_multi`) |
+| TOML emission | Replace `format!()` with `toml::to_string_pretty()` using `Serialize` structs | `emitter.rs` (`generate_plugin_manifest`, `generate_package_manifest`) |
+
+## 5. Detailed Design
+
+### 5.1 YAML Quote Stripping Helper
+
+Add a shared helper function. Since the frontmatter parsing is in the `migrate`
+module, place it in `emitter.rs` (already used by detectors indirectly) or in
+`mod.rs` where `ArtifactMetadata` is defined. Prefer `mod.rs` since it is
+imported by all detectors.
+
+```rust
+// In crates/libaipm/src/migrate/mod.rs
+
+/// Strip matching surrounding YAML quote delimiters from a scalar value.
+///
+/// Handles both double-quoted (`"..."`) and single-quoted (`'...'`) YAML scalars.
+/// Returns the inner content if delimiters match, otherwise returns the input unchanged.
+pub(crate) fn strip_yaml_quotes(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &s[1..s.len() - 1];
+        }
+    }
+    s
+}
+```
+
+### 5.2 Frontmatter Parser Changes
+
+In all four detectors, update `name:` and `description:` parsing to call
+`strip_yaml_quotes()`:
+
+**Before** (all four detectors):
+```rust
+if let Some(value) = trimmed_line.strip_prefix("name:") {
+    metadata.name = Some(value.trim().to_string());
+} else if let Some(value) = trimmed_line.strip_prefix("description:") {
+    metadata.description = Some(value.trim().to_string());
+}
+```
+
+**After:**
+```rust
+use super::strip_yaml_quotes;
+
+if let Some(value) = trimmed_line.strip_prefix("name:") {
+    metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());
+} else if let Some(value) = trimmed_line.strip_prefix("description:") {
+    metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());
+}
+```
+
+**Files to change:**
+- `crates/libaipm/src/migrate/skill_detector.rs:106-109`
+- `crates/libaipm/src/migrate/agent_detector.rs:87-90`
+- `crates/libaipm/src/migrate/command_detector.rs:85-88`
+- `crates/libaipm/src/migrate/output_style_detector.rs:81-84`
+
+### 5.3 JSON Emission (`generate_plugin_json_multi`)
+
+Replace the `format!()` template with `serde_json::json!()` and
+`serde_json::to_string_pretty()`.
+
+**Current** (`emitter.rs:901-931`):
+```rust
+fn generate_plugin_json_multi(
+    name: &str,
+    metadata: &ArtifactMetadata,
+    kinds: &[ArtifactKind],
+) -> String {
+    let description =
+        metadata.description.as_deref().unwrap_or("Migrated from .claude/ configuration");
+    let mut fields = String::new();
+    // ... conditionally append field strings ...
+    format!(
+        "{{\n  \"name\": \"{name}\",\n  \"version\": \"0.1.0\",\n  \
+         \"description\": \"{description}\"{fields}\n}}\n"
+    )
+}
+```
+
+**Proposed:**
+```rust
+fn generate_plugin_json_multi(
+    name: &str,
+    metadata: &ArtifactMetadata,
+    kinds: &[ArtifactKind],
+) -> String {
+    let description =
+        metadata.description.as_deref().unwrap_or("Migrated from .claude/ configuration");
+
+    // Use an ordered map to preserve deterministic field order
+    let mut map = serde_json::Map::new();
+    map.insert("name".to_string(), serde_json::Value::String(name.to_string()));
+    map.insert("version".to_string(), serde_json::Value::String("0.1.0".to_string()));
+    map.insert(
+        "description".to_string(),
+        serde_json::Value::String(description.to_string()),
+    );
+
+    let distinct: HashSet<&ArtifactKind> = kinds.iter().collect();
+    if distinct.contains(&ArtifactKind::Skill) || distinct.contains(&ArtifactKind::Command) {
+        map.insert(
+            "skills".to_string(),
+            serde_json::Value::String("./skills/".to_string()),
+        );
+    }
+    if distinct.contains(&ArtifactKind::Agent) {
+        map.insert(
+            "agents".to_string(),
+            serde_json::Value::String("./agents/".to_string()),
+        );
+    }
+    if distinct.contains(&ArtifactKind::McpServer) {
+        map.insert(
+            "mcpServers".to_string(),
+            serde_json::Value::String("./.mcp.json".to_string()),
+        );
+    }
+    if distinct.contains(&ArtifactKind::Hook) {
+        map.insert(
+            "hooks".to_string(),
+            serde_json::Value::String("./hooks/hooks.json".to_string()),
+        );
+    }
+    if distinct.contains(&ArtifactKind::OutputStyle) {
+        map.insert(
+            "outputStyles".to_string(),
+            serde_json::Value::String("./".to_string()),
+        );
+    }
+
+    let obj = serde_json::Value::Object(map);
+    // to_string_pretty uses 2-space indent by default, matching current output
+    let mut output = serde_json::to_string_pretty(&obj).unwrap_or_default();
+    output.push('\n');
+    output
+}
+```
+
+**Note on `unwrap_or_default()`:** `serde_json::to_string_pretty` can only fail
+if the value contains non-string map keys (impossible with `serde_json::Map`) or
+if a custom serializer fails (not applicable). So this call cannot actually fail.
+Using `unwrap_or_default()` avoids `unwrap()` which is denied by lint policy.
+
+**Note on field order:** `serde_json::Map` preserves insertion order (it uses
+`IndexMap` under the `preserve_order` feature, which is the default in
+serde_json). This means the output field order matches the insertion order above,
+which matches the current output. If `preserve_order` is not enabled, the output
+will be sorted alphabetically by key. Check the serde_json dependency — the
+workspace already depends on `serde_json = "1"`. We should verify that
+`preserve_order` is not needed for our case, since the current tests check for
+content presence (not exact output), and JSON consumers shouldn't depend on field
+order. If exact field order matters, add `features = ["preserve_order"]` to the
+serde_json workspace dependency.
+
+### 5.4 TOML Emission (`generate_plugin_manifest`)
+
+Replace the `format!()` template with `Serialize` structs and
+`toml::to_string_pretty()`. Define local structs within the function (or at
+module level) to model the TOML structure.
+
+**Current** (`emitter.rs:831-889`):
+```rust
+fn generate_plugin_manifest(artifact: &Artifact, plugin_name: &str) -> String {
+    // ... manual format!() string building ...
+}
+```
+
+**Proposed structs** (module-level in `emitter.rs`):
+
+```rust
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct PluginToml {
+    package: PluginPackage,
+    components: PluginComponents,
+}
+
+#[derive(Serialize)]
+struct PluginPackage {
+    name: String,
+    version: String,
+    #[serde(rename = "type")]
+    kind: String,
+    edition: String,
+    description: String,
+}
+
+#[derive(Default, Serialize)]
+struct PluginComponents {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skills: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agents: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mcp_servers: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hooks: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_styles: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scripts: Option<Vec<String>>,
+}
+```
+
+**Updated `generate_plugin_manifest`:**
+```rust
+fn generate_plugin_manifest(artifact: &Artifact, plugin_name: &str) -> String {
+    let type_str = artifact.kind.to_type_string();
+    let description =
+        artifact.metadata.description.as_deref().unwrap_or("Migrated from .claude/ configuration");
+
+    let mut components = PluginComponents::default();
+
+    match artifact.kind {
+        ArtifactKind::Skill | ArtifactKind::Command => {
+            components.skills =
+                Some(vec![format!("skills/{}/SKILL.md", artifact.name)]);
+        },
+        ArtifactKind::Agent => {
+            components.agents = Some(vec![format!("agents/{}.md", artifact.name)]);
+        },
+        ArtifactKind::McpServer => {
+            components.mcp_servers = Some(vec![".mcp.json".to_string()]);
+        },
+        ArtifactKind::Hook => {
+            components.hooks = Some(vec!["hooks/hooks.json".to_string()]);
+        },
+        ArtifactKind::OutputStyle => {
+            components.output_styles = Some(vec![format!("{}.md", artifact.name)]);
+        },
+    }
+
+    // Scripts (if any)
+    if !artifact.referenced_scripts.is_empty() {
+        let scripts_root = Path::new("scripts");
+        let scripts: Vec<String> = artifact
+            .referenced_scripts
+            .iter()
+            .map(|p| {
+                let relative = p.strip_prefix(scripts_root).unwrap_or(p);
+                format!("scripts/{}", relative.to_string_lossy())
+            })
+            .collect();
+        components.scripts = Some(scripts);
+    }
+
+    // Hooks from skill/command frontmatter
+    if artifact.metadata.hooks.is_some() && artifact.kind != ArtifactKind::Hook {
+        components.hooks = Some(vec!["hooks/hooks.json".to_string()]);
+    }
+
+    let manifest = PluginToml {
+        package: PluginPackage {
+            name: plugin_name.to_string(),
+            version: "0.1.0".to_string(),
+            kind: type_str.to_string(),
+            edition: "2024".to_string(),
+            description: description.to_string(),
+        },
+        components,
+    };
+
+    toml::to_string_pretty(&manifest).unwrap_or_default()
+}
+```
+
+**Updated `generate_package_manifest`:** Same pattern — build `PluginToml` from
+the multi-artifact parameters and serialize. The logic for grouping component
+paths by type remains the same, just filling in `PluginComponents` fields instead
+of writing strings.
+
+### 5.5 TOML Output Format Compatibility
+
+`toml::to_string_pretty()` produces slightly different formatting than the
+hand-built strings:
+- May add a blank line between `[package]` and `[components]` differently
+- Uses `\n` for arrays rather than inline `[...]` for long arrays
+
+The current inline array format (e.g., `skills = ["skills/deploy/SKILL.md"]`)
+may change to a multi-line format for longer arrays. This is acceptable — both
+are valid TOML.
+
+However, some existing tests check for exact string matches like
+`contains("skills = [\"skills/deploy/SKILL.md\"]")`. These tests may need minor
+updates to accommodate `toml` crate formatting. Alternatively, the tests can
+parse the TOML and check the values programmatically.
+
+### 5.6 `serde` Dependency
+
+The `serde` crate with `derive` is already a workspace dependency
+(`Cargo.toml:32`). The `Serialize` derive will work with the existing deny lint
+policy — serde's derive macros are explicitly permitted to emit internal
+`#[allow]` attributes per the `CLAUDE.md` lint policy.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A: Strip quotes only (no serialization change) | Minimal diff, fixes the immediate bug | Still vulnerable to backslashes, newlines, or other special characters in descriptions | Rejected: doesn't eliminate the class of bugs |
+| B: Manual JSON/TOML escaping functions | Small diff, no new structs | Reimplements what serde_json/toml already do; error-prone | Rejected: wheel reinvention |
+| C: serde_json + toml serialization (selected) | Eliminates the entire class of escaping bugs; uses battle-tested libraries already in deps | Slightly larger diff; may change output formatting | **Selected**: robust and idiomatic |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Output Format Stability
+
+Downstream tools or tests that parse `plugin.json` or `aipm.toml` by exact
+string matching may break if the formatting changes. Mitigation:
+- `serde_json::to_string_pretty` uses 2-space indentation, same as the current
+  hand-built output.
+- `toml::to_string_pretty` may differ slightly in whitespace. Tests that do exact
+  string comparisons should be updated to parse and compare values instead.
+
+### 7.2 `serde_json::Map` Field Ordering
+
+`serde_json::Map` uses `BTreeMap` by default (alphabetical order). If the
+`preserve_order` feature is enabled, it uses `IndexMap` (insertion order).
+The current output order is: `name`, `version`, `description`, then optional
+component fields. Under alphabetical ordering, `description` would appear before
+`name`. This is valid JSON but may surprise users diffing output.
+
+**Recommendation:** Check if `preserve_order` is already enabled. If not, and if
+field order matters for user experience, add it to the workspace dependency:
+```toml
+serde_json = { version = "1", features = ["preserve_order"] }
+```
+
+### 7.3 `toml` Crate TOML Struct Ordering
+
+The `toml` crate serializes struct fields in declaration order. The `PluginToml`
+struct should declare `package` before `components` to match the current output.
+Within `PluginPackage`, fields should be declared in the desired output order:
+`name`, `version`, `type`, `edition`, `description`.
+
+## 8. Implementation Plan
+
+### Phase 1: Core Fix (Single PR)
+
+- [ ] **Step 1:** Add `strip_yaml_quotes()` to `crates/libaipm/src/migrate/mod.rs`
+  with unit tests.
+- [ ] **Step 2:** Update frontmatter parsers in all four detectors to call
+  `strip_yaml_quotes()` on `name:` and `description:` values.
+- [ ] **Step 3:** Add `PluginToml`, `PluginPackage`, `PluginComponents` structs
+  with `Serialize` to `emitter.rs`.
+- [ ] **Step 4:** Rewrite `generate_plugin_json_multi()` to use `serde_json::Map`
+  and `to_string_pretty()`.
+- [ ] **Step 5:** Rewrite `generate_plugin_manifest()` to use `PluginToml` +
+  `toml::to_string_pretty()`.
+- [ ] **Step 6:** Rewrite `generate_package_manifest()` similarly.
+- [ ] **Step 7:** Update existing unit tests that assert exact string format
+  to parse the output and check values instead.
+- [ ] **Step 8:** Add new tests:
+  - Quoted YAML description: `description: "Deploy app"` → JSON `"Deploy app"`
+  - Single-quoted YAML description: `description: 'Deploy app'` → `"Deploy app"`
+  - Description with special chars: backslash, newline, colon
+  - Name with quotes: `name: "my-plugin"` → JSON `"my-plugin"`
+  - Description with internal quotes: `description: She said "hello"`
+  - E2E test: create a skill with quoted description, migrate, parse the resulting
+    `plugin.json` as valid JSON, verify the description value.
+- [ ] **Step 9:** Run full build/test/clippy/fmt/coverage pipeline.
+
+### Test Plan
+
+- **Unit Tests:** All existing `emitter.rs` unit tests updated + new tests for
+  quoted values and special characters.
+- **Unit Tests:** `strip_yaml_quotes()` tests in `mod.rs`.
+- **Unit Tests:** Each detector gets a test with `description: "quoted text"` to
+  verify quotes are stripped.
+- **Integration Tests:** Existing BDD features in `tests/features/manifest/`.
+- **E2E Tests:** New test in `migrate_e2e.rs` that creates a skill with
+  `description: "Quoted description"`, runs migrate, reads the resulting
+  `plugin.json`, and parses it with `serde_json::from_str` to verify it is valid
+  JSON with the correct unquoted description.
+
+## 9. Open Questions / Unresolved Issues
+
+- [ ] Should we enable `serde_json`'s `preserve_order` feature to maintain
+  the current field ordering in `plugin.json`? (Low stakes — JSON consumers
+  should not depend on field order, but it affects human readability of diffs.)
+- [ ] Should `workspace_init::generate_plugin_json()` also be migrated to
+  `serde_json` for consistency, even though its hardcoded strings cannot trigger
+  this bug? (Consistency vs. unnecessary churn.)


### PR DESCRIPTION
## Summary

- **Bug**: `aipm migrate` produced invalid `plugin.json` and `aipm.toml` when YAML frontmatter descriptions contained quotes (e.g., `description: "Deploy app"` → `"description": ""Deploy app""`).
- **Root cause**: Hand-built `format!()` string interpolation had no escaping, and frontmatter parsers preserved YAML quote delimiters as literal characters.
- **Fix**: Replace all `format!()`-based JSON/TOML generation with `serde_json` and `toml` crate serialization, and strip YAML quotes in frontmatter parsers.

### Changes
- Add `strip_yaml_quotes()` helper and apply to all 4 frontmatter detectors (skill, agent, command, output_style)
- Rewrite `generate_plugin_json_multi()` → `serde_json::Map` + `to_string_pretty()`
- Rewrite `generate_plugin_manifest()` and `generate_package_manifest()` → `Serialize` structs + `toml::to_string_pretty()`
- Migrate `workspace_init::generate_plugin_json()` to `serde_json` for consistency
- Enable `serde_json` `preserve_order` feature for deterministic field ordering

## Test plan

- [x] 7 unit tests for `strip_yaml_quotes()` (double, single, no quotes, mismatched, empty)
- [x] 4 detector tests verifying quoted descriptions are stripped
- [x] 4 emitter tests verifying JSON/TOML roundtrip with special characters
- [x] 1 E2E test: migrate skill with `description: "Analyze bugs..."`, parse output as valid JSON, verify no extra quotes
- [x] All 457 existing + new tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Branch coverage: 90.26% (threshold: 89%)