### PR TITLE
fix: correct copilot-cli download pattern and extract tarball

### DIFF
--- a/.github/actions/copilot-agent-setup/action.yml
+++ b/.github/actions/copilot-agent-setup/action.yml
@@ -63,9 +63,10 @@ runs:
         VERSION=$(gh release view --repo github/copilot-cli --json tagName -q .tagName)
         gh release download "${VERSION}" \
           --repo github/copilot-cli \
-          --pattern "*linux-x64*" \
-          --output /usr/local/bin/copilot
-        chmod +x /usr/local/bin/copilot
+          --pattern "copilot-linux-x64.tar.gz" \
+          --dir /tmp/copilot-dl
+        tar -xzf /tmp/copilot-dl/copilot-linux-x64.tar.gz -C /tmp/copilot-dl
+        install -m 0755 /tmp/copilot-dl/copilot /usr/local/bin/copilot
 
         # AWF binary
         curl -fsSL \


### PR DESCRIPTION
## Summary
- Fix asset pattern from `*linux*amd64*` to `copilot-linux-x64.tar.gz` (copilot-cli uses `x64`, not `amd64`)
- Extract the tarball before installing (assets are `.tar.gz`, not raw binaries)

## Context
The daily-repo-status workflow fails at the "Install Copilot CLI and AWF" step with `no assets match the file pattern`. See #77.

## Test plan
- [x] Re-run the daily-repo-status workflow after merge