### PR TITLE
docs: add feature status audit, eisdir crash research, and fix spec

### DIFF
--- a/research/docs/2026-04-06-feature-status-audit.md
+++ b/research/docs/2026-04-06-feature-status-audit.md
@@ -1,0 +1,268 @@
+---
+date: 2026-04-06 22:45:00 UTC
+researcher: Claude Opus 4.6
+git_commit: 332da9bd3051a3249185e7591d733ced7573997a
+branch: main
+repository: aipm
+topic: "Comprehensive feature status audit — what works, what's partial, what's stubbed"
+tags: [research, codebase, audit, roadmap, feature-status, cli, library]
+status: complete
+last_updated: 2026-04-06
+last_updated_by: Claude Opus 4.6
+---
+
+# Feature Status Audit
+
+## Research Question
+
+Review all docs, guides, README, fixtures, tests, and GitHub issues to produce a comprehensive assessment of what features actually work vs. what is stubbed or unimplemented. Inform roadmap realignment.
+
+## Executive Summary
+
+**aipm is further along than the README roadmap suggests.** The library layer (`libaipm`) has **27 fully-implemented modules** with **~1,600 unit tests** and **89%+ branch coverage**. Most CLI commands work end-to-end. The primary bottleneck is the **StubRegistry** in the `aipm` binary — the library has a real `GitRegistry` implementation, but the binary hardcodes a stub that always errors, blocking `install` and `update` for registry-sourced packages.
+
+All 16 roadmap GitHub issues (#1–#15, #54) remain **open**, but the underlying library code for many of them is already implemented and tested at the unit level. The gap is in **wiring library code to CLI commands** and **BDD end-to-end coverage**.
+
+---
+
+## CLI Command Status Matrix
+
+| Binary | Command | Status | What Works | What Doesn't |
+|--------|---------|--------|------------|--------------|
+| `aipm` | `init` | **WORKING** | Workspace scaffolding, `.ai/` marketplace, starter plugin, Claude/Copilot adaptors, interactive wizard, all flags | — |
+| `aipm` | `install` (local) | **PARTIAL** | Lockfile validation (`--locked`), workspace dep resolution, manifest editing, link state, gitignore | Registry downloads (StubRegistry), path deps, `--registry` flag |
+| `aipm` | `install --global` | **WORKING** | Metadata registry (`~/.aipm/installed.json`), engine scoping, cache policy | Does not deploy files — records specs only |
+| `aipm` | `update` | **PARTIAL** | Manifest parsing, lockfile pin manipulation, workspace dep logic | Registry resolution/download (StubRegistry) |
+| `aipm` | `link` | **WORKING** | Symlink creation, link state tracking, manifest validation | — |
+| `aipm` | `unlink` | **WORKING** | Unlink, link state cleanup, gitignore cleanup | — |
+| `aipm` | `uninstall` (local) | **WORKING** | Delegates to unlink pipeline | — |
+| `aipm` | `uninstall --global` | **WORKING** | Per-engine removal, full uninstall, file-locked writes | — |
+| `aipm` | `list` | **WORKING** | Local (lockfile + linked packages), global (`installed.json`) | — |
+| `aipm` | `lint` | **WORKING** | 14 rules, 4 reporters (human/json/ci-github/ci-azure), config from `aipm.toml`, recursive discovery | — |
+| `aipm` | `migrate` | **WORKING** | All 6 artifact types, recursive discovery, dry-run, `--destructive`, conflict resolution, external ref detection | — |
+| `aipm-pack` | `init` | **WORKING** | Plugin scaffolding for all 6 types, interactive wizard, manifest generation | — |
+| `aipm-pack` | `pack` | **NOT IMPLEMENTED** | — | Command does not exist (mentioned in doc comment only) |
+| `aipm-pack` | `publish` | **NOT IMPLEMENTED** | — | Command does not exist |
+| `aipm-pack` | `yank` | **NOT IMPLEMENTED** | — | Command does not exist |
+| `aipm-pack` | `login` | **NOT IMPLEMENTED** | — | Command does not exist |
+
+### Key Architectural Finding
+
+The library at [`crates/libaipm/src/registry/git.rs`](https://github.com/TheLarkInn/aipm/blob/332da9bd3051a3249185e7591d733ced7573997a/crates/libaipm/src/registry/git.rs) has a real `GitRegistry` implementation that clones/fetches a package index and downloads tarballs via HTTP with SHA-512 verification. However, the `aipm` binary at [`crates/aipm/src/main.rs:215-239`](https://github.com/TheLarkInn/aipm/blob/332da9bd3051a3249185e7591d733ced7573997a/crates/aipm/src/main.rs#L215-L239) hardcodes a `StubRegistry` with the comment: *"placeholder until GitRegistry (git2/reqwest) is implemented"*. **Wiring the real registry to the CLI would unblock `install` and `update` for registry packages.**
+
+---
+
+## Library Module Status (all 27 modules)
+
+Every module in `libaipm` is **COMPLETE** — fully implemented with unit tests, no stubs or TODOs in production code.
+
+| Module | Tests | Description |
+|--------|-------|-------------|
+| manifest | 47 | Parse, validate, load `aipm.toml` |
+| init | 24 | Plugin package scaffolding |
+| workspace_init | 44 | Workspace + `.ai/` marketplace scaffolding |
+| workspace | 13 | Workspace root discovery, member glob expansion |
+| migrate | 438 | Full migration with 10 detectors, 6 artifact types |
+| lint | 244 | 14 rules, config, diagnostics, 4 reporters |
+| discovery | 26 | Gitignore-aware recursive plugin discovery |
+| installer | 85 | Install/update pipeline, manifest editing |
+| linker | 56 | Hard links, dir links, gitignore, security, state |
+| lockfile | 31 | Deterministic lockfile, reconciliation |
+| resolver | 69 | Backtracking constraint solver, overrides |
+| store | 43 | Content-addressable store, SHA-512 |
+| registry | 57 | Git-based registry, config routing, index |
+| logging | 5 | Layered tracing subscriber |
+| frontmatter | 38 | YAML front-matter parsing |
+| fs | 11 | Trait-based filesystem abstraction |
+| version | 22 | Semver parsing and comparison |
+| spec | 111 | Multi-source plugin spec parsing |
+| acquirer | 17 | Plugin acquisition pipeline |
+| cache | 29 | Download cache with TTL policies |
+| engine | 13 | Multi-engine validation |
+| installed | 37 | Global installed plugin registry |
+| locked_file | 7 | OS-level file locking |
+| marketplace | 30 | Marketplace manifest parsing |
+| path_security | 20 | Path traversal prevention |
+| platform | 11 | Platform compatibility checking |
+| security | 16 | Source allowlist enforcement |
+| **TOTAL** | **~1,600** | |
+
+---
+
+## BDD Test Coverage Gap
+
+Of **31 feature files** containing **324 scenarios**, only **4 files (57 scenarios)** have backing step definitions that run in CI:
+
+| Feature File | Scenarios | Status |
+|---|---|---|
+| `manifest/init.feature` | 6 | **Running** |
+| `manifest/versioning.feature` | 5 | **Running** |
+| `manifest/workspace-init.feature` | 26 | **Running** |
+| `manifest/migrate.feature` | 20 | **Running** |
+| All other 27 files | 267 | **Spec-only** (no step definitions) |
+
+The 267 unimplemented BDD scenarios serve as executable specifications for future features. Many of the features they describe (resolution, lockfile, linking, security) are already unit-tested in the library but lack end-to-end CLI integration tests.
+
+---
+
+## GitHub Issues Status
+
+### Roadmap Issues — ALL 16 OPEN
+
+| # | Category | Title | Library Status |
+|---|----------|-------|----------------|
+| 1 | Dependencies | Resolution | **Library complete** (69 resolver tests) |
+| 2 | Dependencies | Lockfile | **Library complete** (31 lockfile tests) |
+| 3 | Dependencies | Features | **Library complete** (feature flags in resolver) |
+| 4 | Dependencies | Patching | **Not implemented** |
+| 5 | Registry | Install | **Library partial** (85 installer tests, but StubRegistry in CLI) |
+| 6 | Registry | Publish | **Not implemented** (no `pack`/`publish` commands) |
+| 7 | Registry | Security | **Library partial** (security module exists, no `audit` command) |
+| 8 | Registry | Yank | **Not implemented** (no `yank` command) |
+| 9 | Registry | Link | **Library complete** (56 linker tests, CLI works) |
+| 10 | Registry | Local & Registry Coexistence | **Library partial** (linking works, registry integration missing) |
+| 11 | Monorepo | Orchestration | **Not implemented** (workspace loading exists, no orchestration) |
+| 12 | Environment | Dependencies | **Not implemented** (manifest field exists, no `doctor` command) |
+| 13 | Guardrails | Quality | **Library partial** (lint works, no publish-gate scoring) |
+| 14 | Reuse | Compositional Reuse | **Library partial** (spec/acquirer/marketplace modules exist) |
+| 15 | Portability | Cross-Stack | **Partial** (Claude + Copilot adaptors, no Cursor) |
+| 54 | Environment | Host Versioning | **Not implemented** |
+
+### Non-Roadmap Open Issues (11)
+
+| # | Title | Category |
+|---|-------|----------|
+| 126 | aipm-pack init should auto-detect `.claude-plugin/plugin.json` | Enhancement |
+| 127 | aipm-pack init can initialize every package in marketplace | Enhancement |
+| 128 | aipm install inside plugin cwd shouldn't modify plugin manifest | Bug |
+| 132 | CI: Analyze latest claude/copilot/opencode runtimes for API changes | CI |
+| 183 | Lint: validate runtime requirements for plugins | New rule |
+| 185 | Lint: new rule — prevent long instructions | New rule |
+| 199 | [aw] No-Op Runs | Bot noise |
+| 204 | Installer: Front page installer links broken | Bug |
+| 205 | Lint: new AI reporter (auto-enable) | Enhancement |
+| 206 | Lint: skill/oversized doesn't explain why 15000 char limit | Docs |
+| 237 | [aw] Coverage Improver failed | Bot noise |
+
+### Closed Feature Issues (shipped)
+
+| # | Title |
+|---|-------|
+| 30 | Better default plugin |
+| 74 | .gitignore update for tool-usage.log |
+| 110 | Make `aipm lint` |
+| 111 | `aipm migrate --destructive` flag |
+| 123 | Migrate: handle all files |
+| 129 | Workspace dependencies link |
+| 170 | Fix installer README paths |
+| 187 | Lint: recursive discovery for misplaced features |
+| 189 | Implement verbosity levels |
+| 198 | Lint display UX |
+| 208 | Lint recursion in `.github` folder |
+
+---
+
+## Test Infrastructure Summary
+
+| Category | Count |
+|----------|-------|
+| Fixture workspaces | 4 (33 files total) |
+| BDD feature files | 31 (324 scenarios) |
+| BDD scenarios running | 57 (4 feature files) |
+| CLI integration tests | 7 (`assert_cmd`-based) |
+| Inline `#[cfg(test)]` modules | 86 source files |
+| Snapshot files (insta) | 31 `.snap` files |
+| Total unit test functions | ~1,600 |
+| Branch coverage | 89.07% |
+
+---
+
+## Feature Parity with Other Tools (from earlier research)
+
+The project recently implemented 10 new modules to close feature gaps with other plugin management tools:
+
+| Capability | Status | Module |
+|------------|--------|--------|
+| Download cache with TTL | **Implemented** | `cache.rs` (29 tests) |
+| Multi-engine validation | **Implemented** | `engine.rs` (13 tests) |
+| Path security (traversal) | **Implemented** | `path_security.rs` (20 tests) |
+| Platform compatibility | **Implemented** | `platform.rs` (11 tests) |
+| Multi-source plugin specs | **Implemented** | `spec.rs` (111 tests) |
+| Plugin acquirer | **Implemented** | `acquirer.rs` (17 tests) |
+| Marketplace manifests | **Implemented** | `marketplace.rs` (30 tests) |
+| Installed plugin registry | **Implemented** | `installed.rs` (37 tests) |
+| OS-level file locking | **Implemented** | `locked_file.rs` (7 tests) |
+| Source allowlist | **Implemented** | `security.rs` (16 tests) |
+
+---
+
+## What Actually Works End-to-End (User Can Run Today)
+
+1. **`aipm init`** — Scaffold a workspace with `.ai/` marketplace, tool configs, starter plugin
+2. **`aipm migrate`** — Migrate existing `.claude/` configs into marketplace plugins (all artifact types)
+3. **`aipm lint`** — Lint AI plugin configurations (14 rules, 4 output formats)
+4. **`aipm-pack init`** — Scaffold a new plugin package with manifest
+5. **`aipm link` / `unlink`** — Local development overrides via symlinks
+6. **`aipm list`** — View installed/linked packages (local and global)
+7. **`aipm install` (workspace deps only)** — Install workspace member-to-member dependencies
+8. **`aipm install --global`** — Register global plugin metadata
+
+## What Does NOT Work End-to-End
+
+1. **`aipm install <pkg>` from registry** — StubRegistry blocks all registry operations
+2. **`aipm update`** — Same StubRegistry blocker
+3. **`aipm-pack pack`** — Command does not exist
+4. **`aipm-pack publish`** — Command does not exist
+5. **`aipm-pack yank`** — Command does not exist
+6. **`aipm-pack login`** — Command does not exist
+7. **`aipm doctor`** — Command does not exist (environment validation)
+8. **`aipm audit`** — Command does not exist (security auditing)
+9. **`aipm patch`** — Command does not exist (dependency patching)
+10. **`aipm validate`** — Command does not exist (standalone manifest validation)
+
+---
+
+## Roadmap Realignment Recommendations
+
+### Tier 1: Quick Wins (library code exists, just needs CLI wiring)
+
+- **Wire GitRegistry to CLI** — Replace StubRegistry with real GitRegistry. Library is ready. Unblocks `install` and `update` for registry packages.
+- **Enable `validation.feature` BDD scenarios** — Library has `parse_and_validate`, just needs a CLI entry point or updated BDD steps.
+- **Close issue #9 (Link)** — `aipm link` / `unlink` is fully working. Issue can be closed.
+
+### Tier 2: Moderate Effort (library partially ready)
+
+- **Enable remaining BDD scenarios** — 267 scenarios across 27 files. Many test features already implemented in the library. Incrementally enable as step definitions are written.
+- **Publish pipeline** — `aipm-pack pack` / `publish` / `yank` / `login` commands. No library code exists.
+- **Environment validation** — `aipm doctor` command. Manifest field `[environment]` exists, needs checker logic.
+
+### Tier 3: Significant Effort (new features)
+
+- **Monorepo orchestration** — Workspace loading/discovery exists, but no filtering, ordering, or CI integration.
+- **Dependency patching** — No library code exists.
+- **Cross-stack portability** — Claude + Copilot adaptors exist. Cursor adaptor not started.
+
+---
+
+## Code References
+
+- [`crates/aipm/src/main.rs`](https://github.com/TheLarkInn/aipm/blob/332da9bd3051a3249185e7591d733ced7573997a/crates/aipm/src/main.rs) — Consumer CLI dispatch
+- [`crates/aipm-pack/src/main.rs`](https://github.com/TheLarkInn/aipm/blob/332da9bd3051a3249185e7591d733ced7573997a/crates/aipm-pack/src/main.rs) — Author CLI dispatch
+- [`crates/libaipm/src/lib.rs`](https://github.com/TheLarkInn/aipm/blob/332da9bd3051a3249185e7591d733ced7573997a/crates/libaipm/src/lib.rs) — Library module exports
+- [`crates/libaipm/tests/bdd.rs`](https://github.com/TheLarkInn/aipm/blob/332da9bd3051a3249185e7591d733ced7573997a/crates/libaipm/tests/bdd.rs) — BDD test runner (filters to 4 feature files)
+- [`crates/libaipm/src/registry/git.rs`](https://github.com/TheLarkInn/aipm/blob/332da9bd3051a3249185e7591d733ced7573997a/crates/libaipm/src/registry/git.rs) — Real GitRegistry (not wired to CLI)
+
+## Historical Context (from research/)
+
+- `research/docs/2026-04-06-plugin-system-feature-parity-analysis.md` — Feature parity analysis with other plugin tools
+- `research/docs/2026-03-26-install-update-link-lockfile-implementation.md` — Install/update/link/lockfile implementation readiness
+- `research/docs/2026-03-31-110-aipm-lint-architecture-research.md` — Lint system architecture
+- `research/docs/2026-03-23-aipm-migrate-command.md` — Migration command design
+- `research/docs/2026-03-19-test-inventory-and-gating-strategy.md` — Test infrastructure strategy
+
+## Open Questions
+
+1. **When should the StubRegistry be replaced?** The library has a working GitRegistry with 23 tests. What's blocking the wiring — is it the git2/reqwest dependency concern noted in the stub comment, or is a registry server needed first?
+2. **Should closed roadmap issues be batched?** Issues #1 (Resolution), #2 (Lockfile), #3 (Features), #9 (Link) have significant library implementations. Should they be partially closed or relabeled to track only remaining CLI/BDD work?
+3. **What's the priority for aipm-pack commands?** `pack`, `publish`, `yank`, `login` have zero implementation. Are these blocked on the registry server existing?
+4. **Is the installer link (#204) a release blocker?** The front-page installer links are reported broken.

--- a/research/docs/2026-04-07-313-migrate-eisdir-crash.md
+++ b/research/docs/2026-04-07-313-migrate-eisdir-crash.md
@@ -1,0 +1,216 @@
+---
+date: 2026-04-07
+researcher: Claude
+git_commit: d8783d6b889c60393524d934006c6172613bf217
+branch: main
+repository: aipm
+topic: "Issue #313: aipm migrate crashes with 'Is a directory (os error 21)' on recursive run"
+tags: [research, codebase, migrate, eisdir, discovery, logging]
+status: complete
+last_updated: 2026-04-07
+last_updated_by: Claude
+---
+
+# Research: Issue #313 — `aipm migrate` EISDIR Crash
+
+## Research Question
+
+What code path in the recursive migration (no `--source`) differs from the single-source and dry-run paths, and where could it attempt a file operation on a directory (triggering EISDIR/os error 21)? Additionally, is there adequate logging to debug the discovery and emission algorithms?
+
+## Summary
+
+The EISDIR error originates in the **emit phase** of the recursive migration pipeline, which is the only phase that runs in the non-dry-run recursive path but not in the dry-run or single-source paths. The error propagates through `migrate::Error::Io` with `#[error(transparent)]`, which **strips all context** — no file path, no function name, no operation type — making diagnosis impossible from the error message alone.
+
+The logging coverage across the migration pipeline is **critically sparse**: only 8 tracing calls exist across ~20 source files. The core pipeline orchestration functions (`migrate`, `migrate_recursive`, `emit_and_register`), all 11 detectors (except copilot_extension_detector), the reconciler, and the registrar have **zero logging**. The `discover_source_dirs` function used by recursive mode also has zero logging.
+
+## Detailed Findings
+
+### 1. How the three code paths diverge
+
+| Path | Discovery | Detection | Reconcile | Emit | Register |
+|------|-----------|-----------|-----------|------|----------|
+| `--dry-run` (recursive) | `discover_source_dirs` | Parallel detectors | `reconciler::reconcile` | **Skipped** (returns at [mod.rs:515](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/mod.rs#L515)) | Skipped |
+| `--source .github` | Manual path join | Sequential detectors | `reconciler::reconcile` | `emit_plugin` per artifact | `register_plugins` |
+| Recursive (no flags) | `discover_source_dirs` | Parallel detectors (rayon) | `reconciler::reconcile` | **`emit_and_register`** (parallel rayon) | `register_plugins` |
+
+The dry-run never reaches the emit phase. The single-source path processes only the specified directory. The recursive path discovers ALL `.claude/` and `.github/` directories and emits them in parallel.
+
+### 2. Where EISDIR can be triggered
+
+All filesystem operations ultimately go through the `Fs` trait ([fs.rs:25-84](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/fs.rs#L25-L84)). The `Real` implementation delegates directly to `std::fs`. On Linux, these operations produce EISDIR (os error 21) when given a directory path:
+
+- `std::fs::read_to_string(dir_path)` → EISDIR
+- `std::fs::File::create(dir_path)` → EISDIR (used by `Real::write_file`)
+
+#### Risk-ranked locations in the emit phase
+
+**HIGH — `emit_other_files`** ([emitter.rs:747-750](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/emitter.rs#L747-L750)):
+```rust
+if fs.exists(&file.path) {
+    let content = fs.read_to_string(&file.path)?;
+    fs.write_file(&dest, content.as_bytes())?;
+}
+```
+- `file.path` comes from `collect_files_recursive` → `collect_all_files` in the reconciler
+- The `collect_files_recursive` function ([skill_common.rs:172-191](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/skill_common.rs#L172-L191)) filters directories via `DirEntry.is_dir`, but **symlinks to directories have `is_dir = false`** in Rust's `DirEntry::file_type()`, so they pass through as "files"
+- `fs.exists()` follows symlinks and returns `true` for symlinked directories
+- `fs.read_to_string()` follows the symlink, finds a directory → EISDIR
+
+**HIGH — `emit_skill_files`** ([emitter.rs:146](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/emitter.rs#L146)):
+```rust
+let content = fs.read_to_string(&source)?;
+```
+- `source` from `artifact.files` populated by `collect_files_recursive` — same symlink vulnerability
+
+**MEDIUM — `copy_referenced_scripts`** ([emitter.rs:678-686](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/emitter.rs#L678-L686)):
+```rust
+if fs.exists(&source) {
+    let content = fs.read_to_string(&source)?;
+    fs.write_file(&dest, content.as_bytes())?;
+}
+```
+- `source` from `artifact.referenced_scripts` (parsed from markdown content)
+- Has `fs.exists()` check but no `is_file()` check
+
+**MEDIUM — `emit_command_as_skill`** ([emitter.rs:161](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/emitter.rs#L161)), **`emit_agent_files`** ([emitter.rs:515](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/emitter.rs#L515)), **`emit_output_style`** ([emitter.rs:557](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/emitter.rs#L557)):
+- All call `fs.read_to_string(&artifact.source_path)` where `source_path` was set by detectors using `is_dir` guards that wouldn't catch symlinks
+
+**LOW — `emit_mcp_config`, `emit_hooks_config`, `emit_lsp_config`** ([emitter.rs:526-574](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/emitter.rs#L526-L574)):
+- Fall back to `fs.read_to_string(&artifact.source_path)` only when `raw_content` is `None`
+- Source paths are hardcoded filenames (e.g., `settings.json`, `.mcp.json`) — low risk
+
+### 3. The `Fs` trait lacks `is_file()`
+
+The `Fs` trait ([fs.rs:25-84](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/fs.rs#L25-L84)) provides `exists()` but no `is_file()` or `is_dir()` method. The only way to distinguish files from directories is through the `DirEntry.is_dir` field returned by `read_dir()`. This means:
+- No code can perform a secondary filesystem check before `read_to_string` or `write_file`
+- Symlinks to directories are invisible — they pass `!is_dir` but fail on read
+
+### 4. Error context is completely stripped
+
+The error chain:
+1. `std::io::Error { kind: IsADirectory, message: "Is a directory (os error 21)" }` — raw OS error
+2. `migrate::Error::Io(io_error)` — via `#[from] std::io::Error` ([mod.rs:293-294](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/mod.rs#L293-L294))
+3. `#[error(transparent)]` — passes through the raw message with zero added context
+4. CLI prints `error: Is a directory (os error 21)` ([main.rs:1017](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/aipm/src/main.rs#L1017))
+
+No information about which file, function, source directory, or plugin plan caused the error.
+
+### 5. Logging coverage audit
+
+**Framework**: `tracing = "0.1"` with dual-layer subscriber — stderr (controlled by `AIPM_LOG` env var or CLI verbosity) + file layer (always DEBUG, daily rotation, `<temp_dir>/aipm-*.log`). Setup in [logging.rs:67-112](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/logging.rs#L67-L112).
+
+| Level | Count | Where |
+|-------|-------|-------|
+| `trace!` | 4 calls | `discovery.rs` only (`discover_features` walk) |
+| `debug!` | 3 calls | `cleanup.rs` (1), `copilot_extension_detector.rs` (2) |
+| `info!` | 0 | None in migration/discovery |
+| `warn!` | 1 call | `emitter.rs` (extension file read failure) |
+| `error!` | 0 | None in migration/discovery |
+| **Total** | **8 calls** | across ~20 source files |
+
+**Zero `#[instrument]` attributes** in the entire codebase.
+
+**Functions with ZERO logging** (critical path highlighted):
+
+| Function | File | Why it matters |
+|----------|------|----------------|
+| **`migrate()`** | [mod.rs:322](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/mod.rs#L322) | Top-level entry — no mode selection log |
+| **`migrate_recursive()`** | [mod.rs:443](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/mod.rs#L443) | No log of discovered dirs or plan count |
+| **`emit_and_register()`** | [mod.rs:531](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/mod.rs#L531) | No log of which plugins are being emitted |
+| **`discover_source_dirs()`** | [discovery.rs:101](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/discovery.rs#L101) | Zero logging (contrast: sibling `discover_features` has 4 trace calls) |
+| **`emit_other_files()`** | [emitter.rs:699](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/emitter.rs#L699) | No log of which files are being read/written |
+| **`reconcile()`** | [reconciler.rs:23](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/reconciler.rs#L23) | No log of file counts or unclaimed files |
+| **`collect_files_recursive()`** | [skill_common.rs:172](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/skill_common.rs#L172) | No log of entries found, dirs recursed, files collected |
+| **`register_plugins()`** | [registrar.rs:10](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/registrar.rs#L10) | No log of which plugins are being registered |
+| All 10 detectors (except copilot_extension_detector) | `*_detector.rs` | No log of what they scan, find, or skip |
+
+### 6. `collect_files_recursive` — the single gatekeeper
+
+[skill_common.rs:172-191](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/skill_common.rs#L172-L191) is the single function responsible for preventing directory paths from entering file lists:
+
+```rust
+pub fn collect_files_recursive(dir: &Path, base: &Path, fs: &dyn Fs) -> Result<Vec<PathBuf>, Error> {
+    let mut files = Vec::new();
+    let entries = fs.read_dir(dir)?;
+    for entry in entries {
+        let full_path = dir.join(&entry.name);
+        if entry.is_dir {
+            let sub_files = collect_files_recursive(&full_path, base, fs)?;
+            files.extend(sub_files);
+        } else if let Ok(relative) = full_path.strip_prefix(base) {
+            files.push(relative.to_path_buf());
+        }
+    }
+    Ok(files)
+}
+```
+
+The `entry.is_dir` check depends on `Real::read_dir()` ([fs.rs:109-120](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/fs.rs#L109-L120)), which uses `entry.file_type()?.is_dir()`. On Linux:
+- Regular directories: `is_dir() = true` → recursed into (correct)
+- Regular files: `is_dir() = false` → added to list (correct)
+- **Symlinks to directories**: `file_type().is_dir() = false` → **added to list as a file** (BUG — will cause EISDIR when read)
+- **Symlinks to files**: `file_type().is_dir() = false` → added to list as a file (correct — read follows symlink to the file)
+
+### 7. Difference between dry-run and emit paths
+
+The dry-run path ([mod.rs:515-524](https://github.com/TheLarkInn/aipm/blob/d8783d6b889c60393524d934006c6172613bf217/crates/libaipm/src/migrate/mod.rs#L515-L524)) only accesses `OtherFile` metadata (name, path, associations) for report generation. It **never calls `fs.read_to_string()`** on the other file paths. This is why dry-run succeeds even when the file list contains a directory path.
+
+## Code References
+
+- `crates/libaipm/src/migrate/mod.rs:322` — `migrate()` entry point
+- `crates/libaipm/src/migrate/mod.rs:443` — `migrate_recursive()` — recursive pipeline
+- `crates/libaipm/src/migrate/mod.rs:531` — `emit_and_register()` — parallel emission
+- `crates/libaipm/src/migrate/mod.rs:293-294` — `Error::Io` with `#[error(transparent)]`
+- `crates/libaipm/src/discovery.rs:101` — `discover_source_dirs()` — zero logging
+- `crates/libaipm/src/migrate/emitter.rs:699-761` — `emit_other_files()` — primary EISDIR risk
+- `crates/libaipm/src/migrate/emitter.rs:130-154` — `emit_skill_files()` — secondary risk
+- `crates/libaipm/src/migrate/emitter.rs:641-690` — `copy_referenced_scripts()` — tertiary risk
+- `crates/libaipm/src/migrate/skill_common.rs:172-191` — `collect_files_recursive()` — symlink gap
+- `crates/libaipm/src/fs.rs:25-84` — `Fs` trait — no `is_file()` method
+- `crates/libaipm/src/fs.rs:109-120` — `Real::read_dir()` — `is_dir` from `file_type()`
+- `crates/libaipm/src/logging.rs:67-112` — Logging framework setup
+- `crates/aipm/src/main.rs:1017` — Error display (no context)
+
+## Architecture Documentation
+
+### Migration pipeline flow (recursive)
+```
+cmd_migrate (main.rs:834)
+  → migrate (mod.rs:322)
+    → migrate_recursive (mod.rs:443)
+      → discover_source_dirs (discovery.rs:101)           [NO LOGGING]
+      → par_iter over discovered dirs (rayon)
+        → detectors_for_source → detect()                 [NO LOGGING in 10/11 detectors]
+        → reconciler::reconcile                            [NO LOGGING]
+          → collect_all_files → collect_files_recursive    [NO LOGGING, SYMLINK GAP]
+      → if dry_run: generate_report → return               [WHY DRY-RUN WORKS]
+      → emit_and_register (mod.rs:531)                     [NO LOGGING]
+        → par_iter over plans (rayon)
+          → emit_plugin_with_name / emit_package_plugin    [NO LOGGING]
+          → emit_other_files                               [NO LOGGING, EISDIR HERE]
+        → register_plugins                                 [NO LOGGING]
+```
+
+### Logging framework
+- **Crate**: `tracing = "0.1"` — workspace dependency
+- **Subscriber**: dual-layer — stderr (AIPM_LOG / verbosity) + file (always DEBUG, daily rotation, `<temp_dir>/aipm-*.log`)
+- **Zero `#[instrument]`** attributes in the codebase
+
+## Historical Context (from research/)
+
+- `research/docs/2026-03-23-recursive-claude-discovery-parallel-migrate.md` — Original design for recursive discovery
+- `research/docs/2026-04-01-migrate-file-discovery-classification.md` — File discovery and classification research
+- `research/docs/2026-04-01-migrate-file-movement-paths.md` — File movement paths during migration
+- `research/docs/2026-04-01-migrate-dry-run-report.md` — Dry-run report design
+
+## Related Research
+
+- `specs/2026-03-23-recursive-migrate-discovery.md` — Design spec for recursive discovery
+- `specs/2026-04-01-migrate-other-files-and-dependency-tracking.md` — Other files handling spec
+
+## Open Questions
+
+1. **Does the user's monorepo contain symlinks inside `.claude/` or `.github/` directories?** A symlink-to-directory inside a source dir would be the simplest explanation for EISDIR.
+2. **Which specific `fs.*` operation triggers the error?** Without path-annotated errors or logging, this cannot be determined from the error message alone.
+3. **Does the error occur during `read_to_string` or `write_file`?** Both can trigger EISDIR for different reasons.
+4. **Are there any unusual directory entries (e.g., named pipes, device files, mount points) in the source directories?** These would also cause unexpected behavior.

--- a/specs/2026-04-07-fix-migrate-eisdir-crash-and-add-logging.md
+++ b/specs/2026-04-07-fix-migrate-eisdir-crash-and-add-logging.md
@@ -1,0 +1,383 @@
+# Fix `aipm migrate` EISDIR Crash and Add Migration Pipeline Logging
+
+| Document Metadata      | Details                                                              |
+| ---------------------- | -------------------------------------------------------------------- |
+| Author(s)              | Sean Larkin                                                          |
+| Status                 | Draft (WIP)                                                          |
+| Team / Owner           | aipm                                                                 |
+| Created / Last Updated | 2026-04-07                                                           |
+| Issue                  | [#313](https://github.com/TheLarkInn/aipm/issues/313)               |
+| Research               | `research/docs/2026-04-07-313-migrate-eisdir-crash.md`               |
+
+## 1. Executive Summary
+
+`aipm migrate` (recursive, without `--source`) crashes with "Is a directory (os error 21)" on monorepos. The dry-run and single-source paths work fine. Root cause: the emit phase performs `fs.read_to_string()` on paths that may resolve to directories (e.g., symlinks to directories), and the `Fs` trait provides no `is_file()` guard. The error message contains zero path context, and the migration pipeline has near-zero diagnostic logging (8 tracing calls across ~20 files). This spec addresses both: (A) fix the EISDIR crash by adding `is_file()` to the `Fs` trait and guarding all emitter read/write sites, and (B) add structured tracing at debug/trace levels across the full migration pipeline.
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+The migration pipeline (`crates/libaipm/src/migrate/`) converts `.claude/` and `.github/` directory structures into `.ai/` marketplace plugins. The recursive code path uses `discover_source_dirs` to find source directories, runs detectors in parallel via rayon, reconciles unclaimed files, then emits plugins and registers them.
+
+The `Fs` trait (`crates/libaipm/src/fs.rs`) provides `exists()`, `read_to_string()`, `write_file()`, and `read_dir()` — but no `is_file()` or `is_dir()` methods. The `DirEntry.is_dir` boolean from `read_dir()` is the only mechanism to distinguish files from directories.
+
+The `collect_files_recursive` function (`crates/libaipm/src/migrate/skill_common.rs:172`) is the single gatekeeper that prevents directory paths from entering file lists. It filters using `DirEntry.is_dir`, which does not detect symlinks to directories (Rust's `DirEntry::file_type().is_dir()` returns `false` for symlinks).
+
+([Research reference: research/docs/2026-04-07-313-migrate-eisdir-crash.md, Sections 2-6](research/docs/2026-04-07-313-migrate-eisdir-crash.md))
+
+### 2.2 The Problem
+
+- **User Impact:** `aipm migrate` crashes on monorepos during recursive discovery, blocking adoption. The error message "Is a directory (os error 21)" provides no actionable information.
+- **Debugging Impact:** The migration pipeline has only 8 tracing calls across ~20 source files. The core orchestration functions (`migrate`, `migrate_recursive`, `emit_and_register`), all detectors (except one), the reconciler, and the registrar have zero logging. Even with `AIPM_LOG=trace`, the log file reveals nothing about the crash.
+- **Technical Debt:** 19 of 20 `fs.read_to_string`/`fs.write_file` call sites in the emitter use bare `?` propagation with no `.map_err()` — raw `std::io::Error` bubbles up through `#[error(transparent)]` with zero path context.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] `aipm migrate` (recursive) no longer crashes with EISDIR when source directories contain symlinks to directories, named pipes, or other non-regular-file entries
+- [ ] When a non-file entry is encountered during emission, it is skipped with a `tracing::warn!` message that includes the offending path
+- [ ] All IO errors in the migration pipeline include the path and operation in the error message
+- [ ] The migration pipeline has structured tracing at `debug` and `trace` levels across: discovery, detection, reconciliation, emission, and registration
+- [ ] The `Fs` trait gains an `is_file()` method with a default implementation
+- [ ] All existing tests continue to pass; new tests cover the `is_file()` guard and skip-on-EISDIR behavior
+- [ ] Coverage remains at or above the 89% branch threshold
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] We will NOT change the migration pipeline's functional behavior (what gets migrated, how plugins are structured)
+- [ ] We will NOT add `#[instrument]` attributes in this PR (may be a follow-up)
+- [ ] We will NOT add logging to detectors in this PR (scope limited to the pipeline spine and emitter)
+- [ ] We will NOT change the `Error` enum variants — we wrap IO errors with context strings, not new enum arms
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Architecture
+
+No new crates, modules, or architectural changes. This is a defensive-fix + observability enhancement within the existing `libaipm` crate.
+
+```
+[Fs trait]                      Add is_file() method
+     |
+[collect_files_recursive]       Use is_file() as secondary guard
+     |
+[emitter: all fs.* call sites]  Guard with is_file(), skip+warn on non-file
+     |
+[pipeline: mod.rs, discovery]   Add tracing at debug/trace levels
+     |
+[Error::Io]                     Wrap with path context via .map_err()
+```
+
+### 4.2 Key Components
+
+| Component | Change | Files |
+|-----------|--------|-------|
+| `Fs` trait | Add `is_file(&self, path: &Path) -> bool` with default impl | `crates/libaipm/src/fs.rs` |
+| `collect_files_recursive` | Add `is_file()` guard after `!is_dir` check | `crates/libaipm/src/migrate/skill_common.rs` |
+| Emitter call sites | Guard reads with `is_file()`, skip+warn on non-file; wrap `?` with `.map_err()` for path context | `crates/libaipm/src/migrate/emitter.rs` |
+| Pipeline orchestration | Add `tracing::debug!` / `tracing::trace!` at pipeline boundaries | `crates/libaipm/src/migrate/mod.rs` |
+| Discovery | Add `tracing::trace!` to `discover_source_dirs` (match sibling `discover_features`) | `crates/libaipm/src/discovery.rs` |
+| Reconciler | Add `tracing::debug!` summary after reconciliation | `crates/libaipm/src/migrate/reconciler.rs` |
+| Registrar | Add `tracing::debug!` for registration | `crates/libaipm/src/migrate/registrar.rs` |
+| Cleanup | Minimal (already has 1 debug call) | `crates/libaipm/src/migrate/cleanup.rs` |
+
+## 5. Detailed Design
+
+### 5.1 Add `is_file()` to the `Fs` Trait
+
+**File:** `crates/libaipm/src/fs.rs`
+
+Add to the trait definition (after `exists`):
+
+```rust
+/// Check if a path is a regular file (not a directory, symlink-to-directory, or special file).
+fn is_file(&self, path: &Path) -> bool {
+    // Default: conservative — defer to exists()
+    self.exists(path)
+}
+```
+
+Implement in `Real`:
+
+```rust
+fn is_file(&self, path: &Path) -> bool {
+    path.is_file()
+}
+```
+
+`std::path::Path::is_file()` follows symlinks and returns `true` only for regular files. Symlinks to directories return `false`. This is exactly the guard we need.
+
+**Mock implementations:** Add `is_file` to each mock `Fs` in the test modules. For existing mocks that track an `exists: HashSet<PathBuf>`, `is_file` can reuse `self.exists.contains(path)` (existing mock behavior — tests don't use symlinks). Mocks that need to simulate the "is a directory" case can add a `dirs: HashSet<PathBuf>` and return `self.exists.contains(path) && !self.dirs.contains(path)`.
+
+### 5.2 Guard `collect_files_recursive`
+
+**File:** `crates/libaipm/src/migrate/skill_common.rs:172-191`
+
+Add an `is_file()` check as a secondary guard after `!is_dir`:
+
+```rust
+pub fn collect_files_recursive(
+    dir: &Path,
+    base: &Path,
+    fs: &dyn Fs,
+) -> Result<Vec<PathBuf>, Error> {
+    let mut files = Vec::new();
+    let entries = fs.read_dir(dir)?;
+
+    for entry in entries {
+        let full_path = dir.join(&entry.name);
+        if entry.is_dir {
+            let sub_files = collect_files_recursive(&full_path, base, fs)?;
+            files.extend(sub_files);
+        } else if fs.is_file(&full_path) {
+            if let Ok(relative) = full_path.strip_prefix(base) {
+                files.push(relative.to_path_buf());
+            }
+        } else {
+            tracing::warn!(
+                path = %full_path.display(),
+                "skipping non-regular file during migration discovery"
+            );
+        }
+    }
+
+    Ok(files)
+}
+```
+
+This catches symlinks-to-directories, named pipes, device files, and any other non-regular-file entry at the collection point, before they reach any emitter.
+
+### 5.3 Guard and Annotate Emitter Call Sites
+
+**File:** `crates/libaipm/src/migrate/emitter.rs`
+
+**Strategy:** For each of the 19 bare-`?` call sites, apply one of two patterns:
+
+#### Pattern A: Skip + warn (for file-iteration sites like `emit_other_files`, `emit_skill_files`)
+
+Model after the existing `emit_extension_files` pattern at line 619:
+
+```rust
+// Before (emit_other_files:747-750):
+if fs.exists(&file.path) {
+    let content = fs.read_to_string(&file.path)?;
+    fs.write_file(&dest, content.as_bytes())?;
+}
+
+// After:
+if fs.exists(&file.path) {
+    if !fs.is_file(&file.path) {
+        tracing::warn!(
+            path = %file.path.display(),
+            "skipping non-regular file during other-file migration"
+        );
+        continue;
+    }
+    let content = fs.read_to_string(&file.path).map_err(|e| {
+        Error::Io(std::io::Error::new(
+            e.kind(),
+            format!("reading {}: {e}", file.path.display()),
+        ))
+    })?;
+    fs.write_file(&dest, content.as_bytes()).map_err(|e| {
+        Error::Io(std::io::Error::new(
+            e.kind(),
+            format!("writing {}: {e}", dest.display()),
+        ))
+    })?;
+}
+```
+
+Apply this skip+warn pattern to these call sites (all iterate over file lists):
+- `emit_skill_files` (line 146, 151) — loop over `artifact.files`
+- `emit_other_files` (line 749, 750) — loop over `other_files`
+- `copy_referenced_scripts` (line 685, 686) — loop over `referenced_scripts`
+
+#### Pattern B: Annotate with path context (for single-file reads)
+
+For call sites that read a single artifact's `source_path` (not iterating), just add `.map_err()` for context. These paths come from detectors that already guard with `is_dir`, so the risk is lower:
+
+```rust
+// Before (emit_agent_files:515):
+let content = fs.read_to_string(&artifact.source_path)?;
+
+// After:
+let content = fs.read_to_string(&artifact.source_path).map_err(|e| {
+    Error::Io(std::io::Error::new(
+        e.kind(),
+        format!("reading agent {}: {e}", artifact.source_path.display()),
+    ))
+})?;
+```
+
+Apply this annotate pattern to:
+- `emit_command_as_skill` (line 161) — `"reading command {path}"`
+- `emit_agent_files` (line 515) — `"reading agent {path}"`
+- `emit_output_style` (line 557) — `"reading output style {path}"`
+- `emit_mcp_config` (line 529) — `"reading mcp config {path}"`
+- `emit_hooks_config` (line 543) — `"reading hooks config {path}"`
+- `emit_lsp_config` (line 569) — `"reading lsp config {path}"`
+
+Also annotate `write_file` calls in these functions with `"writing {dest_path}"`.
+
+### 5.4 Add Pipeline Tracing
+
+All tracing uses fully-qualified `tracing::level!()` calls (no imports). Follow existing field conventions: `path = %path.display()`, `error = %e`, message last, lowercase, no trailing period.
+
+#### `discover_source_dirs` — `crates/libaipm/src/discovery.rs:101`
+
+Match the pattern from sibling `discover_features` (lines 294-338):
+
+```rust
+// After building walker, before iteration:
+tracing::trace!("starting source directory discovery");
+
+// Inside the loop, after matching a pattern:
+tracing::trace!(dir = %source_dir.display(), source_type = source_type_str, "discovered source directory");
+
+// After the loop:
+tracing::trace!(total = discovered.len(), "source directory discovery complete");
+```
+
+#### `migrate` — `crates/libaipm/src/migrate/mod.rs:322`
+
+```rust
+// At entry:
+tracing::debug!(
+    source = ?opts.source,
+    dry_run = opts.dry_run,
+    destructive = opts.destructive,
+    "starting migration"
+);
+```
+
+#### `migrate_recursive` — `crates/libaipm/src/migrate/mod.rs:443`
+
+```rust
+// After discover_source_dirs returns:
+tracing::debug!(discovered = discovered.len(), "discovered source directories for recursive migration");
+
+// After detection results are collected:
+tracing::debug!(plans = plugin_plans.len(), "detection complete");
+
+// Before dry-run early return:
+tracing::debug!("dry-run mode — generating report");
+
+// Before emit_and_register:
+tracing::debug!("emitting plugins");
+```
+
+#### `emit_and_register` — `crates/libaipm/src/migrate/mod.rs:531`
+
+```rust
+// At entry:
+tracing::debug!(plans = resolved.len(), "starting plugin emission");
+
+// For each plan emission (inside the par_iter, at trace level since it's per-item):
+tracing::trace!(plugin = final_name, artifacts = plan.artifacts.len(), other_files = plan.other_files.len(), "emitting plugin");
+
+// After all emissions:
+tracing::debug!(emitted = all_actions.len(), registered = registered_entries.len(), "emission and registration complete");
+```
+
+#### `reconcile` — `crates/libaipm/src/migrate/reconciler.rs:23`
+
+```rust
+// After collecting all files and building claimed set:
+tracing::debug!(
+    total_files = all_files.len(),
+    claimed = claimed.len(),
+    unclaimed = unclaimed.len(),
+    source_dir = %source_dir.display(),
+    "reconciliation complete"
+);
+```
+
+#### `register_plugins` — `crates/libaipm/src/migrate/registrar.rs:10`
+
+```rust
+// At entry:
+tracing::debug!(count = entries.len(), "registering plugins in marketplace.json");
+```
+
+#### `emit_other_files` — `crates/libaipm/src/migrate/emitter.rs:699`
+
+```rust
+// At entry:
+tracing::trace!(count = other_files.len(), plugin_dir = %plugin_dir.display(), "emitting other files");
+
+// Per file (inside the loop):
+tracing::trace!(path = %file.path.display(), dest = %dest.display(), "copying other file");
+```
+
+### 5.5 Tests
+
+#### New unit tests for `Fs::is_file()`
+
+**File:** `crates/libaipm/src/fs.rs` (in the `#[cfg(test)]` block)
+
+- `real_is_file_returns_true_for_regular_file` — create a file, assert `Real.is_file()` returns `true`
+- `real_is_file_returns_false_for_directory` — create a dir, assert `Real.is_file()` returns `false`
+- `real_is_file_returns_false_for_symlink_to_directory` — create a dir, symlink to it, assert `Real.is_file()` returns `false`
+- `real_is_file_returns_true_for_symlink_to_file` — create a file, symlink to it, assert `Real.is_file()` returns `true`
+- `real_is_file_returns_false_for_nonexistent` — assert `Real.is_file()` returns `false` for a path that doesn't exist
+
+#### New unit test for `collect_files_recursive` symlink handling
+
+**File:** `crates/libaipm/src/migrate/skill_common.rs` (in the `#[cfg(test)]` block)
+
+Add a mock that returns a `DirEntry { name: "link", is_dir: false }` where the corresponding path is NOT a file (mock `is_file` returns `false`). Assert the entry is excluded from the collected files list.
+
+#### New unit test for `emit_other_files` skip behavior
+
+**File:** `crates/libaipm/src/migrate/emitter.rs` (in the `#[cfg(test)]` block)
+
+Add a test where an `OtherFile` has a path that exists but `is_file()` returns `false`. Assert the function completes successfully (no error), the file is skipped, and an `OtherFileMigrated` action is still emitted (or skipped — match the decided behavior).
+
+#### Existing test updates
+
+All existing `MockFs` implementations across the test modules gain a trivial `is_file` implementation. Since existing mocks don't track directory state separately, `is_file` can return `self.exists.contains(path)` — this preserves current test behavior.
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Reason for Rejection |
+|--------|------|------|---------------------|
+| Add `metadata()` to `Fs` returning file type, size, etc. | More future-proof, richer API | Much larger API surface change, every mock needs a new method returning a struct | Over-engineered for this fix; `is_file()` is sufficient |
+| Only wrap errors (no `is_file` guard) | Smaller change, identifies the crash site | Still crashes — just with a better message; user must still re-run after fixing the offending file | We want skip+warn, not fail-with-context |
+| Add `--strict` flag for configurable behavior | Flexibility | Added complexity, more code paths to test, not requested | YAGNI — skip+warn is the right default; can add later if needed |
+| Use `DirEntry` with resolved file type (follow symlinks) | Fixes the root cause at the source | Changes `read_dir` semantics for all callers, may have unintended effects in lint/install | Too broad a change; `is_file` guard is surgical |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Observability Strategy
+
+- **Log levels:** `trace` for per-item iteration (each file, each directory), `debug` for pipeline milestones (discovery complete, emission complete, reconciliation summary), `warn` for skipped entries
+- **Field conventions:** Match existing codebase patterns — `path = %path.display()`, `error = %e`, `count = n`, message last, lowercase
+- **File log:** Always captures `debug` level (existing behavior via `logging.rs`), so pipeline milestones appear in `<temp_dir>/aipm-*.log` without any user action
+- **Stderr log:** Controlled by `AIPM_LOG` env var or `-v`/`-vv` flags; users debugging issues set `AIPM_LOG=trace`
+
+### 7.2 Backwards Compatibility
+
+- `Fs::is_file()` has a default implementation (`self.exists(path)`), so existing external implementations (if any) are not broken
+- No new CLI flags, no changed output format, no changed exit codes (except: previously-crashing runs now succeed with warnings)
+- Mock implementations in tests get a trivial `is_file` that reuses `exists` — no test behavior change
+
+## 8. Migration, Rollout, and Testing
+
+### 8.1 Deployment Strategy
+
+Ship in a single PR. No feature flags needed — the fix is purely defensive (skip+warn instead of crash).
+
+### 8.2 Test Plan
+
+- **Unit Tests:** New tests for `is_file()` on `Real`, `collect_files_recursive` with symlink-like entries, `emit_other_files` skip behavior
+- **Existing Tests:** All pass with `is_file` added to mocks; run `cargo test --workspace`
+- **Lint:** `cargo clippy --workspace -- -D warnings` (no new `#[allow]`)
+- **Format:** `cargo fmt --check`
+- **Coverage:** `cargo +nightly llvm-cov report --doctests --branch --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\.rs)'` — must show >= 89% branch coverage
+- **Manual verification:** Run `aipm migrate --dry-run` and `aipm migrate` on a test monorepo with a symlinked directory inside `.claude/` — confirm skip+warn behavior instead of crash
+
+## 9. Open Questions / Unresolved Issues
+
+- [ ] Should skipped non-regular files produce a visible CLI warning (via `writeln!(stderr, ...)`) in addition to the `tracing::warn!`? The tracing warn goes to the log file and stderr-if-verbose, but the user might not see it at default verbosity. **Recommendation:** Add a `Action::Skipped` action for non-regular files so it surfaces in the CLI output naturally.
+- [ ] Should the `OtherFileMigrated` action still be emitted for skipped files, or should we omit it? **Recommendation:** Omit it — only emit for files that were actually copied. The `Action::Skipped` covers the skip case.


### PR DESCRIPTION
## Summary

- Add `research/docs/2026-04-06-feature-status-audit.md` — feature status audit document
- Add `research/docs/2026-04-07-313-migrate-eisdir-crash.md` — research for the eisdir crash bug
- Add `specs/2026-04-07-fix-migrate-eisdir-crash-and-add-logging.md` — implementation spec for the fix