### PR TITLE
fix: switch CodeQL to advanced setup, exclude .ai/

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL config"
+
+paths-ignore:
+  - .ai

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '25 14 * * 1'
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: rust
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Switch from CodeQL default setup to advanced setup with a workflow file
- Exclude `.ai/` marketplace directory from scanning via `codeql-config.yml`
- Drop `javascript-typescript` language (this is a Rust project)
- Keep `actions` and `rust` language scanning

## Context
The default CodeQL setup auto-detected `javascript-typescript` due to `scaffold-plugin.ts` in `.ai/starter-aipm-plugin/scripts/`. That file uses `--experimental-strip-types` which CodeQL cannot parse, causing the Analyze job to fail with exit code 32.

## Test plan
- [x] CodeQL workflow only runs `actions` and `rust` analysis
- [x] `.ai/` directory excluded via config file
- [ ] CI passes with new workflow