### PR TITLE
chore: release v0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1114,7 +1114,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.17.1" }
+libaipm = { path = "crates/libaipm", version = "0.17.2" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.17.2] - 2026-04-05
+
 ## [0.17.1] - 2026-04-04
 
 ## [0.17.0] - 2026-04-03

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.17.2] - 2026-04-05
+
+### Features
+- Unified single-pass feature discovery fixes #208 ([#211](https://github.com/TheLarkInn/aipm/pull/211)) (ec24fe7)
+
 ## [0.17.1] - 2026-04-04
 
 ## [0.17.0] - 2026-04-03

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.17.2] - 2026-04-05
+
+### Features
+- Unified single-pass feature discovery fixes #208 ([#211](https://github.com/TheLarkInn/aipm/pull/211)) (ec24fe7)
+
 ## [0.17.1] - 2026-04-04
 
 ## [0.17.0] - 2026-04-03


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.17.1 -> 0.17.2 (✓ API compatible changes)
* `aipm`: 0.17.1 -> 0.17.2
* `aipm-pack`: 0.17.1 -> 0.17.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.17.2] - 2026-04-05

### Features
- Unified single-pass feature discovery fixes #208 ([#211](https://github.com/TheLarkInn/aipm/pull/211)) (ec24fe7)
</blockquote>

## `aipm`

<blockquote>

## [0.17.2] - 2026-04-05

### Features
- Unified single-pass feature discovery fixes #208 ([#211](https://github.com/TheLarkInn/aipm/pull/211)) (ec24fe7)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).