### PR TITLE
chore: release v0.19.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.19.5"
+version = "0.19.6"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.19.5"
+version = "0.19.6"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1163,7 +1163,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.19.5"
+version = "0.19.6"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.19.5"
+version = "0.19.6"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.19.5" }
+libaipm = { path = "crates/libaipm", version = "0.19.6" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.6] - 2026-04-11
+
 ## [0.19.5] - 2026-04-10
 
 ## [0.19.4] - 2026-04-10

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.6] - 2026-04-11
+
+### Testing
+- Cover extract_rule_id_at when word starts at column zero (00c074e)
+- Cover marketplace_possible=false branches in resolve_workspace_answers (9eb4a5b)
+- Cover load_lint_config early returns, reporter validation, plugins_dir fallback, and Policy aliases (d7ce7f6)
+
 ## [0.19.5] - 2026-04-10
 
 ### Features

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.19.6] - 2026-04-11
+
+### Testing
+- Cover locate_json_key False branch when key is on non-first line (e17d81f)
+- Cover empty-file snippet branch in Human reporter (c64c712)
+- Cover other_files branch in generate_recursive_report (ae3a2d4)
+- Cover MockFs::exists file-only branch in cleanup (e58a242)
+- Cover False branch of emit_and_register with empty artifacts plan (c39e53c)
+- Cover validate_github_owner leading/trailing hyphen branch (7d4e825)
+- Cover invalid semver requirement error path (c7e4eb1)
+- Cover suppressed source/misplaced-features branch (fdeb137)
+- Cover git path-traversal error branch and parse() fallback (c1beb9f)
+- Cover make_temp_dir cleanup of existing directory (6c073b1)
+- Cover load_lint_config early returns, reporter validation, plugins_dir fallback, and Policy aliases (d7ce7f6)
+- Cover gc is_dir false branch for non-directory entries (0635d49)
+
 ## [0.19.5] - 2026-04-10
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.19.5 -> 0.19.6 (✓ API compatible changes)
* `aipm`: 0.19.5 -> 0.19.6
* `aipm-pack`: 0.19.5 -> 0.19.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.19.6] - 2026-04-11

### Testing
- Cover locate_json_key False branch when key is on non-first line (e17d81f)
- Cover empty-file snippet branch in Human reporter (c64c712)
- Cover other_files branch in generate_recursive_report (ae3a2d4)
- Cover MockFs::exists file-only branch in cleanup (e58a242)
- Cover False branch of emit_and_register with empty artifacts plan (c39e53c)
- Cover validate_github_owner leading/trailing hyphen branch (7d4e825)
- Cover invalid semver requirement error path (c7e4eb1)
- Cover suppressed source/misplaced-features branch (fdeb137)
- Cover git path-traversal error branch and parse() fallback (c1beb9f)
- Cover make_temp_dir cleanup of existing directory (6c073b1)
- Cover load_lint_config early returns, reporter validation, plugins_dir fallback, and Policy aliases (d7ce7f6)
- Cover gc is_dir false branch for non-directory entries (0635d49)
</blockquote>

## `aipm`

<blockquote>

## [0.19.6] - 2026-04-11

### Testing
- Cover extract_rule_id_at when word starts at column zero (00c074e)
- Cover marketplace_possible=false branches in resolve_workspace_answers (9eb4a5b)
- Cover load_lint_config early returns, reporter validation, plugins_dir fallback, and Policy aliases (d7ce7f6)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).