### PR TITLE
chore: release v0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1208,7 +1208,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert_cmd",
  "cucumber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.13.0" }
+libaipm = { path = "crates/libaipm", version = "0.14.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.14.0] - 2026-03-28
+
 ## [0.13.0] - 2026-03-28
 
 ## [0.12.1] - 2026-03-28

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.14.0] - 2026-03-28
+
+### Features
+- Workspace dependencies resolve and link locally ([#144](https://github.com/TheLarkInn/aipm/pull/144)) (13630b8)
+
 ## [0.13.0] - 2026-03-28
 
 ## [0.12.1] - 2026-03-28

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.14.0] - 2026-03-28
+
+### Features
+- Workspace dependencies resolve and link locally ([#144](https://github.com/TheLarkInn/aipm/pull/144)) (13630b8)
+
 ## [0.13.0] - 2026-03-28
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.13.0 -> 0.14.0 (⚠ API breaking changes)
* `aipm`: 0.13.0 -> 0.14.0
* `aipm-pack`: 0.13.0 -> 0.14.0

### ⚠ `libaipm` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field InstallConfig.workspace_root in /tmp/.tmpHJ5Cmy/aipm/crates/libaipm/src/installer/pipeline.rs:38

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:InvalidWorkspaceProtocol in /tmp/.tmpHJ5Cmy/aipm/crates/libaipm/src/manifest/error.rs:60
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.14.0] - 2026-03-28

### Features
- Workspace dependencies resolve and link locally ([#144](https://github.com/TheLarkInn/aipm/pull/144)) (13630b8)
</blockquote>

## `aipm`

<blockquote>

## [0.14.0] - 2026-03-28

### Features
- Workspace dependencies resolve and link locally ([#144](https://github.com/TheLarkInn/aipm/pull/144)) (13630b8)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).