### PR TITLE
fix: address PR #104 review comments

### DIFF
--- a/crates/libaipm/src/fs.rs
+++ b/crates/libaipm/src/fs.rs
@@ -151,27 +151,48 @@ impl Fs for Real {
     }
 
     fn is_symlink(&self, path: &Path) -> bool {
-        path.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink())
+        #[cfg(unix)]
+        {
+            path.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink())
+        }
+        #[cfg(windows)]
+        {
+            if path.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink()) {
+                return true;
+            }
+            junction::exists(path).unwrap_or(false)
+        }
     }
 
     fn atomic_write(&self, path: &Path, content: &[u8]) -> std::io::Result<()> {
         use std::io::Write;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
 
         let parent = path.parent().unwrap_or_else(|| Path::new("."));
         std::fs::create_dir_all(parent)?;
 
-        // Write to a per-call unique sibling temp file, then rename for atomicity.
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0);
-        let tmp_path = parent.join(format!(".aipm-tmp-{}-{nanos}", std::process::id()));
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = parent.join(format!(".aipm-tmp-{}-{seq}", std::process::id()));
         let mut file = std::fs::File::create(&tmp_path)?;
         file.write_all(content)?;
         file.sync_all()?;
         drop(file);
 
-        std::fs::rename(&tmp_path, path)
+        #[cfg(unix)]
+        {
+            std::fs::rename(&tmp_path, path)
+        }
+        #[cfg(windows)]
+        {
+            // On Windows, std::fs::rename does not atomically replace an existing
+            // destination. Best-effort remove first, then rename.
+            if path.exists() {
+                let _ = std::fs::remove_file(path);
+            }
+            std::fs::rename(&tmp_path, path)
+        }
     }
 }
 

--- a/crates/libaipm/src/installer/pipeline.rs
+++ b/crates/libaipm/src/installer/pipeline.rs
@@ -74,7 +74,7 @@ pub fn install(config: &InstallConfig, registry: &dyn Registry) -> Result<Instal
     // Step 1: Load manifest
     tracing::info!(manifest = %config.manifest_path.display(), "loading manifest");
     let manifest_content = std::fs::read_to_string(&config.manifest_path)?;
-    let manifest = manifest::parse(&manifest_content)
+    let manifest = manifest::parse_and_validate(&manifest_content, config.manifest_path.parent())
         .map_err(|e| Error::Manifest { reason: e.to_string() })?;
 
     // Step 3: If adding a new package, update the manifest file
@@ -91,7 +91,8 @@ pub fn install(config: &InstallConfig, registry: &dyn Registry) -> Result<Instal
     // Re-read manifest if we just modified it, otherwise use existing
     let manifest = if config.add_package.is_some() {
         let content = std::fs::read_to_string(&config.manifest_path)?;
-        manifest::parse(&content).map_err(|e| Error::Manifest { reason: e.to_string() })?
+        manifest::parse_and_validate(&content, config.manifest_path.parent())
+            .map_err(|e| Error::Manifest { reason: e.to_string() })?
     } else {
         manifest
     };
