### PR TITLE
fix: research-codebase prompt syntax

### DIFF
--- a/.github/workflows/research-codebase.yml
+++ b/.github/workflows/research-codebase.yml
@@ -105,7 +105,6 @@ jobs:
             --allow-all-tools \
             --allow-all-paths \
             --prompt "/aipm-atomic-plugin:research-codebase ${ISSUE_TITLE}"
-          )"
 
       - name: Post research file to issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
## Summary
- Fix broken heredoc/subshell prompt syntax in the research-codebase workflow
- Simplifies the `--prompt` flag to pass the command string directly

## Test plan
- [ ] Workflow YAML parses without syntax errors
- [ ] `research` label trigger runs the agent with the correct prompt