### PR TITLE
chore: release v0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1114,7 +1114,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.18.1"
+version = "0.18.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.18.1" }
+libaipm = { path = "crates/libaipm", version = "0.18.2" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.18.2] - 2026-04-07
+
+### Documentation
+- Document install/update/uninstall/link/unlink/list/lint commands and new libaipm modules ([#244](https://github.com/TheLarkInn/aipm/pull/244)) (fa03dcf)
+
 ## [0.18.1] - 2026-04-06
 
 ## [0.18.0] - 2026-04-06

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.18.2] - 2026-04-07
+
+### Documentation
+- Document install/update/uninstall/link/unlink/list/lint commands and new libaipm modules ([#244](https://github.com/TheLarkInn/aipm/pull/244)) (fa03dcf)
+
 ## [0.18.1] - 2026-04-06
 
 ## [0.18.0] - 2026-04-06

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.18.2] - 2026-04-07
+
+### Documentation
+- Document install/update/uninstall/link/unlink/list/lint commands and new libaipm modules ([#244](https://github.com/TheLarkInn/aipm/pull/244)) (fa03dcf)
+
+### Testing
+- Cover None branch when no artifacts but other files present (8c8a2f0)
+- Cover glob_match middle-part-not-found else branch (2fed3ec)
+- Cover missed branches in installed::Registry::resolve_spec (28867bd)
+- Cover uncovered branches in skill_name_invalid check_file (1253abe)
+- Cover check_file no-frontmatter branch in skill rules (9f8c017)
+- Cover double-quote and single-quote terminators in check_file (e876d99)
+- Cover None branch of path.parent() in write_gitignore (875fd3e)
+- Cover empty-URL branch in parse_git_spec (5ecdf5e)
+- Cover is_env_enforced closure branches via AIPM_ENFORCE_ALLOWLIST (fe8c0e4)
+- Cover is_valid_segment empty-string guard branch (36e5d7c)
+- Cover duplicate source-path branch in emit_package_plugin (ec5ee04)
+- Cover is_local_path non-alphabetic first-char branch (940e462)
+- Cover as_git, as_marketplace, and error-path branches in spec.rs (74814cd)
+- Cover scan_agents plugin-is-file branch (a3a1ce3)
+
 ## [0.18.1] - 2026-04-06
 
 ### Testing


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.18.1 -> 0.18.2 (✓ API compatible changes)
* `aipm`: 0.18.1 -> 0.18.2
* `aipm-pack`: 0.18.1 -> 0.18.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.18.2] - 2026-04-07

### Documentation
- Document install/update/uninstall/link/unlink/list/lint commands and new libaipm modules ([#244](https://github.com/TheLarkInn/aipm/pull/244)) (fa03dcf)

### Testing
- Cover None branch when no artifacts but other files present (8c8a2f0)
- Cover glob_match middle-part-not-found else branch (2fed3ec)
- Cover missed branches in installed::Registry::resolve_spec (28867bd)
- Cover uncovered branches in skill_name_invalid check_file (1253abe)
- Cover check_file no-frontmatter branch in skill rules (9f8c017)
- Cover double-quote and single-quote terminators in check_file (e876d99)
- Cover None branch of path.parent() in write_gitignore (875fd3e)
- Cover empty-URL branch in parse_git_spec (5ecdf5e)
- Cover is_env_enforced closure branches via AIPM_ENFORCE_ALLOWLIST (fe8c0e4)
- Cover is_valid_segment empty-string guard branch (36e5d7c)
- Cover duplicate source-path branch in emit_package_plugin (ec5ee04)
- Cover is_local_path non-alphabetic first-char branch (940e462)
- Cover as_git, as_marketplace, and error-path branches in spec.rs (74814cd)
- Cover scan_agents plugin-is-file branch (a3a1ce3)
</blockquote>

## `aipm`

<blockquote>

## [0.18.2] - 2026-04-07

### Documentation
- Document install/update/uninstall/link/unlink/list/lint commands and new libaipm modules ([#244](https://github.com/TheLarkInn/aipm/pull/244)) (fa03dcf)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.18.2] - 2026-04-07

### Documentation
- Document install/update/uninstall/link/unlink/list/lint commands and new libaipm modules ([#244](https://github.com/TheLarkInn/aipm/pull/244)) (fa03dcf)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).