### PR TITLE
fix: respect --no-starter flag in settings.json enabledPlugins

### DIFF
--- a/crates/libaipm/src/workspace_init/adaptors/claude.rs
+++ b/crates/libaipm/src/workspace_init/adaptors/claude.rs
@@ -16,17 +16,28 @@ impl ToolAdaptor for Adaptor {
         "Claude Code"
     }
 
-    fn apply(&self, dir: &Path, fs: &dyn Fs) -> Result<bool, Error> {
+    fn apply(&self, dir: &Path, no_starter: bool, fs: &dyn Fs) -> Result<bool, Error> {
         let settings_dir = dir.join(".claude");
         let settings_path = settings_dir.join("settings.json");
 
         if fs.exists(&settings_path) {
-            return merge_claude_settings(&settings_path, fs);
+            return merge_claude_settings(&settings_path, no_starter, fs);
         }
 
         fs.create_dir_all(&settings_dir)?;
-        crate::workspace_init::write_file(
-            &settings_path,
+
+        let content = if no_starter {
+            "{\n\
+             \x20 \"extraKnownMarketplaces\": {\n\
+             \x20   \"local-repo-plugins\": {\n\
+             \x20     \"source\": {\n\
+             \x20       \"source\": \"directory\",\n\
+             \x20       \"path\": \"./.ai\"\n\
+             \x20     }\n\
+             \x20   }\n\
+             \x20 }\n\
+             }\n"
+        } else {
             "{\n\
              \x20 \"extraKnownMarketplaces\": {\n\
              \x20   \"local-repo-plugins\": {\n\
@@ -39,14 +50,19 @@ impl ToolAdaptor for Adaptor {
              \x20 \"enabledPlugins\": {\n\
              \x20   \"starter-aipm-plugin@local-repo-plugins\": true\n\
              \x20 }\n\
-             }\n",
-            fs,
-        )?;
+             }\n"
+        };
+
+        crate::workspace_init::write_file(&settings_path, content, fs)?;
         Ok(true)
     }
 }
 
-fn merge_claude_settings(settings_path: &Path, fs: &dyn Fs) -> Result<bool, Error> {
+fn merge_claude_settings(
+    settings_path: &Path,
+    no_starter: bool,
+    fs: &dyn Fs,
+) -> Result<bool, Error> {
     let content = fs.read_to_string(settings_path)?;
     let mut json: serde_json::Value = serde_json::from_str(&content)
         .map_err(|source| Error::JsonParse { path: settings_path.to_path_buf(), source })?;
@@ -59,15 +75,23 @@ fn merge_claude_settings(settings_path: &Path, fs: &dyn Fs) -> Result<bool, Erro
         )),
     })?;
 
-    // Check if both marketplace and enabledPlugins are already correctly configured
+    // Check if already correctly configured
     let has_marketplace =
         obj.get("extraKnownMarketplaces").and_then(|ekm| ekm.get("local-repo-plugins")).is_some();
-    let has_enabled = obj
-        .get("enabledPlugins")
-        .and_then(|ep| ep.as_object())
-        .is_some_and(|ep| ep.contains_key("starter-aipm-plugin@local-repo-plugins"));
-    if has_marketplace && has_enabled {
-        return Ok(false);
+
+    if no_starter {
+        // When no_starter, we only need the marketplace entry
+        if has_marketplace {
+            return Ok(false);
+        }
+    } else {
+        let has_enabled = obj
+            .get("enabledPlugins")
+            .and_then(|ep| ep.as_object())
+            .is_some_and(|ep| ep.contains_key("starter-aipm-plugin@local-repo-plugins"));
+        if has_marketplace && has_enabled {
+            return Ok(false);
+        }
     }
 
     // Ensure marketplace entry exists
@@ -89,12 +113,14 @@ fn merge_claude_settings(settings_path: &Path, fs: &dyn Fs) -> Result<bool, Erro
         );
     }
 