@@ -259,8 +260,13 @@ fn resolve_dependencies(
     let root_deps = manifest_to_resolver_deps(manifest);
 
     // Parse overrides from manifest
-    let override_rules =
-        manifest.overrides.as_ref().map(resolver::overrides::parse).unwrap_or_default();
+    let override_rules = manifest
+        .overrides
+        .as_ref()
+        .map(resolver::overrides::parse)
+        .transpose()
+        .map_err(Error::Resolution)?
+        .unwrap_or_default();
 
     // Determine lockfile pins
     let lockfile_pins = match existing_lockfile {
@@ -488,7 +494,7 @@ pub fn update(config: &UpdateConfig, registry: &dyn Registry) -> Result<InstallR
     // Load manifest
     tracing::info!(manifest = %config.manifest_path.display(), "loading manifest for update");
     let manifest_content = std::fs::read_to_string(&config.manifest_path)?;
-    let manifest = manifest::parse(&manifest_content)
+    let manifest = manifest::parse_and_validate(&manifest_content, config.manifest_path.parent())
         .map_err(|e| Error::Manifest { reason: e.to_string() })?;
 
     // Load existing lockfile
@@ -520,8 +526,13 @@ pub fn update(config: &UpdateConfig, registry: &dyn Registry) -> Result<InstallR
 
     // Resolve dependencies with the adjusted pins
     let root_deps = manifest_to_resolver_deps(&manifest);
-    let override_rules =
-        manifest.overrides.as_ref().map(resolver::overrides::parse).unwrap_or_default();
+    let override_rules = manifest
+        .overrides
+        .as_ref()
+        .map(resolver::overrides::parse)
+        .transpose()
+        .map_err(Error::Resolution)?
+        .unwrap_or_default();
 
     let resolution =
         resolver::resolve_with_overrides(&root_deps, &lockfile_pins, registry, &override_rules)

--- a/crates/libaipm/src/linker/directory_link.rs
+++ b/crates/libaipm/src/linker/directory_link.rs
@@ -50,7 +50,17 @@ pub fn remove(target: &Path) -> Result<(), Error> {
 /// Check whether a path is a symbolic link (Unix) or directory junction (Windows).
 #[must_use]
 pub fn is_link(path: &Path) -> bool {
-    path.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink())
+    #[cfg(unix)]
+    {
+        path.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink())
+    }
+    #[cfg(windows)]
+    {
+        if path.symlink_metadata().is_ok_and(|m| m.file_type().is_symlink()) {
+            return true;
+        }
+        junction::exists(path).unwrap_or(false)
+    }
 }
 
 /// Read the target of a directory link.
@@ -88,7 +98,7 @@ fn remove_link(target: &Path) -> Result<(), Error> {
     }
     #[cfg(windows)]
     {
-        std::fs::remove_dir(target).map_err(|e| Error::Io { path: target.to_path_buf(), source: e })
+        junction::delete(target).map_err(|e| Error::Io { path: target.to_path_buf(), source: e })
     }
 }
 

--- a/crates/libaipm/src/lockfile/mod.rs
+++ b/crates/libaipm/src/lockfile/mod.rs
@@ -94,8 +94,23 @@ pub fn validate_matches_manifest(
         }
     }
 
-    // Direct deps in lockfile but not in manifest (could be transitive, so this
-    // is a simpler check — we just verify manifest deps are present)
+    // Collect all names that appear as transitive dependencies of other packages.
+    // The dependency strings have the format "name ^version" or "name >=version",
+    // so we split on whitespace and take the first token as the dep name.
+    let transitive: std::collections::BTreeSet<String> = lockfile
+        .packages
+        .iter()
+        .flat_map(|p| {
+            p.dependencies.iter().filter_map(|d| d.split_whitespace().next().map(String::from))
+        })
+        .collect();
+
+    // Any lockfile package that is NOT a transitive dep AND NOT in manifest deps is drift.
+    for pkg in &lockfile.packages {
+        if !transitive.contains(&pkg.name) && !manifest_deps.contains(&pkg.name) {
+            issues.push(format!("dependency '{}' is in lockfile but not in manifest", pkg.name));
+        }
+    }
 
     if issues.is_empty() {
         Ok(())
@@ -261,5 +276,48 @@ generated_by = "future-aipm"
         let err_msg = format!("{}", result.err().unwrap());
         assert!(err_msg.contains("dep-a"));
         assert!(err_msg.contains("dep-b"));
+    }
+
+    #[test]
+    fn validate_matches_manifest_detects_removed_dep() {
+        // Create a lockfile with a root-level package ("stale-pkg") that is not
+        // a transitive dependency of any other package AND not in manifest deps.
+        let lf = Lockfile {
+            metadata: Metadata { lockfile_version: 1, generated_by: "aipm 0.10.0".to_string() },
+            packages: vec![
+                Package {
+                    name: "code-review".to_string(),
+                    version: "1.2.0".to_string(),
+                    source: "git+https://github.com/org/aipm-registry.git".to_string(),
+                    checksum: "sha512-abc123".to_string(),
+                    dependencies: vec!["lint-skill ^1.0".to_string()],
+                },
+                Package {
+                    name: "lint-skill".to_string(),
+                    version: "1.5.0".to_string(),
+                    source: "git+https://github.com/org/aipm-registry.git".to_string(),
+                    checksum: "sha512-789ghi".to_string(),
+                    dependencies: vec![],
+                },
+                Package {
+                    name: "stale-pkg".to_string(),
+                    version: "0.1.0".to_string(),
+                    source: "git+https://github.com/org/aipm-registry.git".to_string(),
+                    checksum: "sha512-stale".to_string(),
+                    dependencies: vec![],
+                },
+            ],
+        };
+
+        // Manifest only lists "code-review" — "stale-pkg" is a root-level
+        // lockfile entry that should be flagged as drift.
+        let deps: std::collections::BTreeSet<String> =
+            ["code-review"].iter().map(|s| (*s).to_string()).collect();
+
+        let result = validate_matches_manifest(&lf, &deps);
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.err().unwrap());
+        assert!(err_msg.contains("stale-pkg"));
+        assert!(err_msg.contains("in lockfile but not in manifest"));
     }
 }

