### PR TITLE
chore: release v0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.18.3"
+version = "0.19.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.18.3"
+version = "0.19.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1114,7 +1114,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.18.3"
+version = "0.19.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.18.3"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.18.3" }
+libaipm = { path = "crates/libaipm", version = "0.19.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.0] - 2026-04-07
+
+### Documentation
+- Add missing guides, docs index, and fix lint path matching docs ([#268](https://github.com/TheLarkInn/aipm/pull/268)) (e55a9fb)
+- Cross-link lint.md with configuring-lint.md and README ([#272](https://github.com/TheLarkInn/aipm/pull/272)) (5ddc7c9)
+- Fix marketplace spec format and document mp: alias ([#279](https://github.com/TheLarkInn/aipm/pull/279)) (da9ec77)
+- Add verbosity & logging guide and complete global flags reference ([#300](https://github.com/TheLarkInn/aipm/pull/300)) (a949eb3)
+
 ## [0.18.3] - 2026-04-07
 
 ### Documentation

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.0] - 2026-04-07
+
+### Documentation
+- Add missing guides, docs index, and fix lint path matching docs ([#268](https://github.com/TheLarkInn/aipm/pull/268)) (e55a9fb)
+- Cross-link lint.md with configuring-lint.md and README ([#272](https://github.com/TheLarkInn/aipm/pull/272)) (5ddc7c9)
+- Fix marketplace spec format and document mp: alias ([#279](https://github.com/TheLarkInn/aipm/pull/279)) (da9ec77)
+- Add verbosity & logging guide and complete global flags reference ([#300](https://github.com/TheLarkInn/aipm/pull/300)) (a949eb3)
+
+### Features
+- Add marketplace and plugin.json lint rules (#287, #288, #289, #290) ([#296](https://github.com/TheLarkInn/aipm/pull/296)) (bef9f3d)
+
 ## [0.18.3] - 2026-04-07
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.0] - 2026-04-07
+
+### Bug Fixes
+- Correct help_text direction for hook/legacy-event-name rule ([#299](https://github.com/TheLarkInn/aipm/pull/299)) (33e35f0)
+
+### Documentation
+- Add missing guides, docs index, and fix lint path matching docs ([#268](https://github.com/TheLarkInn/aipm/pull/268)) (e55a9fb)
+- Cross-link lint.md with configuring-lint.md and README ([#272](https://github.com/TheLarkInn/aipm/pull/272)) (5ddc7c9)
+- Fix marketplace spec format and document mp: alias ([#279](https://github.com/TheLarkInn/aipm/pull/279)) (da9ec77)
+- Add verbosity & logging guide and complete global flags reference ([#300](https://github.com/TheLarkInn/aipm/pull/300)) (a949eb3)
+
+### Features
+- Add marketplace and plugin.json lint rules (#287, #288, #289, #290) ([#296](https://github.com/TheLarkInn/aipm/pull/296)) (bef9f3d)
+
+### Testing
+- Cover empty cache index and reconciler raw_content branches (f988cc4)
+- Cover three missed branches (b5ca98d)
+- Cover unknown-field branch in output_style_detector and read_dir error in skill_detector (581b787)
+- Cover unknown migrate source fallback and adaptor error paths (3d170a6)
+- Cover fs.exists collision branch in emit_other_files (dcd2e5a)
+- Cover hook/rewrite missed branches for 90.83% branch coverage (f1b48f8)
+- Cover quote/tab/dollar terminator branches in extract_script_references (b9aab2f)
+- Cover empty-files branch in write_artifact_section (c25a6c3)
+
 ## [0.18.3] - 2026-04-07
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.18.3 -> 0.19.0 (⚠ API breaking changes)
* `aipm`: 0.18.3 -> 0.19.0
* `aipm-pack`: 0.18.3 -> 0.19.0

### ⚠ `libaipm` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant FeatureKind:Marketplace in /tmp/.tmpRkUVQm/aipm/crates/libaipm/src/discovery.rs:20
  variant FeatureKind:PluginJson in /tmp/.tmpRkUVQm/aipm/crates/libaipm/src/discovery.rs:22
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.19.0] - 2026-04-07

### Bug Fixes
- Correct help_text direction for hook/legacy-event-name rule ([#299](https://github.com/TheLarkInn/aipm/pull/299)) (33e35f0)

### Documentation
- Add missing guides, docs index, and fix lint path matching docs ([#268](https://github.com/TheLarkInn/aipm/pull/268)) (e55a9fb)
- Cross-link lint.md with configuring-lint.md and README ([#272](https://github.com/TheLarkInn/aipm/pull/272)) (5ddc7c9)
- Fix marketplace spec format and document mp: alias ([#279](https://github.com/TheLarkInn/aipm/pull/279)) (da9ec77)
- Add verbosity & logging guide and complete global flags reference ([#300](https://github.com/TheLarkInn/aipm/pull/300)) (a949eb3)

### Features
- Add marketplace and plugin.json lint rules (#287, #288, #289, #290) ([#296](https://github.com/TheLarkInn/aipm/pull/296)) (bef9f3d)

### Testing
- Cover empty cache index and reconciler raw_content branches (f988cc4)
- Cover three missed branches (b5ca98d)
- Cover unknown-field branch in output_style_detector and read_dir error in skill_detector (581b787)
- Cover unknown migrate source fallback and adaptor error paths (3d170a6)
- Cover fs.exists collision branch in emit_other_files (dcd2e5a)
- Cover hook/rewrite missed branches for 90.83% branch coverage (f1b48f8)
- Cover quote/tab/dollar terminator branches in extract_script_references (b9aab2f)
- Cover empty-files branch in write_artifact_section (c25a6c3)
</blockquote>

## `aipm`

<blockquote>

## [0.19.0] - 2026-04-07

### Documentation
- Add missing guides, docs index, and fix lint path matching docs ([#268](https://github.com/TheLarkInn/aipm/pull/268)) (e55a9fb)
- Cross-link lint.md with configuring-lint.md and README ([#272](https://github.com/TheLarkInn/aipm/pull/272)) (5ddc7c9)
- Fix marketplace spec format and document mp: alias ([#279](https://github.com/TheLarkInn/aipm/pull/279)) (da9ec77)
- Add verbosity & logging guide and complete global flags reference ([#300](https://github.com/TheLarkInn/aipm/pull/300)) (a949eb3)

### Features
- Add marketplace and plugin.json lint rules (#287, #288, #289, #290) ([#296](https://github.com/TheLarkInn/aipm/pull/296)) (bef9f3d)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.19.0] - 2026-04-07

### Documentation
- Add missing guides, docs index, and fix lint path matching docs ([#268](https://github.com/TheLarkInn/aipm/pull/268)) (e55a9fb)
- Cross-link lint.md with configuring-lint.md and README ([#272](https://github.com/TheLarkInn/aipm/pull/272)) (5ddc7c9)
- Fix marketplace spec format and document mp: alias ([#279](https://github.com/TheLarkInn/aipm/pull/279)) (da9ec77)
- Add verbosity & logging guide and complete global flags reference ([#300](https://github.com/TheLarkInn/aipm/pull/300)) (a949eb3)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).