-    // Add enabledPlugins at the top level (sibling of extraKnownMarketplaces)
-    let enabled = obj.entry("enabledPlugins").or_insert_with(|| serde_json::json!({}));
-    if let Some(enabled_obj) = enabled.as_object_mut() {
-        enabled_obj
-            .entry("starter-aipm-plugin@local-repo-plugins")
-            .or_insert(serde_json::json!(true));
+    // Add enabledPlugins only when starter plugin is requested
+    if !no_starter {
+        let enabled = obj.entry("enabledPlugins").or_insert_with(|| serde_json::json!({}));
+        if let Some(enabled_obj) = enabled.as_object_mut() {
+            enabled_obj
+                .entry("starter-aipm-plugin@local-repo-plugins")
+                .or_insert(serde_json::json!(true));
+        }
     }
 
     let mut output = serde_json::to_string_pretty(&json)
@@ -127,7 +153,7 @@ mod tests {
     fn claude_settings_created_fresh() {
         let tmp = make_temp_dir("fresh");
         let adaptor = Adaptor;
-        let result = adaptor.apply(&tmp, &Real);
+        let result = adaptor.apply(&tmp, false, &Real);
         assert!(result.is_ok_and(|v| v));
         assert!(tmp.join(".claude/settings.json").exists());
 
@@ -148,6 +174,32 @@ mod tests {
     }
 
     #[test]
+    fn claude_settings_created_fresh_no_starter() {
+        let tmp = make_temp_dir("fresh-no-starter");
+        let adaptor = Adaptor;
+        let result = adaptor.apply(&tmp, true, &Real);
+        assert!(result.is_ok_and(|v| v));
+        assert!(tmp.join(".claude/settings.json").exists());
+
+        let content = std::fs::read_to_string(tmp.join(".claude/settings.json"));
+        assert!(content.is_ok());
+        let v: serde_json::Value =
+            serde_json::from_str(content.as_deref().unwrap_or("")).ok().unwrap_or_default();
+
+        // extraKnownMarketplaces should still be present
+        assert!(v["extraKnownMarketplaces"]["local-repo-plugins"].is_object());
+        assert_eq!(v["extraKnownMarketplaces"]["local-repo-plugins"]["source"]["path"], "./.ai");
+
+        // enabledPlugins should NOT exist when no_starter is true
+        assert!(
+            v.get("enabledPlugins").is_none(),
+            "enabledPlugins should not exist when no_starter is true"
+        );
+
+        cleanup(&tmp);
+    }
+
+    #[test]
     fn claude_settings_merge_existing() {
         let tmp = make_temp_dir("merge");
         std::fs::create_dir_all(tmp.join(".claude")).ok();
@@ -158,7 +210,7 @@ mod tests {
         .ok();
 
         let adaptor = Adaptor;
-        let result = adaptor.apply(&tmp, &Real);
+        let result = adaptor.apply(&tmp, false, &Real);
         assert!(result.is_ok_and(|v| v));
 
         let content = std::fs::read_to_string(tmp.join(".claude/settings.json"));
@@ -187,7 +239,7 @@ mod tests {
         ).ok();
 
         let adaptor = Adaptor;
-        let result = adaptor.apply(&tmp, &Real);
+        let result = adaptor.apply(&tmp, false, &Real);
         assert!(result.is_ok_and(|v| !v));
 
         cleanup(&tmp);
@@ -203,7 +255,7 @@ mod tests {
         ).ok();
 
         let adaptor = Adaptor;
-        let result = adaptor.apply(&tmp, &Real);
+        let result = adaptor.apply(&tmp, false, &Real);
         assert!(result.is_ok_and(|v| v));
 
         let content = std::fs::read_to_string(tmp.join(".claude/settings.json"));
@@ -222,7 +274,7 @@ mod tests {
         std::fs::write(tmp.join(".claude/settings.json"), "{{invalid json").ok();
 
         let adaptor = Adaptor;
-        let result = adaptor.apply(&tmp, &Real);
+        let result = adaptor.apply(&tmp, false, &Real);
         assert!(result.is_err());
         let err = result.err();
         assert!(err.is_some_and(|e| e.to_string().contains("JSON parse")));
@@ -237,7 +289,7 @@ mod tests {
         std::fs::write(tmp.join(".claude/settings.json"), "[1, 2, 3]").ok();
 
         let adaptor = Adaptor;
-        let result = adaptor.apply(&tmp, &Real);
+        let result = adaptor.apply(&tmp, false, &Real);
         assert!(result.is_err());
         let err = result.err();
         assert!(err.is_some_and(|e| e.to_string().contains("expected JSON object")));
@@ -252,7 +304,7 @@ mod tests {
         std::fs::write(tmp.join(".claude/settings.json"), r#"{"extraKnownMarketplaces": 42}"#).ok();
 
         let adaptor = Adaptor;
-        let result = adaptor.apply(&tmp, &Real);
+        let result = adaptor.apply(&tmp, false, &Real);
         // Should succeed — silently skips non-object mutation, still writes enabledPlugins
         assert!(result.is_ok());
 
@@ -267,7 +319,7 @@ mod tests {
             .ok();
 
         let adaptor = Adaptor;
-        let result = adaptor.apply(&tmp, &Real);
+        let result = adaptor.apply(&tmp, false, &Real);
         // Should succeed — skips non-object enabledPlugins, still writes marketplace
         assert!(result.is_ok());
 

--- a/crates/libaipm/src/workspace_init/mod.rs
+++ b/crates/libaipm/src/workspace_init/mod.rs
@@ -20,13 +20,17 @@ pub trait ToolAdaptor {
 
     /// Apply tool-specific settings to the workspace directory.
     ///
+    /// When `no_starter` is `true`, adaptors should skip enabling the starter
+    /// plugin (e.g., omit `enabledPlugins` entries) while still registering the
+    /// marketplace directory.
+    ///
     /// Returns `true` if files were written or modified, `false` if the tool
     /// was already configured and no changes were needed.
     ///
     /// # Errors
     ///
     /// Returns `Error` if I/O operations fail or existing config files cannot be parsed.
-    fn apply(&self, dir: &Path, fs: &dyn Fs) -> Result<bool, Error>;
+    fn apply(&self, dir: &Path, no_starter: bool, fs: &dyn Fs) -> Result<bool, Error>;
 }
 
 /// Options for workspace initialization.
@@ -114,7 +118,7 @@ pub fn init(
         actions.push(InitAction::MarketplaceCreated);
 
         for adaptor in adaptors {
-            if adaptor.apply(opts.dir, fs)? {
+            if adaptor.apply(opts.dir, opts.no_starter, fs)? {
                 actions.push(InitAction::ToolConfigured(adaptor.name().to_string()));
             }
         }
@@ -972,6 +976,23 @@ mod tests {
         assert!(tmp.join(".claude/settings.json").exists());
         // But no starter plugin
         assert!(!tmp.join(".ai/starter-aipm-plugin").exists());
+
+        // settings.json should have marketplace but NOT enabledPlugins with starter
+        let content =
+            std::fs::read_to_string(tmp.join(".claude/settings.json")).unwrap_or_default();
+        let v: serde_json::Value = serde_json::from_str(&content).ok().unwrap_or_default();
+        assert!(
+            v["extraKnownMarketplaces"]["local-repo-plugins"].is_object(),
+            "marketplace should still be registered"
+        );
+        let has_starter = v
+            .get("enabledPlugins")
+            .and_then(|ep| ep.as_object())
+            .is_some_and(|ep| ep.contains_key("starter-aipm-plugin@local-repo-plugins"));
+        assert!(
+            !has_starter,
+            "enabledPlugins should not reference starter plugin when no_starter is true"
+        );
 
         cleanup(&tmp);
     }

--- a/research/docs/2026-03-24-no-starter-enabledplugins-bug.md
+++ b/research/docs/2026-03-24-no-starter-enabledplugins-bug.md
@@ -1,0 +1,166 @@
+---
+date: 2026-03-24
+researcher: Claude
+git_commit: 00528c9368cc90b1c121c9e349f4d89ca8073c03
+branch: main
+repository: aipm
+topic: "Bug: no_starter flag not forwarded to Claude Code adaptor — settings.json unconditionally enables starter plugin"
+tags: [research, bug, init, wizard, settings-json, adaptor, no-starter]
+status: complete
+last_updated: 2026-03-24
+last_updated_by: Claude
+---
+
+# Research: `no_starter` Flag Not Forwarded to Claude Code Adaptor
+
+## Research Question
+
+When running `aipm init` interactively and choosing "No" for the starter plugin,
+why does `.claude/settings.json` still contain
+`"starter-aipm-plugin@local-repo-plugins": true` in `enabledPlugins`?
+
+## Summary
+
+The `no_starter` flag flows correctly from the wizard through `Options` to
+`scaffold_marketplace()`, which properly skips creating the starter plugin
+directory and generates an empty `plugins` array in `marketplace.json`. However,
+the `ToolAdaptor::apply()` trait method has no parameter for `no_starter`, so the
+Claude Code adaptor unconditionally writes `enabledPlugins` with the starter
+plugin entry in both the fresh-write and merge code paths.
+
+## Detailed Findings
+
+### 1. The `ToolAdaptor` Trait — No `no_starter` Parameter
+
+The trait at [`mod.rs:17-30`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L17-L30)
+defines:
+
+```rust
+pub trait ToolAdaptor {
+    fn name(&self) -> &'static str;
+    fn apply(&self, dir: &Path, fs: &dyn Fs) -> Result<bool, Error>;
+}
+```
+
+The `apply` method takes only `dir` and `fs`. There is no mechanism to pass
+`no_starter` or any `Options` to adaptors.
+
+### 2. The `init()` Function — `no_starter` Passed to Scaffold but Not Adaptors
+
+At [`mod.rs:100-124`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L100-L124):
+
+```rust
+if opts.marketplace {
+    scaffold_marketplace(opts.dir, opts.no_starter, opts.manifest, fs)?;  // line 113 ✓
+    // ...
+    for adaptor in adaptors {
+        if adaptor.apply(opts.dir, fs)? {  // line 117 — no_starter NOT passed ✗
+            // ...
+        }
+    }
+}
+```
+
+`opts.no_starter` is available at the call site (used one line above at line 113)
+but never forwarded to the adaptor loop.
+
+### 3. `scaffold_marketplace()` — Correctly Respects `no_starter`
+
+At [`mod.rs:173-250`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L173-L250):
+
+- Line 199: `generate_marketplace_json(no_starter)` produces an empty `plugins`
+  array when `no_starter` is true.
+- Lines 202-204: Early return skips the entire starter plugin directory tree.
+
+### 4. Claude Code Adaptor — Unconditionally Enables Starter Plugin
+
+#### Fresh-write path
+
+At [`claude.rs:27-45`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/adaptors/claude.rs#L27-L45),
+the hardcoded JSON string at lines 39-41 includes:
+
+```json
+"enabledPlugins": {
+    "starter-aipm-plugin@local-repo-plugins": true
+}
+```
+
+#### Merge path
+
+At [`claude.rs:93-98`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/adaptors/claude.rs#L93-L98),
+`merge_claude_settings()` unconditionally inserts
+`"starter-aipm-plugin@local-repo-plugins": true` via `or_insert`.
+
+Neither path consults any `no_starter` flag.
+
+### 5. Data Flow Diagram
+
+```
+CLI --no-starter / Wizard "No"
+       │
+       ▼
+  Options { no_starter: true }
+       │
+       ├──► scaffold_marketplace(no_starter=true)   ✓ respects flag
+       │        ├─ marketplace.json: plugins = []   ✓
+       │        └─ early return, no starter dir     ✓
+       │
+       └──► adaptor.apply(dir, fs)                  ✗ no_starter not passed
+                └─ claude.rs writes settings.json
+                   with enabledPlugins:
+                   "starter-aipm-plugin@local-repo-plugins": true  ✗
+```
+
+### 6. Test Coverage
+
+The test `init_no_starter_still_configures_tools` at
+[`mod.rs:958-977`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L958-L977)
+verifies that with `no_starter: true`, `.claude/settings.json` is still created
+and the starter plugin directory is absent. However, the test does not inspect the
+*contents* of `settings.json` to verify that `enabledPlugins` omits the starter
+plugin entry.
+
+## Code References
+
+- [`crates/libaipm/src/workspace_init/mod.rs:17-30`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L17-L30) — `ToolAdaptor` trait definition
+- [`crates/libaipm/src/workspace_init/mod.rs:33-44`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L33-L44) — `Options` struct with `no_starter` field
+- [`crates/libaipm/src/workspace_init/mod.rs:100-124`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L100-L124) — `init()` function; adaptor loop at line 117
+- [`crates/libaipm/src/workspace_init/mod.rs:173-250`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L173-L250) — `scaffold_marketplace()` with `no_starter` early return
+- [`crates/libaipm/src/workspace_init/mod.rs:452-484`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L452-L484) — `generate_marketplace_json()` conditional on `no_starter`
+- [`crates/libaipm/src/workspace_init/adaptors/claude.rs:19-46`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/adaptors/claude.rs#L19-L46) — `apply()` with hardcoded `enabledPlugins` at lines 39-41
+- [`crates/libaipm/src/workspace_init/adaptors/claude.rs:49-106`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/adaptors/claude.rs#L49-L106) — `merge_claude_settings()` unconditional insert at lines 93-98
+- [`crates/libaipm/src/workspace_init/adaptors/mod.rs:13-15`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/adaptors/mod.rs#L13-L15) — adaptor registry
+- [`crates/libaipm/src/workspace_init/mod.rs:958-977`](https://github.com/TheLarkInn/aipm/blob/00528c9368cc90b1c121c9e349f4d89ca8073c03/crates/libaipm/src/workspace_init/mod.rs#L958-L977) — test that doesn't check `enabledPlugins` content
+
+## Architecture Documentation
+
+The init pipeline uses a two-phase design:
+1. **Scaffolding** — `scaffold_marketplace()` creates the `.ai/` directory
+   structure, receiving `no_starter` directly.
+2. **Tool configuration** — The adaptor loop configures tool-specific files
+   (e.g., `.claude/settings.json`) via the `ToolAdaptor` trait, which has no
+   access to init options.
+
+The disconnect is at the boundary between these two phases: the `ToolAdaptor`
+trait was designed to only need `dir` and `fs`, but the `enabledPlugins` logic
+in the Claude adaptor depends on whether the starter plugin was created.
+
+## Where `no_starter` Does and Does Not Flow
+
+| Location | `no_starter` consulted? |
+|---|---|
+| `scaffold_marketplace()` — `marketplace.json` content | Yes (line 199) |
+| `scaffold_marketplace()` — early return before starter dir | Yes (line 202) |
+| `init()` — adaptor loop execution | No (line 116-120) |
+| `ToolAdaptor::apply()` trait signature | No parameter exists (line 29) |
+| `claude::Adaptor::apply()` — fresh `settings.json` | No (lines 28-44) |
+| `merge_claude_settings()` — merge path | No (lines 93-98) |
+
+## Open Questions
+
+1. Should the `ToolAdaptor::apply()` signature be extended to accept `&Options`
+   (or at minimum `no_starter: bool`)?
+2. Should the adaptor skip `enabledPlugins` entirely when `no_starter` is true,
+   or should it write an empty `enabledPlugins` object?
+3. Should the existing test `init_no_starter_still_configures_tools` be updated
+   to assert that `enabledPlugins` does NOT contain the starter plugin entry?

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -1,219 +1,88 @@
 [
   {
     "category": "refactor",
-    "description": "Add strip_yaml_quotes() helper to migrate/mod.rs for stripping YAML quote delimiters from parsed frontmatter values",
-    "steps": [
-      "Open crates/libaipm/src/migrate/mod.rs",
-      "Add a pub(crate) fn strip_yaml_quotes(s: &str) -> &str function after the ArtifactMetadata struct definition (after line 65)",
-      "The function checks if the input has length >= 2 and starts/ends with matching \" or ' characters",
-      "If matching quotes found, return the inner slice &s[1..s.len()-1]; otherwise return s unchanged",
-      "Add unit tests in the existing #[cfg(test)] mod tests block in mod.rs:",
-      "  - strip_yaml_quotes_double: assert_eq!(strip_yaml_quotes(r#\"\"hello\"\"#), \"hello\")",
-      "  - strip_yaml_quotes_single: assert_eq!(strip_yaml_quotes(\"'hello'\"), \"hello\")",
-      "  - strip_yaml_quotes_no_quotes: assert_eq!(strip_yaml_quotes(\"hello\"), \"hello\")",
-      "  - strip_yaml_quotes_mismatched: assert_eq!(strip_yaml_quotes(\"\\\"hello'\"), \"\\\"hello'\")",
-      "  - strip_yaml_quotes_empty_quoted: assert_eq!(strip_yaml_quotes(\"\\\"\\\"\"), \"\")",
-      "  - strip_yaml_quotes_single_char: assert_eq!(strip_yaml_quotes(\"x\"), \"x\")",
-      "  - strip_yaml_quotes_empty: assert_eq!(strip_yaml_quotes(\"\"), \"\")",
-      "Run: cargo test --workspace -- strip_yaml_quotes to verify"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Update skill_detector.rs frontmatter parser to strip YAML quotes from name and description values",
-    "steps": [
-      "Open crates/libaipm/src/migrate/skill_detector.rs",
-      "Add import: use super::strip_yaml_quotes; at the top of the file (with other imports)",
-      "At line 107, change: metadata.name = Some(value.trim().to_string()); to: metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());",
-      "At line 109, change: metadata.description = Some(value.trim().to_string()); to: metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());",
-      "Add a new unit test detect_skill_strips_quoted_description in the existing #[cfg(test)] mod:",
-      "  - Create MockFs with SKILL.md content: ---\\nname: \"my-deploy\"\\ndescription: \"Deploy app\"\\n---\\nBody",
-      "  - Run detect(), assert metadata.name == Some(\"my-deploy\") (no quotes)",
-      "  - Assert metadata.description == Some(\"Deploy app\") (no quotes)",
-      "Run: cargo test --workspace -- skill_detector to verify"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Update agent_detector.rs frontmatter parser to strip YAML quotes from name and description values",
-    "steps": [
-      "Open crates/libaipm/src/migrate/agent_detector.rs",
-      "Add import: use super::strip_yaml_quotes; at the top of the file (with other imports)",
-      "At line 88, change: metadata.name = Some(value.trim().to_string()); to: metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());",
-      "At line 90, change: metadata.description = Some(value.trim().to_string()); to: metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());",
-      "Add a new unit test detect_agent_strips_quoted_description in the existing #[cfg(test)] mod:",
-      "  - Create MockFs with agent .md content: ---\\nname: \"reviewer\"\\ndescription: \"Reviews code\"\\n---\\nBody",
-      "  - Run detect(), assert metadata.name == Some(\"reviewer\") and metadata.description == Some(\"Reviews code\")",
-      "Run: cargo test --workspace -- agent_detector to verify"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Update command_detector.rs frontmatter parser to strip YAML quotes from name and description values",
-    "steps": [
-      "Open crates/libaipm/src/migrate/command_detector.rs",
-      "Add import: use super::strip_yaml_quotes; at the top of the file (with other imports)",
-      "At line 86, change: metadata.name = Some(value.trim().to_string()); to: metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());",
-      "At line 88, change: metadata.description = Some(value.trim().to_string()); to: metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());",
-      "Add a new unit test detect_command_strips_quoted_description in the existing #[cfg(test)] mod:",
-      "  - Create MockFs with command .md content: ---\\nname: \"review\"\\ndescription: \"Code review\"\\n---\\nBody",
-      "  - Run detect(), assert metadata.description == Some(\"Code review\")",
-      "Run: cargo test --workspace -- command_detector to verify"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Update output_style_detector.rs frontmatter parser to strip YAML quotes from name and description values",
-    "steps": [
-      "Open crates/libaipm/src/migrate/output_style_detector.rs",
-      "Add import: use super::strip_yaml_quotes; at the top of the file (with other imports)",
-      "At line 82, change: metadata.name = Some(value.trim().to_string()); to: metadata.name = Some(strip_yaml_quotes(value.trim()).to_string());",
-      "At line 84, change: metadata.description = Some(value.trim().to_string()); to: metadata.description = Some(strip_yaml_quotes(value.trim()).to_string());",
-      "Add a new unit test detect_output_style_strips_quoted_description in the existing #[cfg(test)] mod:",
-      "  - Create MockFs with output style .md content: ---\\nname: \"concise\"\\ndescription: \"Short outputs\"\\n---\\nBody",
-      "  - Run detect(), assert metadata.description == Some(\"Short outputs\")",
-      "Run: cargo test --workspace -- output_style_detector to verify"
-    ],
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Enable serde_json preserve_order feature in workspace Cargo.toml to maintain JSON field insertion order",
-    "steps": [
-      "Open Cargo.toml (workspace root)",
-      "At line 33, change: serde_json = \"1\" to: serde_json = { version = \"1\", features = [\"preserve_order\"] }",
-      "Run: cargo build --workspace to verify the dependency change compiles",
-      "Run: cargo test --workspace to verify no regressions"
-    ],
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Add PluginToml, PluginPackage, PluginComponents serializable structs to emitter.rs for TOML generation",
-    "steps": [
-      "Open crates/libaipm/src/migrate/emitter.rs",
-      "Add use serde::Serialize; to the imports at the top of the file",
-      "Add the following structs before the generate_plugin_manifest function (near line 830):",
-      "  - #[derive(Serialize)] struct PluginToml { package: PluginPackage, components: PluginComponents }",
-      "  - #[derive(Serialize)] struct PluginPackage { name: String, version: String, #[serde(rename = \"type\")] kind: String, edition: String, description: String }",
-      "  - #[derive(Default, Serialize)] struct PluginComponents with Optional Vec<String> fields: skills, agents, mcp_servers, hooks, output_styles, scripts — each with #[serde(skip_serializing_if = \"Option::is_none\")]",
-      "Run: cargo build --workspace to verify structs compile (no usage yet)"
-    ],
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Rewrite generate_plugin_json_multi() to use serde_json::Map and to_string_pretty() instead of format!()",
-    "steps": [
-      "Open crates/libaipm/src/migrate/emitter.rs",
-      "Locate generate_plugin_json_multi function (around line 901-931)",
-      "Replace the function body: create a serde_json::Map::new()",
-      "Insert fields in order: name, version, description (using serde_json::Value::String)",
-      "Conditionally insert component fields using the same HashSet<&ArtifactKind> logic: skills (./skills/), agents (./agents/), mcpServers (./.mcp.json), hooks (./hooks/hooks.json), outputStyles (./)",
-      "Build serde_json::Value::Object(map) and call serde_json::to_string_pretty(&obj).unwrap_or_default()",
-      "Append a trailing newline to the output string",
-      "Run: cargo test --workspace -- generate_plugin_json to verify existing tests pass",
-      "Verify the output is valid JSON by checking the generate_plugin_json_with_description and generate_plugin_json_no_description tests",
-      "Verify generate_plugin_json_multi_composite and generate_plugin_json_multi_all_kinds tests pass",
-      "Verify generate_plugin_json_agent_kind, generate_plugin_json_mcp_kind, generate_plugin_json_hook_kind, generate_plugin_json_output_style_kind tests pass"
-    ],
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Rewrite generate_plugin_manifest() to use PluginToml struct and toml::to_string_pretty() instead of format!()",
-    "steps": [
-      "Open crates/libaipm/src/migrate/emitter.rs",
-      "Locate generate_plugin_manifest function (around line 831-889)",
-      "Replace the function body: build PluginComponents::default() and populate fields based on artifact.kind match",
-      "Handle Skill|Command -> skills, Agent -> agents, McpServer -> mcp_servers, Hook -> hooks, OutputStyle -> output_styles",
-      "Handle referenced_scripts: if non-empty, strip scripts/ prefix and build scripts field",
-      "Handle hooks from frontmatter: if artifact.metadata.hooks.is_some() && kind != Hook, set hooks field",
-      "Build PluginToml { package: PluginPackage { name, version: 0.1.0, kind: type_str, edition: 2024, description }, components }",
-      "Return toml::to_string_pretty(&manifest).unwrap_or_default()",
-      "Run: cargo test --workspace -- generate_manifest to verify existing tests",
-      "Update test assertions if toml crate formatting differs from hand-built format (e.g. array formatting)",
-      "Verify generate_manifest_no_description, generate_manifest_with_scripts_and_hooks, generate_manifest_agent_kind, generate_manifest_mcp_kind, generate_manifest_hook_kind, generate_manifest_output_style_kind tests pass"
-    ],
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Rewrite generate_package_manifest() to use PluginToml struct and toml::to_string_pretty() instead of format!()",
-    "steps": [
-      "Open crates/libaipm/src/migrate/emitter.rs",
-      "Locate generate_package_manifest function (around line 578-686)",
-      "Replace the function body: keep the existing logic for grouping component_paths by type (skill_paths, agent_paths, mcp_paths, hook_paths, style_paths)",
-      "Instead of writing to a String via write!(), populate PluginComponents fields from the grouped paths",
-      "Handle all_scripts collection the same way (flat_map over artifacts' referenced_scripts)",
-      "Handle has_hooks_yaml && hook_paths.is_empty() case for hooks component",
-      "Build PluginToml { package: PluginPackage { name: plugin_name, version: 0.1.0, kind: type_str, edition: 2024, description }, components }",
-      "Return toml::to_string_pretty(&manifest).unwrap_or_default()",
-      "Run: cargo test --workspace -- emit_package_plugin to verify existing tests pass",
-      "Update test assertions if toml crate formatting differs from hand-built format"
-    ],
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Migrate workspace_init::generate_plugin_json() to use serde_json for consistency with the migrate emitter",
+    "description": "Update ToolAdaptor::apply() trait signature to accept no_starter: bool parameter",
     "steps": [
       "Open crates/libaipm/src/workspace_init/mod.rs",
-      "Locate generate_plugin_json function (around line 272-279)",
-      "Replace the hand-built string with serde_json::Map construction:",
-      "  - Insert name: starter-aipm-plugin, version: 0.1.0, description: (existing description text)",
-      "  - Build serde_json::Value::Object(map), call serde_json::to_string_pretty().unwrap_or_default()",
-      "  - Append trailing newline",
-      "Run: cargo test --workspace -- workspace_init to verify existing tests pass",
-      "Run the E2E tests to verify init still produces valid plugin.json"
+      "At line 29, change: fn apply(&self, dir: &Path, fs: &dyn Fs) -> Result<bool, Error>; to: fn apply(&self, dir: &Path, no_starter: bool, fs: &dyn Fs) -> Result<bool, Error>;",
+      "Update the doc comment on apply() to document the no_starter parameter",
+      "At line 117 in init(), change: if adaptor.apply(opts.dir, fs)? { to: if adaptor.apply(opts.dir, opts.no_starter, fs)? {",
+      "Run: cargo build --workspace to verify the trait change compiles (expect errors in claude.rs until next feature)"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Update existing emitter unit tests to accommodate serde_json and toml crate output formatting differences",
+    "description": "Update claude::Adaptor::apply() fresh-write path to conditionally omit enabledPlugins when no_starter is true",
     "steps": [
-      "Open crates/libaipm/src/migrate/emitter.rs test module (starts around line 933)",
-      "Review all tests that use .contains() assertions on generated plugin.json or aipm.toml content",
-      "For plugin.json tests: serde_json::to_string_pretty uses 2-space indent — existing .contains() checks should still pass since field values are preserved",
-      "For aipm.toml tests: toml::to_string_pretty may produce different whitespace or array formatting than the hand-built format!() strings",
-      "Specifically check tests that assert contains(\"skills = [\\\"skills/deploy/SKILL.md\\\"]\") — toml crate may format as multi-line array or with different quoting",
-      "Update any failing assertions to either: (a) parse the TOML/JSON output and check values programmatically, or (b) adjust the expected string to match toml crate output",
-      "Run: cargo test --workspace to verify all existing tests pass after adjustments"
+      "Open crates/libaipm/src/workspace_init/adaptors/claude.rs",
+      "At line 19, change apply signature: fn apply(&self, dir: &Path, fs: &dyn Fs) to: fn apply(&self, dir: &Path, no_starter: bool, fs: &dyn Fs)",
+      "For the fresh-write path (lines 27-44): when no_starter is true, write the JSON string WITHOUT the enabledPlugins block (only extraKnownMarketplaces)",
+      "When no_starter is false, write the existing JSON string WITH enabledPlugins (unchanged behavior)",
+      "Simplest approach: use an if/else with two string variants — one with enabledPlugins, one without",
+      "Run: cargo build --workspace to verify compilation"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Add new unit tests for quoted description handling in emitter JSON and TOML generation",
+    "description": "Update merge_claude_settings() to accept no_starter and skip enabledPlugins insertion when true",
     "steps": [
-      "Open crates/libaipm/src/migrate/emitter.rs test module",
-      "Add test generate_plugin_json_quoted_description: create ArtifactMetadata with description containing pre-stripped value (e.g. 'Deploy app'), generate JSON, parse with serde_json::from_str, verify description == 'Deploy app' and the JSON is valid",
-      "Add test generate_plugin_json_description_with_special_chars: description with backslash and internal quotes (e.g. 'She said \\\"hello\\\"'), generate JSON, parse it, verify it round-trips correctly",
-      "Add test generate_manifest_quoted_description: similar for TOML — create artifact with description, generate manifest, parse with toml::from_str, verify description value",
-      "Add test generate_manifest_description_with_special_chars: description with backslash/newline, generate TOML, parse it, verify round-trip",
-      "Run: cargo test --workspace -- emitter to verify"
+      "Open crates/libaipm/src/workspace_init/adaptors/claude.rs",
+      "At line 49, change merge_claude_settings signature to add no_starter: bool parameter: fn merge_claude_settings(settings_path: &Path, no_starter: bool, fs: &dyn Fs)",
+      "At line 24, update the call site: return merge_claude_settings(&settings_path, no_starter, fs);",
+      "Update the early-return 'fully configured' check at lines 62-71: when no_starter is true, only check has_marketplace (skip has_enabled check). When no_starter is false, keep existing logic (check both has_marketplace && has_enabled)",
+      "Wrap the enabledPlugins insertion block at lines 92-98 in: if !no_starter { ... }",
+      "Run: cargo build --workspace to verify compilation",
+      "Run: cargo test --workspace to see which tests need updating"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Add E2E test for migrating a skill with quoted description and verifying valid JSON output",
+    "description": "Update all existing claude.rs tests to pass no_starter argument to apply()",
     "steps": [
-      "Open crates/aipm/tests/migrate_e2e.rs",
-      "Add test migrate_skill_with_quoted_description_produces_valid_json:",
-      "  - Create tempdir, init workspace",
-      "  - Create skill with content: ---\\nname: analyze-bug\\ndescription: \\\"Analyze bugs by reading bug reports.\\\"\\n---\\nBody",
-      "  - Run aipm migrate",
-      "  - Read the generated .ai/analyze-bug/.claude-plugin/plugin.json",
-      "  - Parse it with serde_json::from_str::<serde_json::Value>() — assert it succeeds (valid JSON)",
-      "  - Extract the description field, assert it equals 'Analyze bugs by reading bug reports.' (no extra quotes)",
-      "  - Extract the name field, assert it equals 'analyze-bug'",
-      "Run: cargo test --workspace -- migrate_skill_with_quoted_description to verify"
+      "Open crates/libaipm/src/workspace_init/adaptors/claude.rs test module (line 108+)",
+      "In claude_settings_created_fresh (line 130): change adaptor.apply(&tmp, &Real) to adaptor.apply(&tmp, false, &Real)",
+      "In claude_settings_merge_existing (line 161): change adaptor.apply(&tmp, &Real) to adaptor.apply(&tmp, false, &Real)",
+      "In claude_settings_skip_if_fully_configured (line 190): change adaptor.apply(&tmp, &Real) to adaptor.apply(&tmp, false, &Real)",
+      "In claude_settings_adds_enabled_plugins_when_marketplace_exists (line 206): change adaptor.apply(&tmp, &Real) to adaptor.apply(&tmp, false, &Real)",
+      "In claude_settings_rejects_invalid_json (line 225): change adaptor.apply(&tmp, &Real) to adaptor.apply(&tmp, false, &Real)",
+      "In claude_settings_rejects_non_object_root (line 240): change adaptor.apply(&tmp, &Real) to adaptor.apply(&tmp, false, &Real)",
+      "In claude_settings_handles_non_object_marketplace_value (line 255): change adaptor.apply(&tmp, &Real) to adaptor.apply(&tmp, false, &Real)",
+      "In claude_settings_handles_non_object_enabled_plugins (line 270): change adaptor.apply(&tmp, &Real) to adaptor.apply(&tmp, false, &Real)",
+      "Run: cargo test --workspace -- claude to verify all existing tests still pass"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Add new test claude_settings_created_fresh_no_starter verifying enabledPlugins is omitted when no_starter is true",
+    "steps": [
+      "Open crates/libaipm/src/workspace_init/adaptors/claude.rs test module",
+      "Add test claude_settings_created_fresh_no_starter after the existing claude_settings_created_fresh test:",
+      "  - Create temp dir, create Adaptor, call adaptor.apply(&tmp, true, &Real) with no_starter=true",
+      "  - Assert result is Ok(true)",
+      "  - Read and parse .claude/settings.json",
+      "  - Assert extraKnownMarketplaces.local-repo-plugins is present (marketplace always written)",
+      "  - Assert enabledPlugins key does NOT exist in the parsed JSON (v.get('enabledPlugins').is_none() or v['enabledPlugins'].is_null())",
+      "  - Cleanup temp dir",
+      "Run: cargo test --workspace -- claude_settings_created_fresh_no_starter to verify"
+    ],
+    "passes": true
+  },
+  {
+    "category": "functional",
+    "description": "Update init_no_starter_still_configures_tools test to assert enabledPlugins does NOT contain starter plugin key",
+    "steps": [
+      "Open crates/libaipm/src/workspace_init/mod.rs test module (around line 958)",
+      "In init_no_starter_still_configures_tools, after the existing assertion that settings.json exists (line 972):",
+      "  - Read settings.json content with std::fs::read_to_string()",
+      "  - Parse it as serde_json::Value",
+      "  - Assert extraKnownMarketplaces.local-repo-plugins is present (marketplace registration should always happen)",
+      "  - Assert enabledPlugins either does not exist as a key OR does not contain 'starter-aipm-plugin@local-repo-plugins'",
+      "  - Keep the existing assertion that .ai/starter-aipm-plugin does not exist (line 974)",
+      "Run: cargo test --workspace -- init_no_starter_still_configures_tools to verify"
     ],
     "passes": true
   },
@@ -231,7 +100,7 @@
       "  - cargo +nightly llvm-cov --no-report --doc",
       "  - cargo +nightly llvm-cov report --doctests --branch --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\\.rs)'",
       "Verify TOTAL branch column shows >= 89%",
-      "If coverage is below 89%, add additional tests targeting uncovered branches in the changed functions"
+      "If coverage is below 89%, add additional tests targeting uncovered branches"
     ],
     "passes": true
   }

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -1,29 +1,20 @@
-2026-03-24: Implemented all 15 features from feature-list.json
+2026-03-24: Implemented all 7 features from feature-list.json
 
-Feature 1:  DONE - Added strip_yaml_quotes() helper to migrate/mod.rs with 7 unit tests
-Feature 2:  DONE - Updated skill_detector.rs to strip YAML quotes + new test
-Feature 3:  DONE - Updated agent_detector.rs to strip YAML quotes + new test
-Feature 4:  DONE - Updated command_detector.rs to strip YAML quotes + new test
-Feature 5:  DONE - Updated output_style_detector.rs to strip YAML quotes + new test
-Feature 6:  DONE - Enabled serde_json preserve_order feature in workspace Cargo.toml
-Feature 7:  DONE - Added PluginToml, PluginPackage, PluginComponents structs to emitter.rs
-Feature 8:  DONE - Rewrote generate_plugin_json_multi() to use serde_json::Map
-Feature 9:  DONE - Rewrote generate_plugin_manifest() to use PluginToml + toml::to_string_pretty()
-Feature 10: DONE - Rewrote generate_package_manifest() to use PluginToml + toml::to_string_pretty()
-Feature 11: DONE - Migrated workspace_init::generate_plugin_json() to serde_json
-Feature 12: DONE - All existing tests pass (no formatting changes needed)
-Feature 13: DONE - Added 4 new unit tests for JSON/TOML roundtrip with special chars
-Feature 14: DONE - Added E2E test for quoted description producing valid JSON
-Feature 15: DONE - Full pipeline passes:
+Feature 1: DONE - Updated ToolAdaptor::apply() trait signature to add no_starter: bool + init() call site
+Feature 2: DONE - Updated claude::Adaptor::apply() fresh-write path to conditionally omit enabledPlugins
+Feature 3: DONE - Updated merge_claude_settings() to accept no_starter and skip enabledPlugins when true
+Feature 4: DONE - Updated all 8 existing claude.rs tests to pass no_starter=false argument
+Feature 5: DONE - Added new test claude_settings_created_fresh_no_starter
+Feature 6: DONE - Updated init_no_starter_still_configures_tools test to assert enabledPlugins content
+Feature 7: DONE - Full pipeline passes:
   - cargo fmt --check: clean
   - cargo clippy --workspace -- -D warnings: clean
   - cargo build --workspace: clean
-  - cargo test --workspace: 457 tests pass (0 failures)
-  - Branch coverage: 90.26% (>= 89% threshold)
+  - cargo test --workspace: 458 tests pass (0 failures)
+  - Branch coverage: 89.74% (>= 89% threshold)
 
 Summary of changes:
-- 10 files modified
-- serde_json dependency updated to include preserve_order feature
-- 12 new tests added
-- All 457 tests pass
-- 90.26% branch coverage
+- 2 files modified (workspace_init/mod.rs, adaptors/claude.rs)
+- 1 new test added, 1 test updated with content assertions, 8 tests updated with new parameter
+- All 458 tests pass
+- 89.74% branch coverage

--- a/specs/2026-03-24-fix-no-starter-enabledplugins-bug.md
+++ b/specs/2026-03-24-fix-no-starter-enabledplugins-bug.md
@@ -1,0 +1,274 @@
+# Fix `no_starter` Flag Not Forwarded to Tool Adaptors
+
+| Document Metadata      | Details                  |
+| ---------------------- | ------------------------ |
+| Author(s)              | selarkin                 |
+| Status                 | Draft (WIP)              |
+| Team / Owner           | aipm                     |
+| Created / Last Updated | 2026-03-24 / 2026-03-24 |
+
+## 1. Executive Summary
+
+When a user runs `aipm init` and declines the starter plugin (via `--no-starter`
+or the wizard's "No" answer), the `.ai/` directory is correctly created without
+the starter plugin, but `.claude/settings.json` is still written with
+`"starter-aipm-plugin@local-repo-plugins": true` in `enabledPlugins`. This
+references a plugin that doesn't exist, creating a broken configuration. The fix
+extends the `ToolAdaptor::apply()` trait to accept `no_starter`, allowing the
+Claude Code adaptor to conditionally omit the `enabledPlugins` entry.
+
+**Research reference:** [research/docs/2026-03-24-no-starter-enabledplugins-bug.md](../research/docs/2026-03-24-no-starter-enabledplugins-bug.md)
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+The `aipm init` pipeline has two phases:
+
+1. **Scaffolding** — `scaffold_marketplace()` receives `no_starter` directly and
+   correctly skips creating the starter plugin directory when `true`.
+2. **Tool configuration** — The adaptor loop calls `adaptor.apply(dir, fs)` for
+   each registered `ToolAdaptor`. The trait method has no parameter for
+   `no_starter`, so the Claude Code adaptor unconditionally writes
+   `enabledPlugins` with the starter plugin entry.
+
+```
+CLI --no-starter / Wizard "No"
+       │
+       ▼
+  Options { no_starter: true }
+       │
+       ├──► scaffold_marketplace(no_starter=true)   ✓ respects flag
+       │        ├─ marketplace.json: plugins = []   ✓
+       │        └─ early return, no starter dir     ✓
+       │
+       └──► adaptor.apply(dir, fs)                  ✗ no_starter not passed
+                └─ claude.rs writes settings.json
+                   with enabledPlugins:
+                   "starter-aipm-plugin@local-repo-plugins": true  ✗
+```
+
+### 2.2 The Problem
+
+- **User Impact:** After `aipm init --no-starter`, `.claude/settings.json`
+  references a plugin that doesn't exist, which may cause errors or warnings in
+  Claude Code when it tries to load the non-existent starter plugin.
+- **Inconsistency:** The `.ai/` directory correctly has no starter plugin and
+  `marketplace.json` has an empty `plugins` array, but `settings.json` says the
+  plugin is enabled — these two states contradict each other.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [x] When `no_starter` is `true`, `.claude/settings.json` must NOT contain
+  `"starter-aipm-plugin@local-repo-plugins"` in `enabledPlugins`.
+- [x] When `no_starter` is `false` (the default), behavior is unchanged —
+  `enabledPlugins` still includes the starter plugin entry.
+- [x] The `extraKnownMarketplaces` section is always written regardless of
+  `no_starter` — the marketplace registration is independent of which plugins
+  are enabled.
+- [x] The existing test `init_no_starter_still_configures_tools` is updated to
+  verify `settings.json` contents.
+- [x] All existing tests continue to pass.
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [x] We will NOT pass the full `Options` struct to adaptors — only `no_starter`
+  is needed. Passing the full struct would over-couple adaptors to init options
+  and violate interface segregation. If more options are needed in the future, we
+  can introduce an `AdaptorOptions` struct at that time.
+- [x] We will NOT change how `enabledPlugins` works for the merge path when the
+  starter plugin was previously enabled by the user — `or_insert` semantics are
+  correct for the merge case (don't overwrite user's explicit choice).
+- [x] We will NOT refactor the hardcoded JSON string in the fresh-write path to
+  use `serde_json` — that's a separate cleanup concern.
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Open Questions Resolution
+
+The research document raised three open questions. Here are the decisions:
+
+**Q1: Should `ToolAdaptor::apply()` accept `&Options` or just `no_starter: bool`?**
+
+**Decision: Add `no_starter: bool` parameter.**
+
+Passing the full `&Options` struct would couple every adaptor to all init
+options, most of which are irrelevant (e.g., `workspace`, `manifest`, `dir`).
+A single `bool` is the minimum information the adaptor needs. If future adaptors
+need more options, we can introduce a purpose-built `AdaptorContext` struct then.
+
+**Q2: Should the adaptor skip `enabledPlugins` entirely or write an empty object?**
+
+**Decision: Skip the `enabledPlugins` key entirely when `no_starter` is true.**
+
+An empty `"enabledPlugins": {}` adds no value — it's an unnecessary key that
+would need to be populated later when the user installs their first plugin. The
+`extraKnownMarketplaces` section (which registers the `.ai/` directory as a
+marketplace source) should still always be written. The user can enable plugins
+later via `aipm enable` or by editing `settings.json`.
+
+**Q3: Should the test be updated to assert `enabledPlugins` content?**
+
+**Decision: Yes.** The existing test `init_no_starter_still_configures_tools`
+should be updated to read `settings.json`, parse it, and assert that
+`enabledPlugins` either does not exist or does not contain the starter plugin
+key. A new test should also verify the default path (no `--no-starter`) still
+includes the `enabledPlugins` entry.
+
+### 4.2 Key Components
+
+| Component | Change | File |
+|-----------|--------|------|
+| `ToolAdaptor` trait | Add `no_starter: bool` parameter to `apply()` | `workspace_init/mod.rs` |
+| `init()` function | Pass `opts.no_starter` to `adaptor.apply()` | `workspace_init/mod.rs` |
+| `claude::Adaptor` | Conditionally omit `enabledPlugins` when `no_starter` | `adaptors/claude.rs` |
+| `merge_claude_settings()` | Accept `no_starter`, skip starter entry when true | `adaptors/claude.rs` |
+| Tests | Update assertions to verify `enabledPlugins` content | `mod.rs`, `claude.rs` |
+
+## 5. Detailed Design
+
+### 5.1 Trait Signature Change
+
+**Before** (`mod.rs:29`):
+```rust
+fn apply(&self, dir: &Path, fs: &dyn Fs) -> Result<bool, Error>;
+```
+
+**After:**
+```rust
+fn apply(&self, dir: &Path, no_starter: bool, fs: &dyn Fs) -> Result<bool, Error>;
+```
+
+### 5.2 Call Site Change
+
+**Before** (`mod.rs:117`):
+```rust
+if adaptor.apply(opts.dir, fs)? {
+```
+
+**After:**
+```rust
+if adaptor.apply(opts.dir, opts.no_starter, fs)? {
+```
+
+### 5.3 Claude Adaptor — Fresh-Write Path
+
+**Before** (`claude.rs:19`):
+```rust
+fn apply(&self, dir: &Path, fs: &dyn Fs) -> Result<bool, Error> {
+```
+
+**After:**
+```rust
+fn apply(&self, dir: &Path, no_starter: bool, fs: &dyn Fs) -> Result<bool, Error> {
+```
+
+When `no_starter` is `true`, the fresh-write JSON string omits the
+`enabledPlugins` block entirely. When `false`, behavior is unchanged.
+
+The simplest approach: build the JSON with `serde_json::Map` (consistent with
+the recent emitter refactor) and conditionally insert `enabledPlugins`.
+
+Alternatively, keep two hardcoded string variants (one with, one without
+`enabledPlugins`) to avoid adding serde construction to the hot path. Either
+approach is acceptable; the conditional logic is the key change.
+
+### 5.4 Claude Adaptor — Merge Path
+
+**Before** (`claude.rs:24`):
+```rust
+return merge_claude_settings(&settings_path, fs);
+```
+
+**After:**
+```rust
+return merge_claude_settings(&settings_path, no_starter, fs);
+```
+
+Inside `merge_claude_settings()`, the `enabledPlugins` block at lines 92-98 is
+wrapped in `if !no_starter { ... }`. The early-return check at lines 62-71 is
+also updated: when `no_starter` is `true`, the "fully configured" check only
+looks at `has_marketplace` (not `has_enabled`).
+
+### 5.5 Test Updates
+
+**Update `init_no_starter_still_configures_tools` (`mod.rs:958`):**
+- After asserting `settings.json` exists, read and parse it.
+- Assert `extraKnownMarketplaces.local-repo-plugins` is present (marketplace
+  registration should always happen).
+- Assert `enabledPlugins` either does not exist as a key or does not contain
+  `"starter-aipm-plugin@local-repo-plugins"`.
+
+**Update `claude_settings_created_fresh` (`claude.rs:127`):**
+- This test calls `adaptor.apply(&tmp, &Real)` — update to
+  `adaptor.apply(&tmp, false, &Real)` to pass `no_starter = false`.
+- Existing assertions remain valid.
+
+**Add `claude_settings_created_fresh_no_starter` (`claude.rs`):**
+- Call `adaptor.apply(&tmp, true, &Real)`.
+- Assert `extraKnownMarketplaces` is present.
+- Assert `enabledPlugins` key does not exist in the parsed JSON.
+
+**Update all other `claude.rs` tests** that call `adaptor.apply()` to pass
+`false` for `no_starter` (preserving existing behavior).
+
+**Update `merge_claude_settings` callers in tests** to pass `no_starter` where
+the function is called directly.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A: Pass `&Options` to `apply()` | Maximum future flexibility | Over-couples adaptors to all init options; most fields are irrelevant | Rejected |
+| B: Pass `no_starter: bool` to `apply()` (selected) | Minimal change; clear intent; only the needed information | Requires updating all trait implementors | **Selected** — only one implementor exists (Claude) |
+| C: Have `init()` conditionally skip the adaptor loop when `no_starter` | Zero trait changes | Wrong — tool configuration (marketplace registration) should still happen even without the starter plugin | Rejected |
+| D: Post-process `settings.json` after adaptor runs to remove `enabledPlugins` | No trait changes | Fragile; breaks encapsulation; the adaptor should know what it writes | Rejected |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Backward Compatibility
+
+The `ToolAdaptor` trait is `pub` but only implemented within `libaipm` (one
+implementor: `claude::Adaptor`). No external crates depend on this trait. The
+signature change is a breaking API change to the trait but has zero external
+consumers.
+
+### 7.2 Future Adaptors
+
+The comment at `adaptors/mod.rs:11-12` mentions future adaptors (Copilot CLI,
+OpenCode, etc.). These would receive the `no_starter` parameter and can decide
+independently whether their configuration needs it. Most future adaptors likely
+don't reference a starter plugin, so they would simply ignore the parameter.
+
+## 8. Implementation Plan
+
+### Phase 1: Core Fix (Single PR)
+
+- [ ] **Step 1:** Update `ToolAdaptor::apply()` signature to add `no_starter: bool`.
+- [ ] **Step 2:** Update `init()` call site to pass `opts.no_starter`.
+- [ ] **Step 3:** Update `claude::Adaptor::apply()` — conditionally omit
+  `enabledPlugins` in fresh-write path when `no_starter` is `true`.
+- [ ] **Step 4:** Update `merge_claude_settings()` — accept `no_starter`, skip
+  starter plugin entry when `true`, update the "fully configured" early-return
+  check.
+- [ ] **Step 5:** Update all existing tests to pass `no_starter` argument.
+- [ ] **Step 6:** Add new test: `claude_settings_created_fresh_no_starter`.
+- [ ] **Step 7:** Update `init_no_starter_still_configures_tools` to assert
+  `enabledPlugins` does NOT contain the starter plugin key.
+- [ ] **Step 8:** Run full pipeline: `cargo fmt --check`, `cargo clippy`,
+  `cargo test`, coverage >= 89%.
+
+### Test Plan
+
+- **Unit Tests:** All existing `claude.rs` tests updated + 1 new test for the
+  `no_starter = true` fresh-write path.
+- **Unit Tests:** `init_no_starter_still_configures_tools` updated with content
+  assertions on `settings.json`.
+- **E2E Tests:** Existing BDD scenarios for `--no-starter` flag.
+
+## 9. Open Questions / Unresolved Issues
+
+All three open questions from the research have been resolved in Section 4.1.
+No remaining open questions.


### PR DESCRIPTION
## Summary

- **Bug**: `aipm init --no-starter` (or wizard "No") correctly skipped creating the starter plugin directory, but `.claude/settings.json` still contained `"starter-aipm-plugin@local-repo-plugins": true` in `enabledPlugins` — referencing a plugin that doesn't exist.
- **Root cause**: `ToolAdaptor::apply()` trait had no `no_starter` parameter, so the Claude adaptor couldn't know to skip the `enabledPlugins` entry.
- **Fix**: Add `no_starter: bool` to `ToolAdaptor::apply()`, pass it from `init()`, and conditionally omit `enabledPlugins` in both the fresh-write and merge paths.

### Changes
- Add `no_starter: bool` parameter to `ToolAdaptor::apply()` trait signature
- Pass `opts.no_starter` from `init()` adaptor loop to each adaptor
- Fresh-write path: use JSON string variant without `enabledPlugins` when `no_starter`
- Merge path: skip `enabledPlugins` insertion and simplify "fully configured" check when `no_starter`
- Update `init_no_starter_still_configures_tools` test to verify `settings.json` content
- Add `claude_settings_created_fresh_no_starter` test

## Test plan

- [x] New test: `claude_settings_created_fresh_no_starter` — verifies `enabledPlugins` is absent when `no_starter=true`
- [x] Updated test: `init_no_starter_still_configures_tools` — now asserts marketplace is registered AND `enabledPlugins` does not reference starter plugin
- [x] All 8 existing `claude.rs` tests updated with new parameter, still passing
- [x] All 458 tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Branch coverage: 89.74% (threshold: 89%)