--- a/crates/libaipm/src/registry/config.rs
+++ b/crates/libaipm/src/registry/config.rs
@@ -43,7 +43,7 @@ pub struct IndexMeta {
 impl Config {
     /// Look up which registry name a package should use.
     ///
-    /// Scoped packages (`@scope/name`) are routed via `[registries.scopes]`.
+    /// Scoped packages (`@scope/name`) are routed via `[scopes]`.
     /// All other packages use the `"default"` registry.
     pub fn registry_for_package(&self, package_name: &str) -> &str {
         if let Some(scope) = extract_scope(package_name) {

--- a/crates/libaipm/src/resolver/overrides.rs
+++ b/crates/libaipm/src/resolver/overrides.rs
@@ -43,45 +43,47 @@ pub enum Override {
 /// Parse override entries from the manifest `[overrides]` table.
 ///
 /// Returns a list of parsed override rules.
-pub fn parse(overrides: &BTreeMap<String, String>) -> Vec<Override> {
+///
+/// # Errors
+///
+/// Returns an error if a scoped key (`parent>child`) is combined with a
+/// replacement value (`aipm:...@...`), which is not supported.
+pub fn parse(overrides: &BTreeMap<String, String>) -> Result<Vec<Override>, String> {
     let mut result = Vec::new();
     for (key, value) in overrides {
-        result.push(parse_single_override(key, value));
+        result.push(parse_single_override(key, value)?);
     }
-    result
+    Ok(result)
 }
 
 /// Parse a single override entry.
-fn parse_single_override(key: &str, value: &str) -> Override {
+fn parse_single_override(key: &str, value: &str) -> Result<Override, String> {
     // Check for scoped override: "parent>child"
     if let Some((parent, child)) = key.split_once('>') {
-        return if let Some(replacement_info) = parse_replacement_value(value) {
-            // Scoped replacement (unusual but technically valid)
-            Override::Replacement {
-                original: child.trim().to_string(),
-                replacement: replacement_info.0,
-                req: replacement_info.1,
-            }
+        return if parse_replacement_value(value).is_some() {
+            Err(format!(
+                "scoped replacements are not supported: '{key} = {value}'; use an unscoped key instead"
+            ))
         } else {
-            Override::Scoped {
+            Ok(Override::Scoped {
                 parent: parent.trim().to_string(),
                 child: child.trim().to_string(),
                 req: value.to_string(),
-            }
+            })
         };
     }
 
     // Check for replacement: value starts with "aipm:"
     if let Some(replacement_info) = parse_replacement_value(value) {
-        return Override::Replacement {
+        return Ok(Override::Replacement {
             original: key.to_string(),
             replacement: replacement_info.0,
             req: replacement_info.1,
-        };
+        });
     }
 
     // Global override
-    Override::Global { name: key.to_string(), req: value.to_string() }
+    Ok(Override::Global { name: key.to_string(), req: value.to_string() })
 }
 
 /// Parse a replacement value like `"aipm:fixed-lib@^1.0"`.
@@ -141,7 +143,7 @@ mod tests {
         let mut overrides = BTreeMap::new();
         overrides.insert("vulnerable-lib".to_string(), "^2.0.0".to_string());
 
-        let parsed = parse(&overrides);
+        let parsed = parse(&overrides).unwrap();
         assert_eq!(parsed.len(), 1);
         assert!(matches!(&parsed[0], Override::Global { name, req }
             if name == "vulnerable-lib" && req == "^2.0.0"));
@@ -152,7 +154,7 @@ mod tests {
         let mut overrides = BTreeMap::new();
         overrides.insert("skill-a>common-util".to_string(), "=2.1.0".to_string());
 
-        let parsed = parse(&overrides);
+        let parsed = parse(&overrides).unwrap();
         assert_eq!(parsed.len(), 1);
         assert!(matches!(&parsed[0], Override::Scoped { parent, child, req }
             if parent == "skill-a" && child == "common-util" && req == "=2.1.0"));
@@ -163,7 +165,7 @@ mod tests {
         let mut overrides = BTreeMap::new();
         overrides.insert("broken-lib".to_string(), "aipm:fixed-lib@^1.0".to_string());
 
-        let parsed = parse(&overrides);
+        let parsed = parse(&overrides).unwrap();
         assert_eq!(parsed.len(), 1);
         assert!(matches!(&parsed[0], Override::Replacement { original, replacement, req }
             if original == "broken-lib" && replacement == "fixed-lib" && req == "^1.0"));
@@ -226,7 +228,7 @@ mod tests {
         overrides.insert("parent>child".to_string(), "=1.0.0".to_string());
         overrides.insert("old-pkg".to_string(), "aipm:new-pkg@^3.0".to_string());
 
-        let parsed = parse(&overrides);
+        let parsed = parse(&overrides).unwrap();
         assert_eq!(parsed.len(), 3);
     }
 
@@ -236,7 +238,7 @@ mod tests {
         let mut overrides = BTreeMap::new();
         overrides.insert("pkg".to_string(), "aipm:nope".to_string());
 
-        let parsed = parse(&overrides);
+        let parsed = parse(&overrides).unwrap();
         assert_eq!(parsed.len(), 1);
         assert!(matches!(&parsed[0], Override::Global { .. }));
     }
@@ -289,21 +291,20 @@ mod tests {
 
     #[test]
     fn parse_scoped_with_replacement_value() {
-        // Unusual case: scoped key with aipm:replacement@version value
+        // Scoped key with aipm:replacement@version value is not supported
         let mut overrides = BTreeMap::new();
         overrides.insert("parent>old-child".to_string(), "aipm:new-child@^2.0".to_string());
 
-        let parsed = parse(&overrides);
-        assert_eq!(parsed.len(), 1);
-        // Should parse as Replacement (with child as original)
-        assert!(matches!(&parsed[0], Override::Replacement { original, replacement, req }
-            if original == "old-child" && replacement == "new-child" && req == "^2.0"));
+        let result = parse(&overrides);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("scoped replacements are not supported"));
     }
 
     #[test]
     fn parse_empty_overrides() {
         let overrides = BTreeMap::new();
-        let parsed = parse(&overrides);
+        let parsed = parse(&overrides).unwrap();
         assert!(parsed.is_empty());
     }
 

--- a/crates/libaipm/src/store/mod.rs
+++ b/crates/libaipm/src/store/mod.rs
@@ -3,6 +3,12 @@
 //! Files are stored by their SHA-512 hash in a 2-character prefix
 //! sharded directory layout: `~/.aipm/store/{prefix}/{rest}`.
 //!
+//! # Concurrency
+//!
+//! The store itself does not acquire locks internally. Callers performing
+//! concurrent writes should hold a [`Lock`] from [`Store::lock()`] for the
+//! duration of the operation to ensure mutual exclusion.
+//!
 //! This module provides:
 //! - [`hash`] — SHA-512 hashing utilities
 //! - [`layout`] — directory path calculation from hashes
@@ -91,6 +97,9 @@ impl Store {
     ///
     /// If a file with the same hash already exists, this is a no-op
     /// (content-addressable writes are idempotent).
+    ///
+    /// Callers performing concurrent writes should hold a [`Lock`] from
+    /// [`Store::lock()`] for the duration of the operation.
     ///
     /// # Errors
     ///
@@ -183,6 +192,9 @@ impl Store {
     ///
     /// Returns a map of relative paths (from `extracted_dir`) to their
     /// content hashes.
+    ///
+    /// Callers performing concurrent writes should hold a [`Lock`] from
+    /// [`Store::lock()`] for the duration of the operation.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary

Addresses all 8 remaining review comments from #104:

- **config.rs**: Fix doc comment — scopes use `[scopes]` not `[registries.scopes]` (#3)
- **store/mod.rs**: Document that callers must hold `Lock` during concurrent writes (#4)
- **directory_link.rs + fs.rs**: Add Windows junction detection via `junction::exists()`; use `junction::delete()` for removal (#5, #6)
- **fs.rs**: Fix `atomic_write` temp filename collision using atomic counter; add Windows-safe rename (#7)
- **lockfile/mod.rs**: Add bidirectional drift detection — now detects stale root-level lockfile packages not in manifest (#9)
- **installer/pipeline.rs**: Switch from `manifest::parse` to `parse_and_validate` for early schema validation (#10)
- **resolver/overrides.rs**: Error on scoped replacement overrides instead of silently dropping parent scope (#11)

## Test plan

- [x] `cargo build --workspace` — zero errors
- [x] `cargo test --workspace` — 659 tests pass (67 BDD scenarios)
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] Branch coverage: **89.33%** (threshold: 89%)