### PR TITLE
chore: release v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1075,7 +1075,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "assert_cmd",
  "cucumber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.15.1" }
+libaipm = { path = "crates/libaipm", version = "0.16.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.16.0] - 2026-04-02
+
 ## [0.15.1] - 2026-04-02
 
 ## [0.15.0] - 2026-04-01

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.16.0] - 2026-04-02
+
+### Features
+- Use recursive discovery for lint misplaced-features rule ([#190](https://github.com/TheLarkInn/aipm/pull/190)) (4b1cab6)
+
 ## [0.15.1] - 2026-04-02
 
 ## [0.15.0] - 2026-04-01

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.16.0] - 2026-04-02
+
+### Features
+- Use recursive discovery for lint misplaced-features rule ([#190](https://github.com/TheLarkInn/aipm/pull/190)) (4b1cab6)
+
 ## [0.15.1] - 2026-04-02
 
 ## [0.15.0] - 2026-04-01


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.15.1 -> 0.16.0 (⚠ API breaking changes)
* `aipm`: 0.15.1 -> 0.16.0
* `aipm-pack`: 0.15.1 -> 0.16.0

### ⚠ `libaipm` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:DiscoveryFailed in /tmp/.tmp3Fpa9M/aipm/crates/libaipm/src/lint/mod.rs:183

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function libaipm::migrate::discovery::discover_claude_dirs, previously in file /tmp/.tmpo2np3P/libaipm/src/migrate/discovery.rs:35
  function libaipm::lint::rules::for_copilot, previously in file /tmp/.tmpo2np3P/libaipm/src/lint/rules/mod.rs:31
  function libaipm::lint::rules::for_source, previously in file /tmp/.tmpo2np3P/libaipm/src/lint/rules/mod.rs:55
  function libaipm::migrate::discovery::discover_source_dirs, previously in file /tmp/.tmpo2np3P/libaipm/src/migrate/discovery.rs:54
  function libaipm::lint::rules::for_claude, previously in file /tmp/.tmpo2np3P/libaipm/src/lint/rules/mod.rs:26
  function libaipm::lint::rules::for_marketplace, previously in file /tmp/.tmpo2np3P/libaipm/src/lint/rules/mod.rs:36

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod libaipm::migrate::discovery, previously in file /tmp/.tmpo2np3P/libaipm/src/migrate/discovery.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct libaipm::lint::rules::misplaced_features::MisplacedFeatures, previously in file /tmp/.tmpo2np3P/libaipm/src/lint/rules/misplaced_features.rs:17
  struct libaipm::migrate::discovery::DiscoveredSource, previously in file /tmp/.tmpo2np3P/libaipm/src/migrate/discovery.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.16.0] - 2026-04-02

### Features
- Use recursive discovery for lint misplaced-features rule ([#190](https://github.com/TheLarkInn/aipm/pull/190)) (4b1cab6)
</blockquote>

## `aipm`

<blockquote>

## [0.16.0] - 2026-04-02

### Features
- Use recursive discovery for lint misplaced-features rule ([#190](https://github.com/TheLarkInn/aipm/pull/190)) (4b1cab6)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).