### PR TITLE
chore: release v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.11.6"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.11.6"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1202,7 +1202,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.11.6"
+version = "0.12.0"
 dependencies = [
  "assert_cmd",
  "cucumber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.11.6"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.11.6" }
+libaipm = { path = "crates/libaipm", version = "0.12.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.12.0] - 2026-03-28
+
 ## [0.11.6] - 2026-03-28
 
 ## [0.11.5] - 2026-03-27

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.12.0] - 2026-03-28
+
+### Features
+- Add --destructive flag and cleanup wizard ([#130](https://github.com/TheLarkInn/aipm/pull/130)) (225dbd0)
+
 ## [0.11.6] - 2026-03-28
 
 ## [0.11.5] - 2026-03-27

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.12.0] - 2026-03-28
+
+### Features
+- Add --destructive flag and cleanup wizard ([#130](https://github.com/TheLarkInn/aipm/pull/130)) (225dbd0)
+
 ## [0.11.6] - 2026-03-28
 
 ### Testing


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.11.6 -> 0.12.0 (⚠ API breaking changes)
* `aipm`: 0.11.6 -> 0.12.0
* `aipm-pack`: 0.11.6 -> 0.12.0

### ⚠ `libaipm` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Options.destructive in /tmp/.tmpmBoxqc/aipm/crates/libaipm/src/migrate/mod.rs:111

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field source_is_dir of variant Action::PluginCreated in /tmp/.tmpmBoxqc/aipm/crates/libaipm/src/migrate/mod.rs:131

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Action:SourceFileRemoved in /tmp/.tmpmBoxqc/aipm/crates/libaipm/src/migrate/mod.rs:160
  variant Action:SourceDirRemoved in /tmp/.tmpmBoxqc/aipm/crates/libaipm/src/migrate/mod.rs:165
  variant Action:EmptyDirPruned in /tmp/.tmpmBoxqc/aipm/crates/libaipm/src/migrate/mod.rs:170

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  libaipm::migrate::dry_run::generate_report now takes 5 parameters instead of 4, in /tmp/.tmpmBoxqc/aipm/crates/libaipm/src/migrate/dry_run.rs:12
  libaipm::migrate::dry_run::generate_recursive_report now takes 4 parameters instead of 3, in /tmp/.tmpmBoxqc/aipm/crates/libaipm/src/migrate/dry_run.rs:83
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.12.0] - 2026-03-28

### Features
- Add --destructive flag and cleanup wizard ([#130](https://github.com/TheLarkInn/aipm/pull/130)) (225dbd0)
</blockquote>

## `aipm`

<blockquote>

## [0.12.0] - 2026-03-28

### Features
- Add --destructive flag and cleanup wizard ([#130](https://github.com/TheLarkInn/aipm/pull/130)) (225dbd0)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).