### PR TITLE
chore: release v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1165,7 +1165,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "assert_cmd",
  "cucumber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.10.0" }
+libaipm = { path = "crates/libaipm", version = "0.10.1" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.10.1] - 2026-03-26
+
 ## [0.10.0] - 2026-03-25
 
 ## [0.9.1] - 2026-03-25

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.10.1] - 2026-03-26
+
 ## [0.10.0] - 2026-03-25
 
 ### Features

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.10.1] - 2026-03-26
+
+### Features
+- Add .tool-usage.log to .ai/.gitignore when starter plugin is installed ([#98](https://github.com/TheLarkInn/aipm/pull/98)) (23796b5)
+
 ## [0.10.0] - 2026-03-25
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `aipm`: 0.10.0 -> 0.10.1
* `aipm-pack`: 0.10.0 -> 0.10.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.10.1] - 2026-03-26

### Features
- Add .tool-usage.log to .ai/.gitignore when starter plugin is installed ([#98](https://github.com/TheLarkInn/aipm/pull/98)) (23796b5)
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).