### PR TITLE
chore: release v0.19.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1114,7 +1114,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.19.3" }
+libaipm = { path = "crates/libaipm", version = "0.19.4" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.4] - 2026-04-10
+
+### Testing
+- Cover dot-directory branch in init command (b71b223)
+- Cover format_steps empty-input branch in aipm-pack wizard (59ce63b)
+
 ## [0.19.3] - 2026-04-08
 
 ## [0.19.2] - 2026-04-08

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.4] - 2026-04-10
+
+### Testing
+- Cover wizard Text validate=false/no-help branches and engine marketplace_manifest_path (f764d63)
+
 ## [0.19.3] - 2026-04-08
 
 ## [0.19.2] - 2026-04-08

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.4] - 2026-04-10
+
+### Bug Fixes
+- Eliminate unreachable None branches in glob_match (04ab684)
+
+### Testing
+- Cover is_dir True branch in acquire_local (70d6f20)
+- Eliminate uncovered if-let branch in hooks test (db46338)
+- Cover symlink-skipping branch in copy_dir_recursive (b4690f5)
+- Fix MockFs setup to cover registered_entries None branch (e7905ef)
+- Cover wizard Text validate=false/no-help branches and engine marketplace_manifest_path (f764d63)
+- Cover put() when old entry dir is already removed (7f571a6)
+- Cover BrokenPaths::check_file root-path no-parent branch (2cafaaf)
+- Cover has_hooks_yaml and non-empty hook_paths branch (5223f6e)
+- Cover wildcard arm in write_cleanup_plan match (081283b)
+- Cover the `_ =>` fallback branch in `is_valid_event` (09c6f01)
+- Cover setup_skill dedup False branch in skill_missing_name (345aac6)
+- Cover update() false-branch when assembled dir exists but checksum stale (8dcc49d)
+- Cover make_temp_dir existing-dir cleanup branch in claude adaptor (7762175)
+- Cover lockfile-pin conflict in backtrack_and_retry (5e08e40)
+
 ## [0.19.3] - 2026-04-08
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.19.3 -> 0.19.4 (✓ API compatible changes)
* `aipm`: 0.19.3 -> 0.19.4
* `aipm-pack`: 0.19.3 -> 0.19.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.19.4] - 2026-04-10

### Bug Fixes
- Eliminate unreachable None branches in glob_match (04ab684)

### Testing
- Cover is_dir True branch in acquire_local (70d6f20)
- Eliminate uncovered if-let branch in hooks test (db46338)
- Cover symlink-skipping branch in copy_dir_recursive (b4690f5)
- Fix MockFs setup to cover registered_entries None branch (e7905ef)
- Cover wizard Text validate=false/no-help branches and engine marketplace_manifest_path (f764d63)
- Cover put() when old entry dir is already removed (7f571a6)
- Cover BrokenPaths::check_file root-path no-parent branch (2cafaaf)
- Cover has_hooks_yaml and non-empty hook_paths branch (5223f6e)
- Cover wildcard arm in write_cleanup_plan match (081283b)
- Cover the `_ =>` fallback branch in `is_valid_event` (09c6f01)
- Cover setup_skill dedup False branch in skill_missing_name (345aac6)
- Cover update() false-branch when assembled dir exists but checksum stale (8dcc49d)
- Cover make_temp_dir existing-dir cleanup branch in claude adaptor (7762175)
- Cover lockfile-pin conflict in backtrack_and_retry (5e08e40)
</blockquote>

## `aipm`

<blockquote>

## [0.19.4] - 2026-04-10

### Testing
- Cover wizard Text validate=false/no-help branches and engine marketplace_manifest_path (f764d63)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.19.4] - 2026-04-10

### Testing
- Cover dot-directory branch in init command (b71b223)
- Cover format_steps empty-input branch in aipm-pack wizard (59ce63b)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).