### PR TITLE
chore: release v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1165,7 +1165,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "assert_cmd",
  "cucumber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.10.1" }
+libaipm = { path = "crates/libaipm", version = "0.11.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.11.0] - 2026-03-26
+
+### Refactoring
+- Remove edition field from aipm.toml manifests ([#102](https://github.com/TheLarkInn/aipm/pull/102)) (a6c2374)
+
 ## [0.10.1] - 2026-03-26
 
 ## [0.10.0] - 2026-03-25

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.11.0] - 2026-03-26
+
 ## [0.10.1] - 2026-03-26
 
 ## [0.10.0] - 2026-03-25

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.11.0] - 2026-03-26
+
+### Refactoring
+- Remove edition field from aipm.toml manifests ([#102](https://github.com/TheLarkInn/aipm/pull/102)) (a6c2374)
+
 ## [0.10.1] - 2026-03-26
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)
* `aipm`: 0.10.1 -> 0.11.0
* `aipm-pack`: 0.10.1 -> 0.11.0

### ⚠ `libaipm` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field edition of struct Package, previously in file /tmp/.tmpMNWx5h/libaipm/src/manifest/types.rs:61
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.11.0] - 2026-03-26

### Refactoring
- Remove edition field from aipm.toml manifests ([#102](https://github.com/TheLarkInn/aipm/pull/102)) (a6c2374)
</blockquote>


## `aipm-pack`

<blockquote>

## [0.11.0] - 2026-03-26

### Refactoring
- Remove edition field from aipm.toml manifests ([#102](https://github.com/TheLarkInn/aipm/pull/102)) (a6c2374)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).