### PR TITLE
feat(lint): add instructions/oversized rule for instruction file size limits

### DIFF
--- a/crates/aipm/src/lsp/helpers.rs
+++ b/crates/aipm/src/lsp/helpers.rs
@@ -488,8 +488,9 @@ mod tests {
         assert!(index.contains_key("agent/missing-tools"));
         assert!(index.contains_key("plugin/missing-manifest"));
         assert!(index.contains_key("source/misplaced-features"));
-        // 17 rules total (16 quality rules + source/misplaced-features)
-        assert_eq!(index.len(), 17);
+        assert!(index.contains_key("instructions/oversized"));
+        // 18 rules total (17 quality rules + source/misplaced-features)
+        assert_eq!(index.len(), 18);
     }
 
     #[test]

--- a/crates/aipm/src/main.rs
+++ b/crates/aipm/src/main.rs
@@ -824,9 +824,14 @@ pub(crate) fn load_lint_config(dir: &Path) -> libaipm::lint::config::Config {
                 .unwrap_or_default();
 
             if let Some(lvl) = level {
+                let options: std::collections::BTreeMap<String, toml::Value> = table
+                    .iter()
+                    .filter(|(k, _)| *k != "level" && *k != "ignore")
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
                 config.rule_overrides.insert(
                     key.clone(),
-                    libaipm::lint::config::RuleOverride::Detailed { level: lvl, ignore },
+                    libaipm::lint::config::RuleOverride::Detailed { level: lvl, ignore, options },
                 );
             }
         }
@@ -1082,6 +1087,47 @@ mod tests {
         let result = cmd_lint(tmp.path().to_path_buf(), None, "not-a-reporter", "auto", None, None);
         let err = result.unwrap_err().to_string();
         assert!(err.contains("unknown reporter"), "unexpected error: {err}");
+    }
+
+    /// `load_lint_config` forwards unknown TOML keys (beyond level/ignore) into
+    /// the `options` map of `RuleOverride::Detailed`.
+    #[test]
+    fn load_lint_config_custom_keys_forwarded_to_options() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("aipm.toml"),
+            "[workspace.lints.\"instructions/oversized\"]\nlevel = \"warn\"\nlines = 200\ncharacters = 20000\nresolve-imports = true\n",
+        )
+        .unwrap();
+
+        let config = load_lint_config(tmp.path());
+        let opts = config.rule_options("instructions/oversized");
+        assert_eq!(opts.get("lines"), Some(&toml::Value::Integer(200)));
+        assert_eq!(opts.get("characters"), Some(&toml::Value::Integer(20_000)));
+        assert_eq!(opts.get("resolve-imports"), Some(&toml::Value::Boolean(true)));
+        // level and ignore must NOT appear in options
+        assert!(!opts.contains_key("level"));
+        assert!(!opts.contains_key("ignore"));
+    }
+
+    /// Existing aipm.toml files with only level/ignore continue to work; the
+    /// `options` BTreeMap in `RuleOverride::Detailed` is empty but not absent.
+    #[test]
+    fn load_lint_config_backward_compatible_level_ignore_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("aipm.toml"),
+            "[workspace.lints.\"skill/oversized\"]\nlevel = \"error\"\nignore = [\"examples/**\"]\n",
+        )
+        .unwrap();
+
+        let config = load_lint_config(tmp.path());
+        let opts = config.rule_options("skill/oversized");
+        assert!(opts.is_empty(), "options must be empty for level/ignore-only config");
+        assert_eq!(
+            config.severity_override("skill/oversized"),
+            Some(libaipm::lint::Severity::Error)
+        );
     }
 
     /// `resolve_plugins_dir` falls back to `.ai` when the manifest has a

--- a/crates/aipm/src/main.rs
+++ b/crates/aipm/src/main.rs
@@ -817,21 +817,25 @@ pub(crate) fn load_lint_config(dir: &Path) -> libaipm::lint::config::Config {
                 .get("level")
                 .and_then(toml::Value::as_str)
                 .and_then(libaipm::lint::Severity::from_str_config);
-            let ignore = table
+            let ignore: Vec<String> = table
                 .get("ignore")
                 .and_then(toml::Value::as_array)
                 .map(|arr| arr.iter().filter_map(toml::Value::as_str).map(String::from).collect())
                 .unwrap_or_default();
 
-            if let Some(lvl) = level {
-                let options: std::collections::BTreeMap<String, toml::Value> = table
-                    .iter()
-                    .filter(|(k, _)| *k != "level" && *k != "ignore")
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect();
+            let options: std::collections::BTreeMap<String, toml::Value> = table
+                .iter()
+                .filter(|(k, _)| *k != "level" && *k != "ignore")
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            // Record Detailed when there is anything meaningful: a level override,
+            // ignore paths, or custom option keys.  This allows users to configure
+            // per-rule options (e.g. `lines`, `characters`) without being forced to
+            // also specify a `level`.
+            if level.is_some() || !ignore.is_empty() || !options.is_empty() {
                 config.rule_overrides.insert(
                     key.clone(),
-                    libaipm::lint::config::RuleOverride::Detailed { level: lvl, ignore, options },
+                    libaipm::lint::config::RuleOverride::Detailed { level, ignore, options },
                 );
             }
         }
@@ -1128,6 +1132,25 @@ mod tests {
             config.severity_override("skill/oversized"),
             Some(libaipm::lint::Severity::Error)
         );
+    }
+
+    /// Custom option keys are recorded even when `level` is absent, so that
+    /// users can configure e.g. `lines = 200` without also specifying `level`.
+    #[test]
+    fn load_lint_config_options_recorded_without_level() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("aipm.toml"),
+            "[workspace.lints.\"instructions/oversized\"]\nlines = 200\ncharacters = 20000\n",
+        )
+        .unwrap();
+
+        let config = load_lint_config(tmp.path());
+        let opts = config.rule_options("instructions/oversized");
+        assert_eq!(opts.get("lines"), Some(&toml::Value::Integer(200)));
+        assert_eq!(opts.get("characters"), Some(&toml::Value::Integer(20_000)));
+        // No level specified → severity_override returns None (rule uses its default)
+        assert_eq!(config.severity_override("instructions/oversized"), None);
     }
 
     /// `resolve_plugins_dir` falls back to `.ai` when the manifest has a

--- a/crates/libaipm/src/discovery.rs
+++ b/crates/libaipm/src/discovery.rs
@@ -20,6 +20,9 @@ pub enum FeatureKind {
     Marketplace,
     /// A plugin JSON manifest (`plugin.json` at `.ai/<plugin>/.claude-plugin/plugin.json`).
     PluginJson,
+    /// An instruction file (CLAUDE.md, AGENTS.md, COPILOT.md, INSTRUCTIONS.md, GEMINI.md, or
+    /// `*.instructions.md`) anywhere in the project tree.
+    Instructions,
 }
 
 /// The source directory context for a discovered feature.
@@ -175,6 +178,13 @@ pub fn discover_source_dirs(
 const SKIP_DIRS: &[&str] =
     &["node_modules", "target", ".git", "vendor", "__pycache__", "dist", "build"];
 
+/// Lowercase filenames that are classified as instruction files.
+///
+/// Checked case-insensitively before other classification rules so that files
+/// like `agents/AGENTS.md` are correctly tagged as `Instructions`, not `Agent`.
+const INSTRUCTION_FILENAMES: &[&str] =
+    &["claude.md", "agents.md", "copilot.md", "instructions.md", "gemini.md"];
+
 /// Classify the source context of a file path by inspecting its ancestor components.
 ///
 /// Returns `Some(SourceContext)` if the path contains a recognized source directory
@@ -245,6 +255,15 @@ fn classify_feature_kind(file_path: &Path) -> Option<FeatureKind> {
         .and_then(|p| p.file_name())
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default();
+
+    // Instruction file check — must come BEFORE the agents check so that
+    // `agents/AGENTS.md` is classified as Instructions, not Agent.
+    let file_name_lower = file_name.to_ascii_lowercase();
+    if INSTRUCTION_FILENAMES.contains(&file_name_lower.as_ref())
+        || file_name_lower.ends_with(".instructions.md")
+    {
+        return Some(FeatureKind::Instructions);
+    }
 
     if file_name == "SKILL.md" {
         // Standard: skills/<name>/SKILL.md; flat: skills/SKILL.md
@@ -933,5 +952,68 @@ mod tests {
 
         let features = discover_features(&root, None).expect("discover_features");
         assert!(features.is_empty(), "plugin.json with wrong parent should not be classified");
+    }
+
+    // --- FeatureKind::Instructions classification tests ---
+
+    fn classify(path: &str) -> Option<FeatureKind> {
+        classify_feature_kind(Path::new(path))
+    }
+
+    #[test]
+    fn classify_claude_md() {
+        assert_eq!(classify("CLAUDE.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_claude_md_lowercase() {
+        assert_eq!(classify("claude.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_agents_md_in_agents_dir_is_instructions_not_agent() {
+        // AGENTS.md inside agents/ must be Instructions, not Agent
+        assert_eq!(classify("agents/AGENTS.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_instructions_md_suffix() {
+        assert_eq!(classify("frontend.instructions.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_instructions_md_suffix_in_subdir() {
+        assert_eq!(classify("packages/auth/api.instructions.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_regular_agent_unchanged() {
+        // A normal agent file in agents/ is still Agent
+        assert_eq!(classify("agents/security-reviewer.md"), Some(FeatureKind::Agent));
+    }
+
+    #[test]
+    fn classify_gemini_md() {
+        assert_eq!(classify("GEMINI.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_copilot_md() {
+        assert_eq!(classify("COPILOT.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_instructions_md() {
+        assert_eq!(classify("INSTRUCTIONS.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_agents_md_alone() {
+        assert_eq!(classify("AGENTS.md"), Some(FeatureKind::Instructions));
+    }
+
+    #[test]
+    fn classify_claude_md_in_subdir() {
+        assert_eq!(classify("packages/auth/CLAUDE.md"), Some(FeatureKind::Instructions));
     }
 }

--- a/crates/libaipm/src/lint/config.rs
+++ b/crates/libaipm/src/lint/config.rs
@@ -20,12 +20,14 @@ pub enum RuleOverride {
     Allow,
     /// Simple severity override.
     Level(Severity),
-    /// Detailed override with severity and per-rule ignore paths.
+    /// Detailed override with severity, per-rule ignore paths, and custom options.
     Detailed {
         /// Severity level.
         level: Severity,
         /// Per-rule ignore paths (globs).
         ignore: Vec<String>,
+        /// Per-rule custom options forwarded from the TOML config.
+        options: BTreeMap<String, toml::Value>,
     },
 }
 
@@ -49,6 +51,19 @@ impl Config {
         match self.rule_overrides.get(rule_id) {
             Some(RuleOverride::Detailed { ignore, .. }) => ignore,
             _ => &[],
+        }
+    }
+
+    /// Get per-rule custom options, if any.
+    ///
+    /// Returns the options `BTreeMap` for `Detailed` overrides, or an empty map otherwise.
+    pub fn rule_options<'a>(&'a self, rule_id: &str) -> &'a BTreeMap<String, toml::Value> {
+        static EMPTY: std::sync::OnceLock<BTreeMap<String, toml::Value>> =
+            std::sync::OnceLock::new();
+        if let Some(RuleOverride::Detailed { options, .. }) = self.rule_overrides.get(rule_id) {
+            options
+        } else {
+            EMPTY.get_or_init(BTreeMap::new)
         }
     }
 }
@@ -90,6 +105,7 @@ mod tests {
             RuleOverride::Detailed {
                 level: Severity::Warning,
                 ignore: vec!["examples/**".to_string()],
+                options: BTreeMap::new(),
             },
         );
         assert_eq!(config.severity_override("plugin/broken-paths"), Some(Severity::Warning));
@@ -112,6 +128,7 @@ mod tests {
             RuleOverride::Detailed {
                 level: Severity::Error,
                 ignore: vec!["examples/**".to_string(), "vendor/**".to_string()],
+                options: BTreeMap::new(),
             },
         );
         let paths = config.rule_ignore_paths("plugin/broken-paths");
@@ -132,5 +149,40 @@ mod tests {
         let mut config = Config::default();
         config.rule_overrides.insert("skill/oversized".to_string(), RuleOverride::Allow);
         assert_eq!(config.severity_override("skill/oversized"), None);
+    }
+
+    #[test]
+    fn rule_override_detailed_with_options_stores_and_returns() {
+        let mut config = Config::default();
+        let mut opts = BTreeMap::new();
+        opts.insert("lines".to_string(), toml::Value::Integer(200));
+        config.rule_overrides.insert(
+            "instructions/oversized".to_string(),
+            RuleOverride::Detailed { level: Severity::Error, ignore: vec![], options: opts },
+        );
+        let returned = config.rule_options("instructions/oversized");
+        assert_eq!(returned.get("lines"), Some(&toml::Value::Integer(200)));
+    }
+
+    #[test]
+    fn rule_options_empty_for_allow_variant() {
+        let mut config = Config::default();
+        config.rule_overrides.insert("skill/oversized".to_string(), RuleOverride::Allow);
+        assert!(config.rule_options("skill/oversized").is_empty());
+    }
+
+    #[test]
+    fn rule_options_empty_for_level_variant() {
+        let mut config = Config::default();
+        config
+            .rule_overrides
+            .insert("skill/oversized".to_string(), RuleOverride::Level(Severity::Warning));
+        assert!(config.rule_options("skill/oversized").is_empty());
+    }
+
+    #[test]
+    fn rule_options_empty_for_missing_rule() {
+        let config = Config::default();
+        assert!(config.rule_options("nonexistent/rule").is_empty());
     }
 }

--- a/crates/libaipm/src/lint/config.rs
+++ b/crates/libaipm/src/lint/config.rs
@@ -20,10 +20,13 @@ pub enum RuleOverride {
     Allow,
     /// Simple severity override.
     Level(Severity),
-    /// Detailed override with severity, per-rule ignore paths, and custom options.
+    /// Detailed override with optional severity, per-rule ignore paths, and custom options.
+    ///
+    /// `level: None` means "use the rule's own default severity" — useful when only
+    /// `ignore` or custom option keys (e.g. `lines`, `characters`) are set.
     Detailed {
-        /// Severity level.
-        level: Severity,
+        /// Severity level override (`None` = keep rule default).
+        level: Option<Severity>,
         /// Per-rule ignore paths (globs).
         ignore: Vec<String>,
         /// Per-rule custom options forwarded from the TOML config.
@@ -41,7 +44,7 @@ impl Config {
     pub fn severity_override(&self, rule_id: &str) -> Option<Severity> {
         match self.rule_overrides.get(rule_id) {
             Some(RuleOverride::Level(s)) => Some(*s),
-            Some(RuleOverride::Detailed { level, .. }) => Some(*level),
+            Some(RuleOverride::Detailed { level, .. }) => *level,
             _ => None,
         }
     }
@@ -103,12 +106,23 @@ mod tests {
         config.rule_overrides.insert(
             "plugin/broken-paths".to_string(),
             RuleOverride::Detailed {
-                level: Severity::Warning,
+                level: Some(Severity::Warning),
                 ignore: vec!["examples/**".to_string()],
                 options: BTreeMap::new(),
             },
         );
         assert_eq!(config.severity_override("plugin/broken-paths"), Some(Severity::Warning));
+    }
+
+    #[test]
+    fn severity_override_none_level_in_detailed_returns_none() {
+        let mut config = Config::default();
+        config.rule_overrides.insert(
+            "instructions/oversized".to_string(),
+            RuleOverride::Detailed { level: None, ignore: vec![], options: BTreeMap::new() },
+        );
+        // No level override → rule uses its own default
+        assert_eq!(config.severity_override("instructions/oversized"), None);
     }
 
     #[test]
@@ -126,7 +140,7 @@ mod tests {
         config.rule_overrides.insert(
             "plugin/broken-paths".to_string(),
             RuleOverride::Detailed {
-                level: Severity::Error,
+                level: Some(Severity::Error),
                 ignore: vec!["examples/**".to_string(), "vendor/**".to_string()],
                 options: BTreeMap::new(),
             },
@@ -158,7 +172,7 @@ mod tests {
         opts.insert("lines".to_string(), toml::Value::Integer(200));
         config.rule_overrides.insert(
             "instructions/oversized".to_string(),
-            RuleOverride::Detailed { level: Severity::Error, ignore: vec![], options: opts },
+            RuleOverride::Detailed { level: Some(Severity::Error), ignore: vec![], options: opts },
         );
         let returned = config.rule_options("instructions/oversized");
         assert_eq!(returned.get("lines"), Some(&toml::Value::Integer(200)));

--- a/crates/libaipm/src/lint/mod.rs
+++ b/crates/libaipm/src/lint/mod.rs
@@ -319,7 +319,7 @@ mod tests {
         cfg.rule_overrides.insert(
             "stub/per-rule-ignore".to_string(),
             config::RuleOverride::Detailed {
-                level: Severity::Warning,
+                level: Some(Severity::Warning),
                 ignore: vec!["vendor/**".to_string()],
                 options: std::collections::BTreeMap::new(),
             },
@@ -836,7 +836,7 @@ mod tests {
         cfg.rule_overrides.insert(
             "source/misplaced-features".to_string(),
             config::RuleOverride::Detailed {
-                level: Severity::Warning,
+                level: Some(Severity::Warning),
                 ignore: vec!["**/vendor/**".to_string()],
                 options: std::collections::BTreeMap::new(),
             },
@@ -1189,7 +1189,7 @@ mod tests {
         cfg.rule_overrides.insert(
             "instructions/oversized".to_string(),
             config::RuleOverride::Detailed {
-                level: Severity::Warning,
+                level: Some(Severity::Warning),
                 ignore: vec![],
                 options: opts_map,
             },

--- a/crates/libaipm/src/lint/mod.rs
+++ b/crates/libaipm/src/lint/mod.rs
@@ -82,7 +82,7 @@ fn run_rules_for_feature(
     let is_inside_ai = feature.source_context.as_ref().is_some_and(|ctx| ctx.source_type == ".ai");
 
     // 1. Quality rules — run on ALL features regardless of location.
-    let quality_rules = rules::quality_rules_for_kind(&feature.kind);
+    let quality_rules = rules::quality_rules_for_kind(&feature.kind, config);
     for rule in &quality_rules {
         if config.is_suppressed(rule.id()) {
             continue;
@@ -321,6 +321,7 @@ mod tests {
             config::RuleOverride::Detailed {
                 level: Severity::Warning,
                 ignore: vec!["vendor/**".to_string()],
+                options: std::collections::BTreeMap::new(),
             },
         );
 
@@ -837,6 +838,7 @@ mod tests {
             config::RuleOverride::Detailed {
                 level: Severity::Warning,
                 ignore: vec!["**/vendor/**".to_string()],
+                options: std::collections::BTreeMap::new(),
             },
         );
 
@@ -1140,6 +1142,90 @@ mod tests {
         assert!(
             !outcome.diagnostics.iter().any(|d| d.rule_id == "source/misplaced-features"),
             "source/misplaced-features should be suppressed when set to Allow"
+        );
+    }
+
+    // --- instructions/oversized integration tests ---
+
+    #[test]
+    fn lint_discovers_oversized_instruction_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Create a CLAUDE.md with >100 lines
+        let content: String = (0..110).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(root.join("CLAUDE.md"), &content).unwrap();
+        // Create .ai/ marker
+        std::fs::create_dir_all(root.join(".ai")).unwrap();
+
+        let opts = Options {
+            dir: root.to_path_buf(),
+            source: None,
+            config: config::Config::default(),
+            max_depth: None,
+        };
+        let result = lint(&opts, &crate::fs::Real);
+        assert!(result.is_ok());
+        let outcome = result.unwrap();
+        assert!(
+            outcome.diagnostics.iter().any(|d| d.rule_id == "instructions/oversized"),
+            "should detect oversized CLAUDE.md"
+        );
+    }
+
+    #[test]
+    fn lint_config_overrides_thresholds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // 60 lines — under default 100, over custom 50
+        let content: String = (0..60).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(root.join("CLAUDE.md"), &content).unwrap();
+        std::fs::create_dir_all(root.join(".ai")).unwrap();
+
+        let mut cfg = config::Config::default();
+        let mut opts_map = std::collections::BTreeMap::new();
+        opts_map.insert("lines".to_string(), toml::Value::Integer(50));
+        cfg.rule_overrides.insert(
+            "instructions/oversized".to_string(),
+            config::RuleOverride::Detailed {
+                level: Severity::Warning,
+                ignore: vec![],
+                options: opts_map,
+            },
+        );
+
+        let opts = Options { dir: root.to_path_buf(), source: None, config: cfg, max_depth: None };
+        let result = lint(&opts, &crate::fs::Real);
+        assert!(result.is_ok());
+        let outcome = result.unwrap();
+        assert!(
+            outcome.diagnostics.iter().any(|d| d.rule_id == "instructions/oversized"),
+            "custom threshold of 50 lines should trigger on 60-line file"
+        );
+    }
+
+    #[test]
+    fn lint_config_allow_suppresses_instructions_oversized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Oversized CLAUDE.md
+        let content: String = (0..110).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(root.join("CLAUDE.md"), &content).unwrap();
+        std::fs::create_dir_all(root.join(".ai")).unwrap();
+
+        let mut cfg = config::Config::default();
+        cfg.rule_overrides
+            .insert("instructions/oversized".to_string(), config::RuleOverride::Allow);
+
+        let opts = Options { dir: root.to_path_buf(), source: None, config: cfg, max_depth: None };
+        let result = lint(&opts, &crate::fs::Real);
+        assert!(result.is_ok());
+        let outcome = result.unwrap();
+        assert!(
+            !outcome.diagnostics.iter().any(|d| d.rule_id == "instructions/oversized"),
+            "instructions/oversized should be suppressed by allow"
         );
     }
 }

--- a/crates/libaipm/src/lint/rules/import_resolver.rs
+++ b/crates/libaipm/src/lint/rules/import_resolver.rs
@@ -60,13 +60,23 @@ fn parse_markdown_links(content: &str) -> Vec<String> {
 
 /// Return `true` when `path` is safe to follow.
 ///
-/// Rejects absolute paths and any path containing `..` segments, preventing
-/// escapes outside the project tree.
+/// Rejects absolute paths, Windows drive prefixes, and `..` segments using
+/// `Path::components()` so that both `/`-separated and `\`-separated paths
+/// are handled correctly on every platform.
 fn is_path_safe(path: &str) -> bool {
-    if Path::new(path).is_absolute() {
-        return false;
-    }
-    path.split('/').all(|segment| segment != "..")
+    use std::path::Component;
+    Path::new(path)
+        .components()
+        .all(|c| !matches!(c, Component::ParentDir | Component::RootDir | Component::Prefix(..)))
+}
+
+/// Lexically normalize a path by stripping redundant `./` prefixes.
+///
+/// `a.md` and `./a.md` resolve to the same file; normalizing before inserting
+/// into the `visited` set prevents double-counting and strengthens cycle detection.
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    path.components().filter(|c| !matches!(c, Component::CurDir)).collect()
 }
 
 /// Recursively resolve imports for a single file, accumulating sizes.
@@ -87,7 +97,9 @@ pub fn resolve_imports<S: BuildHasher>(
     fs: &dyn Fs,
     visited: &mut HashSet<PathBuf, S>,
 ) -> (usize, usize) {
-    let canonical = file_path.to_path_buf();
+    // Normalize before the visited check so that `./a.md` and `a.md` map to
+    // the same key, preventing double-counting and strengthening cycle detection.
+    let canonical = normalize_path(file_path);
 
     if visited.contains(&canonical) {
         return (0, 0);

--- a/crates/libaipm/src/lint/rules/import_resolver.rs
+++ b/crates/libaipm/src/lint/rules/import_resolver.rs
@@ -1,0 +1,345 @@
+//! Import resolution for instruction files.
+//!
+//! Follows `@path/to/file.md` imports and relative markdown inline links,
+//! accumulating total line and character counts across all transitively
+//! imported files.  Circular references are detected and skipped; absolute
+//! paths and path-traversal segments (`..`) are rejected for safety.
+
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+use std::path::{Path, PathBuf};
+
+use crate::fs::Fs;
+
+/// Parse `@path/to/file.md` import lines from file content.
+///
+/// A line matches when it begins with `@`, contains no whitespace after the
+/// `@`, and ends with `.md` (after trimming surrounding whitespace).
+fn parse_at_imports(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            let rest = trimmed.strip_prefix('@')?;
+            // No whitespace allowed in the path portion
+            if rest.contains(char::is_whitespace) {
+                return None;
+            }
+            let ext = Path::new(rest).extension()?;
+            if ext.eq_ignore_ascii_case("md") {
+                Some(rest.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Parse relative markdown inline links that point to `.md` files.
+///
+/// Matches `[label](url)` patterns where `url` ends with `.md` and does not
+/// begin with `http://` or `https://` (external URLs are not followed).
+fn parse_markdown_links(content: &str) -> Vec<String> {
+    let mut links = Vec::new();
+    let mut remaining = content;
+
+    while let Some(bracket_close) = remaining.find("](") {
+        let after_paren = &remaining[bracket_close + 2..];
+        if let Some(paren_close) = after_paren.find(')') {
+            let url = &after_paren[..paren_close];
+            let is_md = Path::new(url).extension().is_some_and(|e| e.eq_ignore_ascii_case("md"));
+            if is_md && !url.starts_with("http://") && !url.starts_with("https://") {
+                links.push(url.to_string());
+            }
+        }
+        remaining = &remaining[bracket_close + 2..];
+    }
+
+    links
+}
+
+/// Return `true` when `path` is safe to follow.
+///
+/// Rejects absolute paths and any path containing `..` segments, preventing
+/// escapes outside the project tree.
+fn is_path_safe(path: &str) -> bool {
+    if Path::new(path).is_absolute() {
+        return false;
+    }
+    path.split('/').all(|segment| segment != "..")
+}
+
+/// Recursively resolve imports for a single file, accumulating sizes.
+///
+/// Returns `(total_lines, total_chars)` for the file itself plus all files it
+/// transitively imports through `@path` syntax or relative markdown links.
+///
+/// # Arguments
+/// * `file_path` — Absolute or project-relative path of the file to resolve.
+/// * `fs` — Filesystem abstraction for reading file contents.
+/// * `visited` — Set of already-visited paths; updated on entry to protect
+///   against circular imports.
+///
+/// Returns `(0, 0)` when the file cannot be read, has already been visited,
+/// or any error is encountered — callers treat such files as empty.
+pub fn resolve_imports<S: BuildHasher>(
+    file_path: &Path,
+    fs: &dyn Fs,
+    visited: &mut HashSet<PathBuf, S>,
+) -> (usize, usize) {
+    let canonical = file_path.to_path_buf();
+
+    if visited.contains(&canonical) {
+        return (0, 0);
+    }
+    visited.insert(canonical);
+
+    let Ok(content) = fs.read_to_string(file_path) else { return (0, 0) };
+
+    let direct_lines = content.lines().count();
+    let direct_chars = content.len();
+
+    let parent_dir = file_path.parent().unwrap_or_else(|| Path::new("."));
+
+    let mut total_lines = direct_lines;
+    let mut total_chars = direct_chars;
+
+    for import_path in parse_at_imports(&content) {
+        if is_path_safe(&import_path) {
+            let resolved = parent_dir.join(&import_path);
+            let (lines, chars) = resolve_imports(&resolved, fs, visited);
+            total_lines += lines;
+            total_chars += chars;
+        }
+    }
+
+    for link_path in parse_markdown_links(&content) {
+        if is_path_safe(&link_path) {
+            let resolved = parent_dir.join(&link_path);
+            let (lines, chars) = resolve_imports(&resolved, fs, visited);
+            total_lines += lines;
+            total_chars += chars;
+        }
+    }
+
+    (total_lines, total_chars)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::lint::rules::test_helpers::MockFs;
+
+    fn make_fs_with_file(path: &str, content: &str) -> MockFs {
+        let mut fs = MockFs::new();
+        let p = PathBuf::from(path);
+        fs.exists.insert(p.clone());
+        fs.files.insert(p, content.to_string());
+        fs
+    }
+
+    // --- parse_at_imports ---
+
+    #[test]
+    fn at_import_basic() {
+        let content = "@shared/context.md\n\nsome other text";
+        let imports = parse_at_imports(content);
+        assert_eq!(imports, vec!["shared/context.md"]);
+    }
+
+    #[test]
+    fn at_import_with_leading_whitespace_trimmed() {
+        let content = "  @shared/context.md  ";
+        let imports = parse_at_imports(content);
+        assert_eq!(imports, vec!["shared/context.md"]);
+    }
+
+    #[test]
+    fn at_import_non_md_ignored() {
+        let content = "@config.json";
+        let imports = parse_at_imports(content);
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn at_import_with_spaces_ignored() {
+        let content = "@path with spaces.md";
+        let imports = parse_at_imports(content);
+        assert!(imports.is_empty());
+    }
+
+    // --- parse_markdown_links ---
+
+    #[test]
+    fn markdown_link_basic() {
+        let content = "See [other doc](./other.md) for details";
+        let links = parse_markdown_links(content);
+        assert_eq!(links, vec!["./other.md"]);
+    }
+
+    #[test]
+    fn external_url_ignored() {
+        let content = "[external](https://example.com/file.md)";
+        let links = parse_markdown_links(content);
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn http_url_ignored() {
+        let content = "[external](http://example.com/file.md)";
+        let links = parse_markdown_links(content);
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn non_md_link_ignored() {
+        let content = "[config](./config.json)";
+        let links = parse_markdown_links(content);
+        assert!(links.is_empty());
+    }
+
+    // --- is_path_safe ---
+
+    #[test]
+    fn path_traversal_rejected() {
+        assert!(!is_path_safe("../../etc/passwd"));
+    }
+
+    #[test]
+    fn absolute_path_rejected() {
+        assert!(!is_path_safe("/etc/passwd"));
+    }
+
+    #[test]
+    fn relative_path_safe() {
+        assert!(is_path_safe("shared/context.md"));
+    }
+
+    // --- resolve_imports integration ---
+
+    #[test]
+    fn at_import_resolves_and_sums_sizes() {
+        let mut fs = MockFs::new();
+        // main file imports shared.md
+        let main = PathBuf::from("CLAUDE.md");
+        let shared = PathBuf::from("shared.md");
+        fs.exists.insert(main.clone());
+        fs.files.insert(main.clone(), "@shared.md\nsome text".to_string());
+        fs.exists.insert(shared.clone());
+        fs.files.insert(shared, "shared content".to_string());
+
+        let mut visited = HashSet::new();
+        let (lines, chars) = resolve_imports(&main, &fs, &mut visited);
+        // main: 2 lines, shared: 1 line
+        assert_eq!(lines, 3);
+        // chars of both files combined
+        assert!(chars > 0);
+    }
+
+    #[test]
+    fn markdown_link_resolves() {
+        let mut fs = MockFs::new();
+        let main = PathBuf::from("CLAUDE.md");
+        let other = PathBuf::from("other.md");
+        fs.exists.insert(main.clone());
+        fs.files.insert(main.clone(), "See [other](other.md)".to_string());
+        fs.exists.insert(other.clone());
+        fs.files.insert(other, "other content\n".to_string());
+
+        let mut visited = HashSet::new();
+        let (lines, chars) = resolve_imports(&main, &fs, &mut visited);
+        assert_eq!(lines, 2); // main: 1, other: 1
+        assert!(chars > 0);
+    }
+
+    #[test]
+    fn circular_import_no_infinite_loop() {
+        let mut fs = MockFs::new();
+        let a = PathBuf::from("a.md");
+        let b = PathBuf::from("b.md");
+        fs.exists.insert(a.clone());
+        fs.files.insert(a.clone(), "@b.md\ncontent a".to_string());
+        fs.exists.insert(b.clone());
+        fs.files.insert(b, "@a.md\ncontent b".to_string());
+
+        let mut visited = HashSet::new();
+        // Should not loop; each file counted once
+        let (lines, _chars) = resolve_imports(&a, &fs, &mut visited);
+        assert_eq!(lines, 4); // a: 2 lines, b: 2 lines, a again: skipped (visited)
+    }
+
+    #[test]
+    fn path_traversal_in_at_import_rejected() {
+        let mut fs = make_fs_with_file("CLAUDE.md", "@../../etc/passwd.md\ntext");
+        let path = PathBuf::from("CLAUDE.md");
+        let mut visited = HashSet::new();
+        let (lines, _) = resolve_imports(&path, &fs, &mut visited);
+        // Only the CLAUDE.md content (2 lines), traversal not followed
+        assert_eq!(lines, 2);
+    }
+
+    #[test]
+    fn absolute_path_in_at_import_rejected() {
+        let mut fs = make_fs_with_file("CLAUDE.md", "@/etc/passwd.md\ntext");
+        let path = PathBuf::from("CLAUDE.md");
+        let mut visited = HashSet::new();
+        let (lines, _) = resolve_imports(&path, &fs, &mut visited);
+        assert_eq!(lines, 2);
+    }
+
+    #[test]
+    fn nested_imports_all_counted() {
+        let mut fs = MockFs::new();
+        let a = PathBuf::from("a.md");
+        let b = PathBuf::from("b.md");
+        let c = PathBuf::from("c.md");
+        fs.exists.insert(a.clone());
+        fs.files.insert(a.clone(), "@b.md\na content".to_string());
+        fs.exists.insert(b.clone());
+        fs.files.insert(b, "@c.md\nb content".to_string());
+        fs.exists.insert(c.clone());
+        fs.files.insert(c, "c content".to_string());
+
+        let mut visited = HashSet::new();
+        let (lines, _) = resolve_imports(&a, &fs, &mut visited);
+        assert_eq!(lines, 5); // a: 2, b: 2, c: 1
+    }
+
+    #[test]
+    fn missing_import_target_silently_skipped() {
+        let mut fs = make_fs_with_file("CLAUDE.md", "@nonexistent.md\ntext");
+        let path = PathBuf::from("CLAUDE.md");
+        let mut visited = HashSet::new();
+        let (lines, _) = resolve_imports(&path, &fs, &mut visited);
+        assert_eq!(lines, 2); // only CLAUDE.md counted
+    }
+
+    #[test]
+    fn mixed_imports_both_followed() {
+        let mut fs = MockFs::new();
+        let main = PathBuf::from("CLAUDE.md");
+        let imp = PathBuf::from("imported.md");
+        let linked = PathBuf::from("linked.md");
+        fs.exists.insert(main.clone());
+        fs.files.insert(main.clone(), "@imported.md\nSee [linked](linked.md)\ntext".to_string());
+        fs.exists.insert(imp.clone());
+        fs.files.insert(imp, "imported".to_string());
+        fs.exists.insert(linked.clone());
+        fs.files.insert(linked, "linked".to_string());
+
+        let mut visited = HashSet::new();
+        let (lines, _) = resolve_imports(&main, &fs, &mut visited);
+        assert_eq!(lines, 5); // main: 3, imported: 1, linked: 1
+    }
+
+    #[test]
+    fn missing_file_returns_zero() {
+        let fs = MockFs::new();
+        let path = PathBuf::from("nonexistent.md");
+        let mut visited = HashSet::new();
+        let result = resolve_imports(&path, &fs, &mut visited);
+        assert_eq!(result, (0, 0));
+    }
+}

--- a/crates/libaipm/src/lint/rules/instructions_oversized.rs
+++ b/crates/libaipm/src/lint/rules/instructions_oversized.rs
@@ -71,16 +71,17 @@ impl Rule for Oversized {
         let source_type_raw = scan::source_type_from_path(file_path);
         let source_type = if source_type_raw == "other" { "project" } else { source_type_raw };
 
+        // Compute direct counts once; reuse them in the non-resolve-imports path.
+        let direct_lines = content.lines().count();
+        let direct_chars = content.len();
+
         let (checked_lines, checked_chars, is_resolved) = if self.resolve_imports {
             let mut visited = HashSet::new();
             let (lines, chars) = import_resolver::resolve_imports(file_path, fs, &mut visited);
             (lines, chars, true)
         } else {
-            (content.lines().count(), content.len(), false)
+            (direct_lines, direct_chars, false)
         };
-
-        let direct_lines = content.lines().count();
-        let direct_chars = content.len();
 
         let mut diagnostics = Vec::new();
 

--- a/crates/libaipm/src/lint/rules/instructions_oversized.rs
+++ b/crates/libaipm/src/lint/rules/instructions_oversized.rs
@@ -1,0 +1,394 @@
+//! Rule: `instructions/oversized` — instruction file exceeds size thresholds.
+//!
+//! Emits up to two diagnostics per file: one if the line count exceeds
+//! `max_lines`, and one if the character count exceeds `max_chars`.  When
+//! `resolve_imports` is enabled, transitive `@import` and relative markdown
+//! links are followed and the aggregated size is checked instead.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::fs::Fs;
+use crate::lint::diagnostic::{Diagnostic, Severity};
+use crate::lint::rule::Rule;
+use crate::lint::Error;
+
+use super::import_resolver;
+use super::scan;
+
+/// Default maximum line count for instruction files.
+pub const DEFAULT_MAX_LINES: usize = 100;
+/// Default maximum character count for instruction files.
+pub const DEFAULT_MAX_CHARS: usize = 15_000;
+
+/// Checks that instruction files don't exceed line and character limits.
+pub struct Oversized {
+    /// Maximum number of lines allowed.
+    pub max_lines: usize,
+    /// Maximum number of characters allowed.
+    pub max_chars: usize,
+    /// When `true`, `@import` and relative markdown link chains are followed
+    /// and the resolved totals are checked instead of the direct file size.
+    pub resolve_imports: bool,
+}
+
+impl Default for Oversized {
+    fn default() -> Self {
+        Self { max_lines: DEFAULT_MAX_LINES, max_chars: DEFAULT_MAX_CHARS, resolve_imports: false }
+    }
+}
+
+impl Rule for Oversized {
+    fn id(&self) -> &'static str {
+        "instructions/oversized"
+    }
+
+    fn name(&self) -> &'static str {
+        "oversized instruction file"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn help_url(&self) -> Option<&'static str> {
+        Some("https://github.com/TheLarkInn/aipm/blob/main/docs/rules/instructions/oversized.md")
+    }
+
+    fn help_text(&self) -> Option<&'static str> {
+        Some("reduce instruction file size below the configured line and character limits")
+    }
+
+    fn check(&self, _source_dir: &Path, _fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error> {
+        // The unified discovery pipeline dispatches via check_file(); the legacy
+        // check() path is unused for instruction files.
+        Ok(vec![])
+    }
+
+    fn check_file(&self, file_path: &Path, fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error> {
+        let Ok(content) = fs.read_to_string(file_path) else { return Ok(vec![]) };
+
+        let source_type_raw = scan::source_type_from_path(file_path);
+        let source_type = if source_type_raw == "other" { "project" } else { source_type_raw };
+
+        let (checked_lines, checked_chars, is_resolved) = if self.resolve_imports {
+            let mut visited = HashSet::new();
+            let (lines, chars) = import_resolver::resolve_imports(file_path, fs, &mut visited);
+            (lines, chars, true)
+        } else {
+            (content.lines().count(), content.len(), false)
+        };
+
+        let direct_lines = content.lines().count();
+        let direct_chars = content.len();
+
+        let mut diagnostics = Vec::new();
+
+        if checked_lines > self.max_lines {
+            let message = if is_resolved {
+                format!(
+                    "instruction file exceeds {} line limit (resolved total: {} lines, direct: {} lines)",
+                    self.max_lines, checked_lines, direct_lines
+                )
+            } else {
+                format!(
+                    "instruction file exceeds {} line limit ({} lines)",
+                    self.max_lines, checked_lines
+                )
+            };
+            diagnostics.push(Diagnostic {
+                rule_id: self.id().to_string(),
+                severity: self.default_severity(),
+                message,
+                file_path: file_path.to_path_buf(),
+                line: Some(1),
+                col: None,
+                end_line: None,
+                end_col: None,
+                source_type: source_type.to_string(),
+                help_text: None,
+                help_url: None,
+            });
+        }
+
+        if checked_chars > self.max_chars {
+            let message = if is_resolved {
+                format!(
+                    "instruction file exceeds {} character limit (resolved total: {} chars, direct: {} chars)",
+                    self.max_chars, checked_chars, direct_chars
+                )
+            } else {
+                format!(
+                    "instruction file exceeds {} character limit ({} chars)",
+                    self.max_chars, checked_chars
+                )
+            };
+            diagnostics.push(Diagnostic {
+                rule_id: self.id().to_string(),
+                severity: self.default_severity(),
+                message,
+                file_path: file_path.to_path_buf(),
+                line: Some(1),
+                col: None,
+                end_line: None,
+                end_col: None,
+                source_type: source_type.to_string(),
+                help_text: None,
+                help_url: None,
+            });
+        }
+
+        Ok(diagnostics)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::lint::rules::test_helpers::MockFs;
+
+    fn make_rule() -> Oversized {
+        Oversized::default()
+    }
+
+    fn make_file(fs: &mut MockFs, path: &str, content: &str) -> PathBuf {
+        let p = PathBuf::from(path);
+        fs.exists.insert(p.clone());
+        fs.files.insert(p.clone(), content.to_string());
+        p
+    }
+
+    fn lines(n: usize) -> String {
+        (0..n).map(|i| format!("line {i}\n")).collect()
+    }
+
+    // --- basic threshold tests ---
+
+    #[test]
+    fn small_file_no_finding() {
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", "short content\n");
+        let result = make_rule().check_file(&path, &fs);
+        assert!(result.is_ok());
+        assert!(result.ok().unwrap_or_default().is_empty());
+    }
+
+    #[test]
+    fn exactly_at_line_limit_no_finding() {
+        let content = lines(DEFAULT_MAX_LINES);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", &content);
+        let result = make_rule().check_file(&path, &fs);
+        assert!(result.is_ok());
+        assert!(result.ok().unwrap_or_default().is_empty());
+    }
+
+    #[test]
+    fn exactly_at_char_limit_no_finding() {
+        let content = "x".repeat(DEFAULT_MAX_CHARS);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", &content);
+        let result = make_rule().check_file(&path, &fs);
+        assert!(result.is_ok());
+        assert!(result.ok().unwrap_or_default().is_empty());
+    }
+
+    #[test]
+    fn over_line_limit_one_diagnostic() {
+        let content = lines(DEFAULT_MAX_LINES + 1);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", &content);
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].rule_id, "instructions/oversized");
+        assert!(diags[0].message.contains("line limit"));
+    }
+
+    #[test]
+    fn over_char_limit_one_diagnostic() {
+        let content = "x".repeat(DEFAULT_MAX_CHARS + 1);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", &content);
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("character limit"));
+    }
+
+    #[test]
+    fn both_limits_exceeded_two_diagnostics() {
+        // Build content that exceeds both limits
+        let line_content = format!("{}\n", "x".repeat(200));
+        let content = line_content.repeat(DEFAULT_MAX_LINES + 1);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", &content);
+        let rule = make_rule();
+        let diags = rule.check_file(&path, &fs).ok().unwrap_or_default();
+        assert_eq!(diags.len(), 2);
+    }
+
+    #[test]
+    fn empty_file_no_finding() {
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", "");
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn missing_file_returns_empty() {
+        let fs = MockFs::new();
+        let path = PathBuf::from("CLAUDE.md");
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn case_insensitive_detection_claude_lowercase() {
+        let content = lines(DEFAULT_MAX_LINES + 1);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "claude.md", &content);
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert!(!diags.is_empty());
+    }
+
+    #[test]
+    fn instructions_md_suffix() {
+        let content = lines(DEFAULT_MAX_LINES + 1);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "frontend.instructions.md", &content);
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert!(!diags.is_empty());
+    }
+
+    #[test]
+    fn subdirectory_detection() {
+        let content = lines(DEFAULT_MAX_LINES + 1);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "packages/auth/CLAUDE.md", &content);
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert!(!diags.is_empty());
+    }
+
+    #[test]
+    fn custom_thresholds_trigger_at_lower_limit() {
+        let rule =
+            Oversized { max_lines: 50, max_chars: DEFAULT_MAX_CHARS, resolve_imports: false };
+        let content = lines(51);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", &content);
+        let diags = rule.check_file(&path, &fs).ok().unwrap_or_default();
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("50 line limit"));
+    }
+
+    #[test]
+    fn source_type_project_for_root_file() {
+        let content = lines(DEFAULT_MAX_LINES + 1);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, "CLAUDE.md", &content);
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert_eq!(diags[0].source_type, "project");
+    }
+
+    #[test]
+    fn source_type_claude_for_dotclaude_file() {
+        let content = lines(DEFAULT_MAX_LINES + 1);
+        let mut fs = MockFs::new();
+        let path = make_file(&mut fs, ".claude/CLAUDE.md", &content);
+        let diags = make_rule().check_file(&path, &fs).ok().unwrap_or_default();
+        assert_eq!(diags[0].source_type, ".claude");
+    }
+
+    // --- resolve-imports integration ---
+
+    #[test]
+    fn resolve_imports_basic() {
+        let rule = Oversized { max_lines: 5, max_chars: 10_000, resolve_imports: true };
+        let mut fs = MockFs::new();
+        let main = make_file(&mut fs, "CLAUDE.md", "@shared.md\nline2\nline3");
+        let shared = PathBuf::from("shared.md");
+        fs.exists.insert(shared.clone());
+        fs.files.insert(shared, "a\nb\nc\n".to_string());
+
+        // main: 3 lines, shared: 3 lines → total 6 > max_lines 5
+        let diags = rule.check_file(&main, &fs).ok().unwrap_or_default();
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("resolved total"));
+    }
+
+    #[test]
+    fn resolve_imports_circular_no_loop() {
+        let rule = Oversized { max_lines: 1, max_chars: 10_000, resolve_imports: true };
+        let mut fs = MockFs::new();
+        let a = PathBuf::from("a.md");
+        let b = PathBuf::from("b.md");
+        fs.exists.insert(a.clone());
+        fs.files.insert(a.clone(), "@b.md\ncontent a".to_string());
+        fs.exists.insert(b.clone());
+        fs.files.insert(b, "@a.md\ncontent b".to_string());
+
+        // Should not loop
+        let diags = rule.check_file(&a, &fs).ok().unwrap_or_default();
+        assert!(!diags.is_empty());
+    }
+
+    #[test]
+    fn resolve_imports_diagnostic_message_includes_both_counts() {
+        let rule = Oversized { max_lines: 3, max_chars: 10_000, resolve_imports: true };
+        let mut fs = MockFs::new();
+        let main = make_file(&mut fs, "CLAUDE.md", "@shared.md\nline2\nline3");
+        let shared = PathBuf::from("shared.md");
+        fs.exists.insert(shared.clone());
+        fs.files.insert(shared, "a\nb\n".to_string());
+
+        // total 5 lines > 3
+        let diags = rule.check_file(&main, &fs).ok().unwrap_or_default();
+        assert!(!diags.is_empty());
+        assert!(diags[0].message.contains("resolved total"));
+        assert!(diags[0].message.contains("direct"));
+    }
+
+    #[test]
+    fn resolve_imports_under_limit_no_finding() {
+        let rule = Oversized { max_lines: 100, max_chars: 100_000, resolve_imports: true };
+        let mut fs = MockFs::new();
+        let main = make_file(&mut fs, "CLAUDE.md", "@shared.md\nline2");
+        let shared = PathBuf::from("shared.md");
+        fs.exists.insert(shared.clone());
+        fs.files.insert(shared, "one line".to_string());
+
+        let diags = rule.check_file(&main, &fs).ok().unwrap_or_default();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn resolve_imports_markdown_link_followed() {
+        let rule = Oversized { max_lines: 2, max_chars: 10_000, resolve_imports: true };
+        let mut fs = MockFs::new();
+        let main = make_file(&mut fs, "CLAUDE.md", "See [other](linked.md)\ntext");
+        let linked = PathBuf::from("linked.md");
+        fs.exists.insert(linked.clone());
+        fs.files.insert(linked, "extra\nextra2\n".to_string());
+
+        // main: 2 lines, linked: 2 lines → total 4 > 2
+        let diags = rule.check_file(&main, &fs).ok().unwrap_or_default();
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn resolve_imports_disabled_by_default() {
+        let rule = Oversized::default();
+        assert!(!rule.resolve_imports);
+    }
+
+    #[test]
+    fn check_method_returns_empty() {
+        let rule = make_rule();
+        let fs = MockFs::new();
+        let result = rule.check(Path::new("."), &fs);
+        assert!(result.is_ok());
+        assert!(result.ok().unwrap_or_default().is_empty());
+    }
+}

--- a/crates/libaipm/src/lint/rules/mod.rs
+++ b/crates/libaipm/src/lint/rules/mod.rs
@@ -8,6 +8,8 @@ pub mod agent_missing_tools;
 pub mod broken_paths;
 pub mod hook_legacy_event;
 pub mod hook_unknown_event;
+pub mod import_resolver;
+pub mod instructions_oversized;
 pub mod known_events;
 pub mod marketplace_field_mismatch;
 pub mod marketplace_source_resolve;
@@ -29,13 +31,14 @@ pub(crate) mod test_helpers;
 use crate::discovery::{DiscoveredFeature, FeatureKind};
 use misplaced_features::MisplacedFeatures;
 
+use super::config::Config;
 use super::rule::Rule;
 
 /// Get quality rules applicable to a feature kind.
 ///
 /// These rules validate individual feature files without regard to which
 /// source directory the feature came from.
-pub(crate) fn quality_rules_for_kind(kind: &FeatureKind) -> Vec<Box<dyn Rule>> {
+pub(crate) fn quality_rules_for_kind(kind: &FeatureKind, config: &Config) -> Vec<Box<dyn Rule>> {
     match kind {
         FeatureKind::Skill => vec![
             Box::new(skill_missing_name::MissingName),
@@ -60,6 +63,26 @@ pub(crate) fn quality_rules_for_kind(kind: &FeatureKind) -> Vec<Box<dyn Rule>> {
             Box::new(plugin_missing_manifest::MissingManifest),
         ],
         FeatureKind::PluginJson => vec![Box::new(plugin_required_fields::RequiredFields)],
+        FeatureKind::Instructions => {
+            let opts = config.rule_options("instructions/oversized");
+            let max_lines = opts
+                .get("lines")
+                .and_then(toml::Value::as_integer)
+                .and_then(|v| usize::try_from(v).ok())
+                .unwrap_or(instructions_oversized::DEFAULT_MAX_LINES);
+            let max_chars = opts
+                .get("characters")
+                .and_then(toml::Value::as_integer)
+                .and_then(|v| usize::try_from(v).ok())
+                .unwrap_or(instructions_oversized::DEFAULT_MAX_CHARS);
+            let resolve_imports =
+                opts.get("resolve-imports").and_then(toml::Value::as_bool).unwrap_or(false);
+            vec![Box::new(instructions_oversized::Oversized {
+                max_lines,
+                max_chars,
+                resolve_imports,
+            })]
+        },
     }
 }
 
@@ -87,6 +110,7 @@ pub fn catalog() -> Vec<Box<dyn Rule>> {
         Box::new(plugin_missing_registration::MissingRegistration),
         Box::new(plugin_missing_manifest::MissingManifest),
         Box::new(plugin_required_fields::RequiredFields),
+        Box::new(instructions_oversized::Oversized::default()),
         Box::new(MisplacedFeatures { ai_exists: true }),
     ]
 }
@@ -102,38 +126,44 @@ pub(crate) const fn misplaced_features_rule(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lint::config::Config;
 
     #[test]
     fn quality_rules_for_skill_kind() {
-        let rules = quality_rules_for_kind(&FeatureKind::Skill);
+        let config = Config::default();
+        let rules = quality_rules_for_kind(&FeatureKind::Skill, &config);
         assert!(!rules.is_empty());
         assert!(rules.iter().any(|r| r.id() == "skill/missing-name"));
     }
 
     #[test]
     fn quality_rules_for_agent_kind() {
-        let rules = quality_rules_for_kind(&FeatureKind::Agent);
+        let config = Config::default();
+        let rules = quality_rules_for_kind(&FeatureKind::Agent, &config);
         assert!(!rules.is_empty());
         assert!(rules.iter().any(|r| r.id() == "agent/missing-tools"));
     }
 
     #[test]
     fn quality_rules_for_hook_kind() {
-        let rules = quality_rules_for_kind(&FeatureKind::Hook);
+        let config = Config::default();
+        let rules = quality_rules_for_kind(&FeatureKind::Hook, &config);
         assert!(!rules.is_empty());
         assert!(rules.iter().any(|r| r.id() == "hook/unknown-event"));
     }
 
     #[test]
     fn quality_rules_for_plugin_kind_includes_broken_paths() {
-        let rules = quality_rules_for_kind(&FeatureKind::Plugin);
+        let config = Config::default();
+        let rules = quality_rules_for_kind(&FeatureKind::Plugin, &config);
         assert!(!rules.is_empty());
         assert!(rules.iter().any(|r| r.id() == "plugin/broken-paths"));
     }
 
     #[test]
     fn quality_rules_for_marketplace_kind() {
-        let rules = quality_rules_for_kind(&FeatureKind::Marketplace);
+        let config = Config::default();
+        let rules = quality_rules_for_kind(&FeatureKind::Marketplace, &config);
         assert!(!rules.is_empty());
         assert!(rules.iter().any(|r| r.id() == "marketplace/source-resolve"));
         assert!(rules.iter().any(|r| r.id() == "marketplace/plugin-field-mismatch"));
@@ -143,8 +173,16 @@ mod tests {
 
     #[test]
     fn quality_rules_for_plugin_json_kind() {
-        let rules = quality_rules_for_kind(&FeatureKind::PluginJson);
+        let config = Config::default();
+        let rules = quality_rules_for_kind(&FeatureKind::PluginJson, &config);
         assert!(!rules.is_empty());
         assert!(rules.iter().any(|r| r.id() == "plugin/required-fields"));
+    }
+
+    #[test]
+    fn quality_rules_for_instructions_kind() {
+        let config = Config::default();
+        let rules = quality_rules_for_kind(&FeatureKind::Instructions, &config);
+        assert!(rules.iter().any(|r| r.id() == "instructions/oversized"));
     }
 }

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -1,295 +1,224 @@
 [
   {
     "category": "functional",
-    "description": "Hand-written JSON Schema for [workspace.lints] in aipm.toml (Phase 1 — G1)",
+    "description": "Add FeatureKind::Instructions variant to discovery.rs enum and extend classify_feature_kind() with case-insensitive matching for CLAUDE.md, AGENTS.md, COPILOT.md, INSTRUCTIONS.md, GEMINI.md, and *.instructions.md at any depth",
     "steps": [
-      "Create schemas/ directory at the repository root",
-      "Create schemas/aipm.toml.schema.json using JSON Schema Draft 4",
-      "Set root type to object with additionalProperties: true",
-      "Define workspace.lints as nested object under properties.workspace.properties.lints",
-      "Add ignore.paths as an array of strings",
-      "Add patternProperties regex matching all rule IDs",
-      "Define oneOf for rule values: string enum OR object with level and ignore",
-      "Set additionalProperties: false on lints object to catch typos",
-      "Add x-taplo annotations with initKeys: [workspace.lints]",
-      "Add description fields for all properties"
+      "Add Instructions variant to FeatureKind enum in crates/libaipm/src/discovery.rs",
+      "Add INSTRUCTION_FILENAMES constant with lowercase filenames: claude.md, agents.md, copilot.md, instructions.md, gemini.md",
+      "In classify_feature_kind(), add case-insensitive filename check BEFORE existing checks using to_ascii_lowercase()",
+      "Add .instructions.md suffix check using ends_with on the lowercased filename",
+      "Update all existing match arms on FeatureKind throughout the codebase to handle the new Instructions variant",
+      "Verify the ordering ensures CLAUDE.md inside agents/ directory is classified as Instructions, not Agent",
+      "Run cargo build --workspace to confirm compilation"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "SchemaStore.org submission for zero-install schema discovery (Phase 1 — G2)",
+    "description": "Extend RuleOverride::Detailed variant in config.rs with an options BTreeMap<String, toml::Value> for per-rule custom options, and add rule_options() accessor method",
     "steps": [
-      "Fork the SchemaStore/schemastore repository on GitHub",
-      "Copy schemas/aipm.toml.schema.json to src/schemas/json/aipm.toml.json",
-      "Add catalog entry to src/api/json/catalog.json",
-      "Create positive and negative test fixtures",
-      "Run SchemaStore's test suite",
-      "Submit PR to SchemaStore/schemastore"
+      "Add options: BTreeMap<String, toml::Value> field to the Detailed variant of RuleOverride in crates/libaipm/src/lint/config.rs",
+      "Add use std::collections::BTreeMap to imports",
+      "Implement rule_options() method on Config that looks up a rule ID and returns its options (empty BTreeMap if not Detailed or rule not found)",
+      "Update all existing construction sites of RuleOverride::Detailed to include options: BTreeMap::new()",
+      "Run cargo build --workspace to confirm compilation"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Add field_value_range() shared helper for frontmatter range computation (Phase 2 — G4 prerequisite)",
+    "description": "Extend load_lint_config() in main.rs to forward unknown TOML keys (beyond 'level' and 'ignore') into the RuleOverride options BTreeMap",
     "steps": [
-      "Add pub fn field_value_range(line_content: &str, key: &str) -> Option<(usize, usize)> to frontmatter module",
-      "Returns 1-based (col, end_col) for the value portion after the colon",
-      "Handle whitespace between colon and value",
-      "Handle values with trailing whitespace via trim_end",
-      "Return None if key prefix not found",
-      "Write unit tests for exact match, extra spaces, wrong key, empty value",
-      "Run cargo clippy --workspace -- -D warnings",
-      "Run cargo test --workspace"
+      "In crates/aipm/src/main.rs load_lint_config(), when processing a TOML table for a rule, collect all keys that are not 'level' or 'ignore' into a BTreeMap<String, toml::Value>",
+      "Pass the collected options to RuleOverride::Detailed constructor",
+      "Ensure backward compatibility: existing aipm.toml files with only level/ignore continue to work",
+      "Run cargo build --workspace and cargo test --workspace to confirm no regressions"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate end_line/end_col in skill/missing-name rule (Phase 2 — G4)",
+    "description": "Change quality_rules_for_kind() signature to accept &Config parameter and update all call sites in the lint pipeline",
     "steps": [
-      "When field is absent: set line to closing ---, col=1, end_line=same, end_col=4",
-      "Use field_value_range() to compute col/end_col for existing name field",
-      "Add unit tests for missing field and populated range"
+      "Change signature of quality_rules_for_kind() in crates/libaipm/src/lint/rules/mod.rs from (kind: &FeatureKind) to (kind: &FeatureKind, config: &Config)",
+      "Add use super::config::Config to imports in rules/mod.rs",
+      "Update the call in run_rules_for_feature() in crates/libaipm/src/lint/mod.rs to pass config",
+      "Update any other call sites (check with grep for quality_rules_for_kind)",
+      "Existing match arms can ignore the config parameter \u2014 no logic changes needed for current rules",
+      "Run cargo build --workspace to confirm compilation"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate end_line/end_col in skill/missing-description rule (Phase 2 — G4)",
+    "description": "Create import_resolver.rs module with resolve_imports() function that follows @path imports and relative markdown inline links, with circular reference protection and path traversal rejection",
     "steps": [
-      "When field is absent: set line to closing ---, col=1, end_line=same, end_col=4",
-      "Use field_value_range() to compute col/end_col for description field",
-      "Add unit tests"
+      "Create crates/libaipm/src/lint/rules/import_resolver.rs",
+      "Implement parse_at_imports() function using regex ^@([^\\s]+\\.md)\\s*$ to extract @path import targets",
+      "Implement parse_markdown_links() function using regex \\[([^\\]]*)\\]\\(([^)]+\\.md)\\) to extract relative markdown links, filtering out http:// and https:// URLs",
+      "Implement resolve_imports(file_path, fs, visited: &mut HashSet<PathBuf>) -> (usize, usize) that recursively resolves imports",
+      "Add circular reference protection: check visited set before processing, insert path before recursing",
+      "Add path traversal protection: reject paths containing '..' segments or absolute paths",
+      "Handle missing import targets gracefully (return (0, 0) for unreadable files)",
+      "Add module declaration in crates/libaipm/src/lint/rules/mod.rs",
+      "Run cargo build --workspace to confirm compilation"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate end_line/end_col in skill/name-too-long rule (Phase 2 — G4)",
+    "description": "Create instructions_oversized.rs with Oversized struct (max_lines, max_chars, resolve_imports fields), Default impl, and Rule trait implementation with check_file() logic emitting up to 2 diagnostics per file using OR logic",
     "steps": [
-      "Use field_value_range() to compute col/end_col for the name field value",
-      "Set end_line equal to line",
-      "Add unit test: name exceeding 64 chars produces diagnostic with correct range"
+      "Create crates/libaipm/src/lint/rules/instructions_oversized.rs",
+      "Define DEFAULT_MAX_LINES = 100 and DEFAULT_MAX_CHARS = 15_000 constants",
+      "Define Oversized struct with pub max_lines: usize, pub max_chars: usize, pub resolve_imports: bool",
+      "Implement Default for Oversized using the constants and resolve_imports: false",
+      "Implement Rule trait: id() returns 'instructions/oversized', name() returns 'oversized instruction file', default_severity() returns Warning",
+      "Implement help_url() and help_text() with appropriate guidance",
+      "Implement check_file(): read file content, count lines and chars, optionally resolve imports, emit up to 2 diagnostics (one for lines, one for chars) using OR logic",
+      "Use source_type 'project' for files outside .ai/.claude/.github via scan::source_type_from_path() mapping 'other' to 'project'",
+      "When resolve_imports is true, call import_resolver::resolve_imports() and use resolved totals for threshold comparison",
+      "Format diagnostic messages differently for resolve-imports (include both resolved and direct counts) vs direct-only",
+      "Implement check() method that delegates to check_file() or iterates directory for instruction files",
+      "Add module declaration in crates/libaipm/src/lint/rules/mod.rs",
+      "Run cargo build --workspace to confirm compilation"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate end_line/end_col in skill/name-invalid-chars rule (Phase 2 — G4)",
+    "description": "Register instructions/oversized rule in quality_rules_for_kind() under FeatureKind::Instructions arm with config-based construction, and add to catalog() for LSP integration",
     "steps": [
-      "Use field_value_range() to compute col/end_col for the name field value",
-      "Set end_line equal to line",
-      "Add unit test: invalid chars produce diagnostic with correct col/end_col"
+      "In crates/libaipm/src/lint/rules/mod.rs quality_rules_for_kind(), add FeatureKind::Instructions arm",
+      "Extract options from config using config.rule_options('instructions/oversized')",
+      "Parse 'lines' option as usize with DEFAULT_MAX_LINES fallback",
+      "Parse 'characters' option as usize with DEFAULT_MAX_CHARS fallback",
+      "Parse 'resolve-imports' option as bool with false fallback",
+      "Construct Oversized { max_lines, max_chars, resolve_imports } and return in vec",
+      "Add Oversized::default() to catalog() vec for LSP rule registry",
+      "Run cargo build --workspace to confirm compilation"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate end_line/end_col in skill/description-too-long rule (Phase 2 — G4)",
+    "description": "Unit tests for FeatureKind::Instructions discovery classification \u2014 case-insensitive matching, instruction files in agents/ dir, *.instructions.md suffix, and ensuring regular agent .md files are unaffected",
     "steps": [
-      "Use field_value_range() to compute col/end_col for the description field value",
-      "Set end_line equal to line",
-      "Add unit test"
+      "Add test classify_claude_md: CLAUDE.md at root returns FeatureKind::Instructions",
+      "Add test classify_claude_md_lowercase: claude.md at root returns FeatureKind::Instructions",
+      "Add test classify_agents_md_in_agents_dir: agents/AGENTS.md returns FeatureKind::Instructions (not Agent)",
+      "Add test classify_instructions_md_suffix: frontend.instructions.md returns FeatureKind::Instructions",
+      "Add test classify_regular_agent_unchanged: agents/security-reviewer.md still returns FeatureKind::Agent",
+      "Add test classify_gemini_md: GEMINI.md returns FeatureKind::Instructions",
+      "Add test classify_copilot_md: COPILOT.md returns FeatureKind::Instructions",
+      "Run cargo test --workspace to verify all pass"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate end_line/end_col in skill/invalid-shell rule (Phase 2 — G4)",
+    "description": "Unit tests for import_resolver.rs \u2014 @import syntax, markdown links, circular refs, path traversal, nested imports, missing targets, mixed imports",
     "steps": [
-      "Use field_value_range() to compute col/end_col for the shell field value",
-      "Set end_line equal to line",
-      "Add unit test: 'shell: zsh' produces diagnostic with col/end_col spanning 'zsh'"
+      "Add test at_import_basic: file with @path/to/file.md follows import and sums sizes",
+      "Add test markdown_link_basic: file with [text](./file.md) follows link and sums sizes",
+      "Add test external_url_ignored: [text](https://example.com/file.md) not followed",
+      "Add test non_md_link_ignored: [text](./config.json) not followed",
+      "Add test circular_import: A imports B, B imports A \u2014 no infinite loop, each file counted once",
+      "Add test path_traversal_rejected: @../../etc/passwd is ignored",
+      "Add test absolute_path_rejected: @/etc/passwd is ignored",
+      "Add test nested_imports: A -> B -> C chain of 3 all counted",
+      "Add test missing_import_target: @nonexistent.md silently skipped",
+      "Add test mixed_imports: file with both @import and markdown links, both followed",
+      "Run cargo test --workspace to verify all pass"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate end_line/end_col in agent/missing-tools rule (Phase 2 — G4)",
+    "description": "Unit tests for instructions_oversized rule \u2014 small file, at-limit, over-limit lines, over-limit chars, both exceeded, empty file, missing file, custom thresholds, source_type values",
     "steps": [
-      "When tools field is absent: set line to closing ---, col=1, end_line=same, end_col=4",
-      "Add unit test: missing tools field produces diagnostic at closing --- delimiter"
+      "Add test small_file_no_finding: file under both limits emits no diagnostics",
+      "Add test exactly_at_line_limit: exactly 100 lines emits no diagnostics",
+      "Add test exactly_at_char_limit: exactly 15000 characters emits no diagnostics",
+      "Add test over_line_limit: 101+ lines under char limit emits 1 diagnostic for lines",
+      "Add test over_char_limit: under line limit 15001+ chars emits 1 diagnostic for chars",
+      "Add test both_limits_exceeded: over both limits emits 2 diagnostics",
+      "Add test empty_file: empty instruction file emits no diagnostics",
+      "Add test missing_file: non-existent file returns empty vec",
+      "Add test case_insensitive_detection: claude.md lowercase is discovered and checked",
+      "Add test instructions_md_suffix: frontend.instructions.md is discovered and checked",
+      "Add test subdirectory_detection: packages/auth/CLAUDE.md is discovered and checked",
+      "Add test custom_thresholds: rule with lines=50 triggers at 51 lines",
+      "Add test source_type_project: file at project root has source_type 'project'",
+      "Add test source_type_claude: file at .claude/CLAUDE.md has source_type '.claude'",
+      "Run cargo test --workspace to verify all pass"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate end_col in plugin/broken-paths rule (Phase 2 — G4)",
+    "description": "Unit tests for resolve-imports integration in the oversized rule \u2014 basic import resolution, circular refs, both resolved and direct sizes in diagnostic messages",
     "steps": [
-      "Add end_col spanning the full ${CLAUDE_SKILL_DIR}/path string",
-      "Set end_line equal to line",
-      "Add unit test: broken path produces diagnostic with col and end_col"
+      "Add test resolve_imports_basic: Oversized with resolve_imports=true follows @import and checks resolved total",
+      "Add test resolve_imports_circular: circular import chain does not infinite loop and counts each file once",
+      "Add test resolve_imports_diagnostic_message: diagnostic message includes both resolved total and direct size",
+      "Add test resolve_imports_under_limit: resolved total under limit emits no diagnostic",
+      "Add test resolve_imports_markdown_link: follows relative markdown links when resolve_imports=true",
+      "Add test resolve_imports_disabled_by_default: Oversized::default() does not follow imports",
+      "Run cargo test --workspace to verify all pass"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate line/col/end_col in hook/unknown-event rule (Phase 2 — G4)",
+    "description": "Config system tests \u2014 RuleOverride with options BTreeMap, rule_options() accessor, load_lint_config() forwarding custom TOML keys",
     "steps": [
-      "Add locate_json_key() helper to find key position in JSON content",
-      "Set line, col, end_col on diagnostics via the helper",
-      "Set end_line equal to line",
-      "Add unit test: unknown event produces diagnostic with line/col/end_col"
+      "Add test rule_override_detailed_with_options: Detailed variant stores and returns options",
+      "Add test rule_options_empty_for_non_detailed: Allow and Level variants return empty options",
+      "Add test config_rule_options_accessor: Config.rule_options() returns options for a known rule",
+      "Add test config_rule_options_missing_rule: Config.rule_options() returns empty for unknown rule",
+      "Add test load_lint_config_custom_keys: TOML with lines/characters/resolve-imports keys are parsed into options",
+      "Add test load_lint_config_backward_compatible: existing TOML with only level/ignore still works",
+      "Run cargo test --workspace to verify all pass"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Populate col/end_col in hook/legacy-event-name rule (Phase 2 — G4)",
+    "description": "Integration tests \u2014 full lint() pipeline discovers instruction files, config overrides thresholds, allow suppresses rule",
     "steps": [
-      "Add locate_json_key() helper to find key position in JSON content",
-      "Set col, end_col on diagnostics via the helper",
-      "Set end_line equal to line",
-      "Add unit test: legacy event produces diagnostic with col/end_col"
+      "Add test lint_discovers_instruction_files: full lint() call with MockFs containing oversized CLAUDE.md produces diagnostics",
+      "Add test lint_config_overrides_thresholds: custom lines/characters in config are respected by the rule",
+      "Add test lint_config_allow_suppresses: 'allow' in config suppresses instructions/oversized rule entirely",
+      "Run cargo test --workspace to verify all pass"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Verify human reporter renders populated ranges correctly (Phase 2 verification)",
+    "description": "Verify LSP integration \u2014 catalog() includes instructions/oversized, build_rule_index() picks it up, lint_file() dispatches for FeatureKind::Instructions files",
     "steps": [
-      "Verify the existing reporter logic handles col and end_col populated together",
-      "Run existing reporter snapshot tests to confirm no regressions",
-      "All 1751+ tests pass"
+      "Verify catalog() in rules/mod.rs includes Oversized::default()",
+      "Check crates/aipm/src/lsp/helpers.rs build_rule_index() \u2014 confirm it calls catalog() generically",
+      "Verify lint_file() in lsp/helpers.rs will dispatch rules for FeatureKind::Instructions files",
+      "If needed, update lint_file() to handle Instructions classification",
+      "Run cargo build --workspace to confirm compilation"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Add aipm lsp CLI subcommand with stdio transport (Phase 3 — G5)",
+    "description": "Run all four build gates (cargo build, test, clippy, fmt) with zero warnings and verify branch coverage >= 89%",
     "steps": [
-      "Add tower-lsp and tokio to workspace and aipm crate Cargo.toml",
-      "Add Commands::Lsp variant to clap CLI in main.rs",
-      "Create crates/aipm/src/lsp.rs with Backend struct",
-      "Implement LanguageServer trait: initialize, shutdown, did_open, did_save, did_close",
-      "Implement find_workspace_dir() for workspace root detection",
-      "Implement to_lsp_diagnostic() for 1-based to 0-based range conversion",
-      "Implement lint_file_diagnostics() wrapping libaipm::lint::lint()",
-      "Wire Lsp command in main.rs to lsp::run()"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "LSP textDocument/completion for aipm.toml rule IDs and severity values (Phase 3 — G6)",
-    "steps": [
-      "Build rule index at Backend::new() via libaipm::lint::rules::catalog()",
-      "Implement completion() handler in LanguageServer impl",
-      "Detect cursor context: inside [workspace.lints] section via detect_completion_context()",
-      "Return rule ID completions at key positions, severity completions at value positions",
-      "Return level/ignore object key completions at key positions",
-      "Add unit tests for detect_completion_context() and severity_completions()"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "LSP textDocument/hover for rule ID documentation (Phase 3 — G7)",
-    "steps": [
-      "Implement hover() handler in LanguageServer impl",
-      "Use extract_rule_id_at() to find rule ID at cursor position",
-      "Look up rule in rule_index, return markdown with name, severity, help_text, help_url",
-      "Return None for non-rule-ID positions",
-      "Add unit tests for extract_rule_id_at()"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "LSP server integration tests for all 6 feature kinds (Phase 3 testing)",
-    "steps": [
-      "Create fixture files for each of the 6 feature kinds with known lint errors",
-      "Write integration tests that spawn aipm lsp and send LSP protocol messages",
-      "Assert publishDiagnostics response contains expected rule_id, severity, and range for each kind",
-      "Test stale diagnostic clearing: save fixed file, verify empty diagnostics published"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "VS Code extension scaffold with package.json and tomlValidation (Phase 4 — G3)",
-    "steps": [
-      "Create vscode-aipm/ directory with package.json, tsconfig.json, .vscodeignore",
-      "Add tomlValidation contribution pointing to bundled schema",
-      "Add aipm.lint.enable and aipm.path configuration properties",
-      "Copy schemas/aipm.toml.schema.json to vscode-aipm/schemas/"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "VS Code extension activation and LSP client connection (Phase 4 — G3)",
-    "steps": [
-      "Create vscode-aipm/src/extension.ts with activate() and deactivate()",
-      "Configure ServerOptions to spawn aipm lsp via stdio",
-      "Configure documentSelector for all 6 feature kinds",
-      "Add error handler to show notification when binary is not found",
-      "Push client to context.subscriptions for cleanup"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "LSP workspace detection for multi-root and nested projects (Phase 3 infrastructure)",
-    "steps": [
-      "Implement find_workspace_dir(): walk up parent dirs until aipm.toml or .ai/ found",
-      "Fall back to file's parent when no marker found",
-      "Add unit tests: with aipm.toml marker, with .ai/ marker, fallback to parent"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "LSP graceful error handling for missing binary and missing config (Phase 3/4)",
-    "steps": [
-      "lint_file_diagnostics() logs warning and returns empty vec on lint error",
-      "load_lint_config() returns default config when aipm.toml is missing or malformed",
-      "VS Code extension errorHandler shows notification on unexpected server close"
-    ],
-    "passes": true
-  },
-  {
-    "category": "performance",
-    "description": "LSP debounce and startup performance (Phase 3 — 7.1)",
-    "steps": [
-      "Add 300ms debounce using tokio::time::sleep before triggering re-lint on save",
-      "Verify initialize response completes in <100ms",
-      "Verify full lint pass completes in <500ms on typical project",
-      "Add tracing spans around lint execution"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "JSON Schema positive/negative test fixtures for schema validation (Phase 1 testing)",
-    "steps": [
-      "Create schemas/tests/valid.toml with valid [workspace.lints] section",
-      "Create schemas/tests/valid-with-other-sections.toml with non-lints sections",
-      "Create schemas/tests/invalid-unknown-rule.toml with typo in rule ID",
-      "Create schemas/tests/invalid-wrong-type.toml with number value instead of string"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Range population unit tests for all modified rules (Phase 2 testing)",
-    "steps": [
-      "Unit tests asserting end_line/end_col populated for all modified rules",
-      "Tests asserting col is correct (1-based)",
-      "Tests for missing-field case: end_line/end_col point to closing ---",
-      "Tests for hook rules: col and end_col span the event string"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "LSP coordinate conversion unit tests (Phase 3 testing)",
-    "steps": [
-      "Unit test: line=1,col=1,end_line=1,end_col=4 -> Range{start:Position(0,0),end:Position(0,3)}",
-      "Unit test: line=None,col=None -> Range{start:Position(0,0),end:Position(0,1)} (default)",
-      "Unit test: warning severity maps to DiagnosticSeverity::WARNING",
-      "Unit test: rule_id set as code field"
+      "Run cargo build --workspace and verify zero errors",
+      "Run cargo test --workspace and verify all tests pass",
+      "Run cargo clippy --workspace -- -D warnings and verify zero warnings",
+      "Run cargo fmt --check and verify formatting is correct",
+      "Run cargo +nightly llvm-cov clean --workspace",
+      "Run cargo +nightly llvm-cov --no-report --workspace --branch",
+      "Run cargo +nightly llvm-cov --no-report --doc",
+      "Run cargo +nightly llvm-cov report --doctests --branch --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\\.rs|lsp\\.rs)' and verify TOTAL branch column >= 89%",
+      "Fix any clippy warnings, formatting issues, or coverage gaps before marking complete"
     ],
     "passes": true
   }

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -1,0 +1,3 @@
+Iteration 1 complete - all 15 features implemented and verified
+Build gates: cargo build ✓, cargo test ✓, cargo clippy ✓, cargo fmt ✓
+Coverage: 89.07% branch (≥89% required)

--- a/research/tickets/2026-04-11-185-prevent-long-instructions-files.md
+++ b/research/tickets/2026-04-11-185-prevent-long-instructions-files.md
@@ -1,0 +1,405 @@
+---
+date: 2026-04-11 14:30:00 UTC
+researcher: Claude Opus 4.6
+git_commit: 325ab6bdfadc11b929e975498692455e777acba6
+branch: fix/vscode-extension-launch-lsp
+repository: aipm
+topic: "[lint] new rule — prevent long instructions files (Issue #185)"
+tags: [research, lint, instructions, claude-md, agents-md, copilot-md, file-size, token-limit]
+status: complete
+last_updated: 2026-04-11
+last_updated_by: Claude Opus 4.6
+last_updated_note: "Added follow-up research on recursive subdirectory detection of instruction files (lazy-loaded per-directory pattern)"
+---
+
+# Research: Prevent Long Instructions Files — Issue #185
+
+## Research Question
+
+What is required to implement a new `aipm lint` rule that warns when AI instruction files (CLAUDE.md, AGENTS.md, COPILOT.md, INSTRUCTIONS.md) exceed configurable line or character limits?
+
+## Issue Summary
+
+**GitHub Issue**: [TheLarkInn/aipm#185](https://github.com/TheLarkInn/aipm/issues/185)
+**Title**: `[lint] new rule — prevent long instructions files`
+**Author**: @TheLarkInn
+**Created**: 2026-04-02
+**State**: Open
+**Labels**: `lint`
+
+**Problem statement**: Most AI models re-inject instruction files (CLAUDE.md, agents.md, etc.) into every turn of a conversation. Excessively long instruction files waste context window tokens on every interaction. A configurable lint rule should warn users when their instruction files are too long.
+
+**Requested detectors**: AGENTS.md, INSTRUCTIONS.md, CLAUDE.md, COPILOT.md (for now).
+
+**Configurable options** from the issue:
+- `lines` (number), default: 100
+- `characters` (number), default: ? (unspecified)
+- `ignore` pattern (possibly already built into framework?)
+
+## Summary
+
+This rule requires a new category of lint target — **project-root instruction files** — which the current lint pipeline does not discover or classify. The existing discovery pipeline (`discover_features()`) only finds feature files inside `.ai/`, `.claude/`, and `.github/` directory structures (skills, agents, hooks, plugins). Root-level `.md` files like `CLAUDE.md` and `AGENTS.md` are completely invisible to the current lint system.
+
+Implementation requires:
+1. A new file discovery mechanism (or extension of the existing one) to find instruction files at project root and known subdirectories
+2. A new `FeatureKind` variant (e.g., `Instructions`) or a standalone rule that bypasses the feature-kind dispatch
+3. A new lint rule struct with configurable thresholds (unlike all existing rules which use hardcoded constants)
+4. Extension of the `aipm.toml` config parsing to support per-rule options beyond severity/ignore
+
+## Detailed Findings
+
+### 1. Instruction File Locations (Known Conventions)
+
+Based on research from the Copilot CLI source analysis ([`research/docs/2026-03-28-copilot-cli-source-code-analysis.md`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/research/docs/2026-03-28-copilot-cli-source-code-analysis.md)) and Claude Code defaults ([`research/docs/2026-03-16-claude-code-defaults.md`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/research/docs/2026-03-16-claude-code-defaults.md)):
+
+| Tool | Convention Dir | Filename | Scope |
+|------|---------------|----------|-------|
+| Claude Code | `.` (project root) | `CLAUDE.md` | Project instructions |
+| Claude Code | `.claude/` | `CLAUDE.md` | Project instructions (alternative) |
+| Claude Code | `~/.claude/` | `CLAUDE.md` | Personal/global instructions |
+| Copilot CLI | `.github/` | `copilot-instructions.md` | Project instructions |
+| Copilot CLI | `.github/instructions/` | `*.instructions.md` | Scoped instructions |
+| Copilot CLI | `.` (project root) | `AGENTS.md` | Agent instructions |
+| Copilot CLI | `.` (project root) | `GEMINI.md` | Gemini instructions |
+| General | `.` (project root) | `COPILOT.md` | Copilot instructions |
+| General | `.` (project root) | `INSTRUCTIONS.md` | Generic instructions |
+
+**Key finding**: Copilot CLI reads `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in addition to its own `copilot-instructions.md`. This cross-reading behavior makes the issue's concern about re-injection particularly relevant.
+
+### 2. Current Lint Discovery Pipeline — Gap Analysis
+
+The lint pipeline discovers files via `discover_features()` at [`crates/libaipm/src/discovery.rs:280-350`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/discovery.rs#L280-L350).
+
+**How discovery currently works**:
+- Uses `ignore::WalkBuilder` for gitignore-aware recursive directory walking
+- Each file is classified by `classify_feature_kind()` at [`discovery.rs:233-278`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/discovery.rs#L233-L278)
+- Classification is based on filename + parent/grandparent directory naming conventions
+- Files that don't match any `FeatureKind` pattern are silently skipped (`None` returned)
+
+**What the current system classifies**:
+- `SKILL.md` in `skills/` directories → `FeatureKind::Skill`
+- `*.md` in `agents/` directories → `FeatureKind::Agent`
+- `hooks.json` in `hooks/` directories → `FeatureKind::Hook`
+- `aipm.toml` in `.ai/<plugin>/` → `FeatureKind::Plugin`
+- `marketplace.json` in `.ai/.claude-plugin/` → `FeatureKind::Marketplace`
+- `plugin.json` in `.ai/<plugin>/.claude-plugin/` → `FeatureKind::PluginJson`
+
+**What is NOT classified** (and therefore invisible to lint):
+- `CLAUDE.md` at project root or `.claude/CLAUDE.md`
+- `AGENTS.md` at project root
+- `COPILOT.md` at project root
+- `INSTRUCTIONS.md` at project root
+- `.github/copilot-instructions.md`
+- `.github/instructions/*.instructions.md`
+
+### 3. Existing Size-Based Rule: `skill/oversized`
+
+The closest existing pattern is the `skill/oversized` rule at [`crates/libaipm/src/lint/rules/skill_oversized.rs`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/lint/rules/skill_oversized.rs):
+
+- Uses a hardcoded `SKILL_CHAR_BUDGET = 15_000` constant (line 15)
+- Checks `skill.content.len() > SKILL_CHAR_BUDGET`
+- Returns a `Diagnostic` with the actual character count in the message
+- Has both `check()` (directory scan) and `check_file()` (single file) implementations
+- No configurable threshold — the constant is fixed at compile time
+
+**Differences from what #185 needs**:
+- `skill/oversized` operates on already-discovered `FeatureKind::Skill` files
+- Issue #185 targets files that are NOT currently discovered
+- Issue #185 requests configurable thresholds (lines AND characters), not hardcoded constants
+- Issue #185 targets multiple filename patterns, not a single `SKILL.md` pattern
+
+### 4. Lint Configuration System — Configurable Options Gap
+
+The current config system at [`crates/libaipm/src/lint/config.rs`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/lint/config.rs) supports:
+
+- **Severity override**: Change a rule's severity (`error`, `warn`, `allow`)
+- **Per-rule ignore paths**: Glob patterns to skip specific files for a specific rule
+- **Global ignore paths**: Glob patterns to skip files across all rules
+
+**What it does NOT support**:
+- **Per-rule custom options** (e.g., `lines = 100`, `characters = 5000`)
+
+The `RuleOverride` enum has three variants:
+```rust
+pub enum RuleOverride {
+    Allow,
+    Level(Severity),
+    Detailed { level: Severity, ignore: Vec<String> },
+}
+```
+
+To support configurable thresholds for the new rule, one of these approaches is needed:
+1. Extend `RuleOverride` with an additional variant or field for rule-specific options
+2. Add a separate config section for rule-specific options (e.g., `[workspace.lints.instructions/oversized.options]`)
+3. Make the rule read its own config key from the TOML (similar to how `load_lint_config()` at [`main.rs:748-836`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/aipm/src/main.rs#L748-L836) already navigates the TOML tree)
+
+### 5. Rule Registration Pattern
+
+New rules are registered in two places in [`crates/libaipm/src/lint/rules/mod.rs`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/lint/rules/mod.rs):
+
+1. **`quality_rules_for_kind()`** (line 38-64): Dispatches rules based on `FeatureKind`. A new rule needs either:
+   - A new `FeatureKind` variant (e.g., `Instructions`) with its own rule set
+   - Or a separate dispatch mechanism (like `misplaced_features` which runs outside the kind-based dispatch)
+
+2. **`catalog()`** (line 72-92): Returns all rules for LSP/tooling. The new rule must be added here too.
+
+### 6. Rule Trait Interface
+
+The `Rule` trait at [`crates/libaipm/src/lint/rule.rs:16-50`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/lint/rule.rs#L16-L50):
+
+```rust
+pub trait Rule: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn name(&self) -> &'static str;
+    fn default_severity(&self) -> Severity;
+    fn help_url(&self) -> Option<&'static str>;
+    fn help_text(&self) -> Option<&'static str>;
+    fn check(&self, source_dir: &Path, fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error>;
+    fn check_file(&self, file_path: &Path, fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error>;
+}
+```
+
+All current rules are **zero-sized unit structs** (stateless). A configurable rule would need to either:
+- Be a struct with fields for the thresholds (e.g., `pub struct InstructionsOversized { max_lines: usize, max_chars: usize }`)
+- Or read thresholds from a static/global config (less idiomatic)
+
+The struct-with-fields approach is compatible with the trait since `Rule` requires `Send + Sync` but not `Default` or zero-size.
+
+### 7. File Detection Approach — Design Considerations
+
+Since instruction files are NOT inside feature directories, the rule likely needs its own detection logic. Two approaches:
+
+**Approach A — Extend `FeatureKind`**:
+- Add `FeatureKind::Instructions` to the enum
+- Extend `classify_feature_kind()` to match known instruction filenames at expected locations
+- The file would flow through the normal lint pipeline
+- Pro: Cleanest integration with existing pipeline
+- Con: Instruction files aren't really "features" in the plugin sense
+
+**Approach B — Standalone rule with own file scanning**:
+- Similar to how `misplaced_features` is dispatched separately from quality rules
+- The rule runs its own targeted file scan (check project root, `.claude/`, `.github/` for known filenames)
+- Dispatch it in `lint()` alongside or after the feature loop
+- Pro: No changes to discovery/FeatureKind needed
+- Con: Introduces a second scanning pattern
+
+### 8. Known Instruction File Patterns to Detect
+
+Based on the issue and research, the initial set of detectors should cover:
+
+| Filename Pattern | Locations to Check |
+|---|---|
+| `CLAUDE.md` | Project root, `.claude/CLAUDE.md` |
+| `AGENTS.md` | Project root |
+| `COPILOT.md` | Project root |
+| `INSTRUCTIONS.md` | Project root |
+| `copilot-instructions.md` | `.github/copilot-instructions.md` |
+| `*.instructions.md` | `.github/instructions/` (recursive) |
+
+The issue specifically mentions: "We should have detectors for AGENTS, INSTRUCTIONS, CLAUDE, COPILOT.md for now."
+
+### 9. Suggested Rule ID Convention
+
+Following the existing hierarchical naming pattern:
+- `instructions/oversized` — aligns with `skill/oversized` naming
+- Alternative: `instructions/too-long` — more descriptive of line-based checking
+
+### 10. Default Thresholds — Research
+
+The issue proposes `lines: 100` as default. For characters, relevant benchmarks:
+- `skill/oversized` uses 15,000 characters (derived from Copilot CLI's `SKILL_CHAR_BUDGET`)
+- A 100-line markdown file is typically 3,000–8,000 characters depending on content
+- Claude's context window is ~200K tokens; a 100-line CLAUDE.md is ~500-1500 tokens
+- The concern is cumulative cost across many turns, not single-turn overflow
+
+## Code References
+
+- `crates/libaipm/src/lint/rules/skill_oversized.rs` — Existing size-based rule (closest pattern)
+- `crates/libaipm/src/lint/rules/mod.rs:38-64` — Rule dispatch table (`quality_rules_for_kind`)
+- `crates/libaipm/src/lint/rules/mod.rs:72-92` — Full rule catalog
+- `crates/libaipm/src/lint/rule.rs:16-50` — `Rule` trait definition
+- `crates/libaipm/src/lint/config.rs:1-54` — Config/override structs
+- `crates/libaipm/src/lint/mod.rs:115-162` — Lint pipeline entry point
+- `crates/libaipm/src/lint/mod.rs:68-104` — Per-feature rule dispatch
+- `crates/libaipm/src/discovery.rs:233-278` — Feature classification (gap: no instruction file support)
+- `crates/libaipm/src/discovery.rs:280-350` — Feature discovery walk
+- `crates/libaipm/src/lint/diagnostic.rs` — Diagnostic/Severity structures
+- `crates/libaipm/src/lint/rules/test_helpers.rs` — MockFs test infrastructure
+- `crates/aipm/src/main.rs:748-836` — TOML config loading (`load_lint_config`)
+
+## Architecture Documentation
+
+### Current Lint Pipeline Flow
+
+```
+aipm lint (CLI)
+  → cmd_lint() [main.rs:666]
+    → load_lint_config() [main.rs:748] → reads aipm.toml
+    → libaipm::lint::lint() [mod.rs:115]
+      → discover_features() [discovery.rs:280] → single recursive walk
+      → for each feature:
+        → quality_rules_for_kind(feature.kind) → dispatch rules
+        → misplaced_features_rule() → if outside .ai/
+      → sort diagnostics
+      → return Outcome
+    → reporter.report() → Text/Human/Json/CiGitHub/CiAzure
+```
+
+### Key Architectural Observations
+
+1. **All current rules operate on discovered features** — the new rule targets files that are not currently "features"
+2. **No rule currently has configurable thresholds** — all use compile-time constants
+3. **The config system supports severity overrides and ignores** but not arbitrary per-rule options
+4. **The `ignore` framework from the issue IS already built into the system** — `aipm.toml`'s `[workspace.lints.ignore]` and per-rule `ignore` patterns provide path-based filtering
+
+## Historical Context (from research/)
+
+- [`research/tickets/2026-03-28-110-aipm-lint.md`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/research/tickets/2026-03-28-110-aipm-lint.md) — Original lint research (Issue #110) referenced a BDD scenario with a "5000 token limit" for skill files; the shipped implementation uses 15,000 characters
+- [`research/docs/2026-03-28-copilot-cli-source-code-analysis.md`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/research/docs/2026-03-28-copilot-cli-source-code-analysis.md) — Documents that Copilot CLI reads `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` as instruction files (lines 317-321) and notes lint rules should check for these (line 434)
+- [`research/docs/2026-03-16-claude-code-defaults.md`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/research/docs/2026-03-16-claude-code-defaults.md) — Documents Claude Code's CLAUDE.md locations at project root, `.claude/CLAUDE.md`, and `~/.claude/CLAUDE.md` (line 38)
+- [`research/docs/2026-04-06-feature-status-audit.md`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/research/docs/2026-04-06-feature-status-audit.md) — Lists Issue #185 as an open non-roadmap issue under "New rule" category
+
+## Related Research
+
+- `research/docs/2026-03-31-110-aipm-lint-architecture-research.md` — Lint architecture deep dive
+- `research/docs/2026-04-02-aipm-lint-configuration-research.md` — Lint config system documentation
+- `specs/2026-03-31-aipm-lint-command.md` — Core lint spec
+- `specs/2026-04-07-lint-marketplace-plugin-json-rules.md` — Most recent new-rule spec (template for #185's spec)
+
+## Open Questions
+
+1. **Character default**: The issue leaves the default character limit as "?". Should it be derived from token estimates (e.g., ~4 chars/token × 1000 tokens = 4,000 chars)? Or based on the 100-line default (~5,000-8,000 chars)?
+2. **GEMINI.md**: Copilot CLI also reads `GEMINI.md` — should this be included in the initial set of detectors?
+3. **Scoped instructions**: Should `.github/instructions/*.instructions.md` files be included? These are scoped (not injected every turn) but could still be oversized.
+4. **Personal instruction files**: Should `~/.claude/CLAUDE.md` be checked? The lint command currently operates on project directories, not user-global paths.
+5. **FeatureKind extension vs. standalone scan**: Should instruction files be integrated into the discovery pipeline as a new `FeatureKind`, or should the rule use its own file scanning approach?
+6. **Config schema for custom options**: How should configurable thresholds be represented in `aipm.toml`? E.g.:
+   ```toml
+   [workspace.lints."instructions/oversized"]
+   level = "warn"
+   lines = 150
+   characters = 8000
+   ```
+   This would require extending the TOML parsing in `load_lint_config()` and the `RuleOverride` enum.
+7. **Both or either**: Should the rule trigger when EITHER the line limit OR the character limit is exceeded? Or only when both are exceeded?
+
+---
+
+## Follow-up Research 2026-04-11
+
+### Recursive Subdirectory Detection of Instruction Files
+
+Many real-world repos place instruction files in product-area subdirectories rather than (or in addition to) the project root. These files are designed to be **lazy-loaded**: the AI tool only injects them into context when work is occurring inside that subdirectory or the directory is otherwise relevant, saving top-level context budget. This pattern is in widespread use across both Claude Code and GitHub Copilot ecosystems.
+
+#### How Lazy-Loading Works Per Tool
+
+**Claude Code — hierarchical CLAUDE.md**
+
+Claude Code performs a directory walk-up at session start: it reads every `CLAUDE.md` found from the current working directory up to the project root. Files deeper in the directory tree are therefore loaded only when the working directory is inside that subtree. A common pattern:
+
+```
+repo-root/
+├── CLAUDE.md                    # always loaded — repo-wide instructions
+├── packages/
+│   ├── auth/
+│   │   └── CLAUDE.md            # loaded only when working inside packages/auth/
+│   ├── payments/
+│   │   └── CLAUDE.md            # loaded only when working inside packages/payments/
+│   └── ui/
+│       └── CLAUDE.md
+├── scripts/
+│   └── CLAUDE.md                # loaded only when working in scripts/
+└── .claude/
+    └── CLAUDE.md                # equivalent to root CLAUDE.md
+```
+
+This is documented in the Claude Code defaults research (`research/docs/2026-03-16-claude-code-defaults.md`, line 155): CLAUDE.md "supports `@path/to/import` syntax" — files can also chain imports to other subdirectory files.
+
+**GitHub Copilot — scoped `.instructions.md` files**
+
+Copilot CLI's `.github/instructions/` directory uses a glob-matched lazy-loading model: each `*.instructions.md` file has an `applyTo` frontmatter field (a glob pattern) specifying which files should trigger its inclusion:
+
+```
+.github/
+└── instructions/
+    ├── frontend.instructions.md       # applyTo: "src/frontend/**"
+    ├── auth-service.instructions.md   # applyTo: "services/auth/**"
+    ├── testing.instructions.md        # applyTo: "**/*.test.ts"
+    └── database.instructions.md       # applyTo: "src/db/**"
+```
+
+These files are scoped (not always injected) but can still accumulate to large sizes individually.
+
+Source: `research/docs/2026-03-28-copilot-cli-source-code-analysis.md`, lines 323-326.
+
+**AGENTS.md in subdirectories**
+
+The OpenAI agents convention (`AGENTS.md`) follows the same hierarchical walk-up pattern as `CLAUDE.md`. Subdirectory-scoped `AGENTS.md` files are loaded by the tool when context is relevant to that subtree.
+
+#### Implication: Repo-Wide Recursive Scan Is Required
+
+A rule that only checks known root-level locations (`./CLAUDE.md`, `./.claude/CLAUDE.md`, `./.github/copilot-instructions.md`) would produce **false negatives** for every subdirectory-scoped instruction file — which, in monorepos, may be the majority of instruction files present.
+
+The rule must perform a **full recursive scan of the project tree**, matching files by name regardless of depth. Pseudocode for the detection logic:
+
+```
+Walk entire project tree (gitignore-aware):
+  For each file encountered:
+    If filename matches any of the known instruction file patterns:
+      Collect as a candidate for the rule check
+```
+
+Known instruction file patterns (by filename only — location is arbitrary):
+
+| Filename pattern | Tool | Lazy-loaded? |
+|---|---|---|
+| `CLAUDE.md` | Claude Code | Yes — per directory depth |
+| `AGENTS.md` | OpenAI / Copilot | Yes — per directory depth |
+| `COPILOT.md` | Copilot | Yes — per directory depth |
+| `INSTRUCTIONS.md` | Generic | Yes — per directory depth |
+| `GEMINI.md` | Google Gemini CLI | Yes — per directory depth |
+| `*.instructions.md` | GitHub Copilot | Yes — `applyTo` scoped |
+
+#### Alignment with Existing Discovery Infrastructure
+
+The existing `discover_features()` function at [`crates/libaipm/src/discovery.rs:280-350`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/discovery.rs#L280-L350) already performs a gitignore-aware recursive walk via `ignore::WalkBuilder`. The same walk that discovers `SKILL.md` files anywhere in the tree can be extended to match instruction file naming patterns.
+
+Two viable implementation paths:
+
+**Option A — Extend `classify_feature_kind()` with a new `FeatureKind::Instructions` variant**
+
+Modify `classify_feature_kind()` at [`discovery.rs:233`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/discovery.rs#L233) to recognise instruction file names:
+
+```rust
+// Instruction files — match by filename only, any depth
+const INSTRUCTION_FILENAMES: &[&str] = &[
+    "CLAUDE.md", "AGENTS.md", "COPILOT.md", "INSTRUCTIONS.md", "GEMINI.md",
+];
+
+if INSTRUCTION_FILENAMES.contains(&file_name.as_ref()) {
+    return Some(FeatureKind::Instructions);
+}
+// Also match *.instructions.md (Copilot scoped instructions)
+if file_name.ends_with(".instructions.md") {
+    return Some(FeatureKind::Instructions);
+}
+```
+
+This integrates naturally with the existing single-pass walk. The `instructions/oversized` rule would be added to `quality_rules_for_kind()` under `FeatureKind::Instructions`, and the rule's `check_file()` receives each instruction file path directly.
+
+**Option B — Standalone scan inside the rule's `check()` method**
+
+The rule implements its own targeted walk (similar to how `scan::scan_skills()` iterates a directory tree). This avoids touching `discovery.rs` and `FeatureKind` but creates a second traversal of the filesystem per lint run.
+
+Given that Option A integrates with the existing single-pass design principle and the existing skip-list (`SKIP_DIRS`) already handles `node_modules`, `target`, etc., **Option A is architecturally preferred**.
+
+#### Handling the `source_type` Field
+
+The `Diagnostic.source_type` field currently holds `.ai`, `.claude`, or `.github`. Instruction files found at arbitrary subdirectory depths won't always be inside one of these directories. The `source_type_from_path()` function at [`scan.rs:169-180`](https://github.com/TheLarkInn/aipm/blob/325ab6bdfadc11b929e975498692455e777acba6/crates/libaipm/src/lint/rules/scan.rs#L169-L180) already returns `"other"` for paths outside recognized source dirs. For instruction files, returning `"other"` or a new `"instructions"` label (or the first recognized ancestor dir, or `"project"`) needs a decision.
+
+#### Updated Open Questions
+
+8. **Depth limit**: Should the recursive scan apply a maximum depth limit to avoid flagging instruction files buried deep in `node_modules`-style subtrees that slipped past the skip list? (The existing `max_depth` option from the CLI could apply.)
+9. **Filename matching — case sensitivity**: On case-insensitive filesystems (macOS, Windows) `claude.md` and `CLAUDE.md` are the same file. The detection should match case-insensitively, or document that only the uppercase convention is checked.
+10. **`.instructions.md` scoped files**: Because these files are `applyTo`-scoped (not always injected), their size budget concern is different from always-injected files. Should they be a separate rule variant or have a different default threshold?
+11. **`@path/to/import` chains**: Claude Code's `@import` syntax means a short root `CLAUDE.md` may pull in large imported files. A size check on the root file alone could give false confidence. Is checking the direct file content sufficient for the initial rule, with import-chain checking deferred?

--- a/specs/2026-04-11-lint-instructions-oversized.md
+++ b/specs/2026-04-11-lint-instructions-oversized.md
@@ -1,0 +1,613 @@
+# Lint Rule: `instructions/oversized` — Prevent Long Instruction Files
+
+| Document Metadata      | Details                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| Author(s)              | Sean Larkin                                                                  |
+| Status                 | Draft                                                                        |
+| Team / Owner           | aipm                                                                         |
+| Created / Last Updated | 2026-04-11                                                                   |
+| Issues                 | #185                                                                         |
+| Research               | `research/tickets/2026-04-11-185-prevent-long-instructions-files.md`         |
+
+## 1. Executive Summary
+
+This spec adds a new lint rule `instructions/oversized` that warns when AI instruction files (`CLAUDE.md`, `AGENTS.md`, `COPILOT.md`, `INSTRUCTIONS.md`, `GEMINI.md`, `*.instructions.md`) exceed configurable line or character limits. Most AI models re-inject these instruction files into every conversation turn, so excessively long files waste context window tokens on every interaction. The rule performs a recursive, case-insensitive scan of the entire project tree via a new `FeatureKind::Instructions` variant in the discovery pipeline, introduces configurable per-rule options in `aipm.toml` (a first for the lint system), and supports an opt-in `resolve-imports` mode that follows `@path` imports and relative markdown links to report total resolved content size.
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+The `aipm lint` pipeline discovers feature files (SKILL.md, agent .md, hooks.json, aipm.toml, marketplace.json, plugin.json) via a gitignore-aware recursive walk in `crates/libaipm/src/discovery.rs`. Each file is classified by `FeatureKind` and dispatched to rules via `quality_rules_for_kind()` in `crates/libaipm/src/lint/rules/mod.rs:38-64`.
+
+Currently, 17 lint rules exist — targeting skill frontmatter, agent frontmatter, hook JSON events, broken file paths, marketplace/plugin.json validation, and misplaced features. **None target instruction files** like `CLAUDE.md`, `AGENTS.md`, or `COPILOT.md`.
+
+The closest precedent is `skill/oversized` (`crates/libaipm/src/lint/rules/skill_oversized.rs`), which checks that `SKILL.md` files stay under a hardcoded 15,000-character budget. However, it only operates on files already classified as `FeatureKind::Skill`.
+
+**Key architectural gaps:**
+
+- **Discovery gap**: Root-level instruction files (`CLAUDE.md`, `AGENTS.md`, etc.) and subdirectory instruction files are invisible to the current discovery pipeline — `classify_feature_kind()` returns `None` for them (ref: `discovery.rs:233-278`).
+- **No configurable thresholds**: All 17 existing rules use hardcoded compile-time constants. The `RuleOverride` enum in `config.rs` only supports severity overrides and ignore paths — not arbitrary per-rule options.
+- **No instruction file awareness**: The codebase has zero references to `CLAUDE.md`, `AGENTS.md`, `COPILOT.md`, or `INSTRUCTIONS.md` as string literals in any detection or scanning logic. (Ref: research pattern-finder agent findings.)
+
+### 2.2 The Problem
+
+- **User Impact:** AI tools (Claude Code, GitHub Copilot, Gemini CLI) re-inject instruction files into every turn of a conversation. Long instruction files silently consume context window tokens, reducing the effective context available for actual work. Users have no automated feedback about this cost.
+- **Monorepo amplification:** Many repos place instruction files in product-area subdirectories (`packages/auth/CLAUDE.md`, `services/payments/CLAUDE.md`) for lazy-loading. A single monorepo may have dozens of instruction files, each independently contributing to context bloat when their subtree is in scope.
+- **Cross-tool reading:** Copilot CLI reads `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` in addition to its own `copilot-instructions.md` (ref: `research/docs/2026-03-28-copilot-cli-source-code-analysis.md`, lines 317-321). This means instruction file bloat affects multiple tools, not just the one the file was authored for.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] **`instructions/oversized` rule**: Warn when any instruction file exceeds the line limit (default: 100) or character limit (default: 15,000). Emit up to two separate diagnostics per file (one for lines, one for characters) using OR logic.
+- [ ] **Recursive detection**: Discover instruction files at any depth in the project tree via a new `FeatureKind::Instructions` variant in the discovery pipeline. Case-insensitive filename matching.
+- [ ] **Detected filenames**: `CLAUDE.md`, `AGENTS.md`, `COPILOT.md`, `INSTRUCTIONS.md`, `GEMINI.md`, `*.instructions.md` — all matched case-insensitively.
+- [ ] **Configurable options**: Support `lines`, `characters`, and `resolve-imports` options inline under the rule key in `aipm.toml`. This extends the config system to support per-rule custom options (a new capability).
+- [ ] **`resolve-imports` option**: When enabled (default: `false`), follow `@path/to/file` imports and relative markdown links (`[text](./path/to/file.md)`) to compute the total resolved content size. Track visited files to prevent circular import loops. Report both resolved total and direct file size in diagnostics.
+- [ ] **`source_type` for diagnostics**: Use `"project"` for instruction files found outside `.ai/`, `.claude/`, `.github/` directories. Use the existing source type (`.claude`, `.github`, etc.) when the file is inside a recognized source directory.
+- [ ] All rules configurable via `aipm.toml` `[workspace.lints]` (allow, warn, error, plus custom options).
+- [ ] Rule has `help_text` and `help_url` guiding the user to reduce file size.
+- [ ] Unit tests using `MockFs` covering: small file (pass), at-limit (pass), over-limit lines (fail), over-limit chars (fail), both exceeded (two diagnostics), case-insensitive detection, recursive subdirectory detection, `resolve-imports` with circular refs, `resolve-imports` with `@import` and markdown links, empty file, missing file.
+- [ ] All four `cargo build/test/clippy/fmt` gates pass with zero warnings.
+- [ ] Branch coverage remains >= 89%.
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] Checking personal/user-global instruction files (`~/.claude/CLAUDE.md`). The lint command operates on project directories only.
+- [ ] Different thresholds for scoped `.instructions.md` files vs. always-injected files. Same defaults apply; users override via config.
+- [ ] Depth limits on recursive scanning. The existing `SKIP_DIRS` list + gitignore filtering is sufficient.
+- [ ] Auto-fix capability (splitting files, extracting sections). Future work.
+- [ ] Validating instruction file content quality or structure (frontmatter correctness, etc.). This rule only checks size.
+- [ ] Configurable import pattern syntax. Only `@path` and inline relative markdown links to local `.md` files are recognized.
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Discovery Extension
+
+Extend `FeatureKind` in `crates/libaipm/src/discovery.rs` with a new variant:
+
+```
+FeatureKind::Instructions — triggered by case-insensitive filename match against known instruction file patterns
+```
+
+Detection logic in `classify_feature_kind()` (case-insensitive):
+
+| Pattern | Match Logic |
+|---|---|
+| `CLAUDE.md` | `file_name.eq_ignore_ascii_case("CLAUDE.md")` |
+| `AGENTS.md` | `file_name.eq_ignore_ascii_case("AGENTS.md")` |
+| `COPILOT.md` | `file_name.eq_ignore_ascii_case("COPILOT.md")` |
+| `INSTRUCTIONS.md` | `file_name.eq_ignore_ascii_case("INSTRUCTIONS.md")` |
+| `GEMINI.md` | `file_name.eq_ignore_ascii_case("GEMINI.md")` |
+| `*.instructions.md` | `file_name_lower.ends_with(".instructions.md")` |
+
+These checks apply at **any depth** — the existing `discover_features()` walk already recurses through the full project tree (gitignore-aware, skipping `SKIP_DIRS`).
+
+### 4.2 Rule Dispatch
+
+Add a new arm to `quality_rules_for_kind()` in `crates/libaipm/src/lint/rules/mod.rs`:
+
+```rust
+FeatureKind::Instructions => vec![
+    Box::new(instructions_oversized::Oversized::default()),
+],
+```
+
+And add the rule to `catalog()` for LSP integration.
+
+### 4.3 Config Extension
+
+Extend the TOML parsing in `load_lint_config()` (`crates/aipm/src/main.rs:748-836`) and the `RuleOverride` enum (`crates/libaipm/src/lint/config.rs`) to support per-rule custom options.
+
+Config surface in `aipm.toml`:
+
+```toml
+[workspace.lints."instructions/oversized"]
+level = "warn"
+lines = 150
+characters = 20000
+resolve-imports = true
+ignore = ["vendor/**"]
+```
+
+### 4.4 System Flow
+
+```
+aipm lint (CLI)
+  → cmd_lint()
+    → load_lint_config()           → reads aipm.toml (including custom options)
+    → libaipm::lint::lint()
+      → discover_features()        → walks tree, classifies FeatureKind::Instructions
+      → for each Instructions feature:
+        → instructions_oversized::Oversized.check_file()
+          → read file content
+          → count lines, count characters
+          → if resolve-imports enabled:
+            → parse @imports and relative markdown links
+            → recursively resolve (tracking visited set)
+            → compute resolved totals
+          → emit diagnostics for exceeded limits
+      → sort diagnostics
+      → return Outcome
+    → reporter.report()
+```
+
+### 4.5 Key Components
+
+| Component | Responsibility | File Location | Justification |
+|---|---|---|---|
+| `FeatureKind::Instructions` | Classify instruction files during discovery | `crates/libaipm/src/discovery.rs` | Integrates with single-pass walk, reuses SKIP_DIRS |
+| `instructions_oversized::Oversized` | Rule struct with configurable thresholds | `crates/libaipm/src/lint/rules/instructions_oversized.rs` | Follows established rule pattern (skill_oversized.rs) |
+| `RuleOverride` extension | Support per-rule custom options | `crates/libaipm/src/lint/config.rs` | Required for configurable thresholds |
+| `import_resolver` module | Follow @imports and markdown links | `crates/libaipm/src/lint/rules/import_resolver.rs` | Encapsulated import resolution logic |
+| Config parsing extension | Parse custom options from TOML | `crates/aipm/src/main.rs` | Extends existing `load_lint_config()` |
+
+## 5. Detailed Design
+
+### 5.1 Discovery Changes (`discovery.rs`)
+
+#### 5.1.1 `FeatureKind` Enum
+
+```rust
+pub enum FeatureKind {
+    Skill,
+    Agent,
+    Hook,
+    Plugin,
+    Marketplace,
+    PluginJson,
+    Instructions,  // NEW
+}
+```
+
+#### 5.1.2 `classify_feature_kind()` Extension
+
+Add instruction file detection **before** the existing checks (to avoid a `.md` file in an `agents/` directory being misclassified if it happens to also match an instruction filename):
+
+```rust
+const INSTRUCTION_FILENAMES: &[&str] = &[
+    "claude.md", "agents.md", "copilot.md", "instructions.md", "gemini.md",
+];
+
+fn classify_feature_kind(file_path: &Path) -> Option<FeatureKind> {
+    let file_name = file_path.file_name()?.to_string_lossy();
+    let file_name_lower = file_name.to_ascii_lowercase();
+
+    // Instruction files — match by filename only (case-insensitive), any depth.
+    if INSTRUCTION_FILENAMES.contains(&file_name_lower.as_ref()) {
+        return Some(FeatureKind::Instructions);
+    }
+    if file_name_lower.ends_with(".instructions.md") {
+        return Some(FeatureKind::Instructions);
+    }
+
+    // ... existing classification logic unchanged ...
+}
+```
+
+**Important ordering consideration**: Instruction file checks MUST come first because a file like `agents/CLAUDE.md` should be classified as `Instructions`, not `Agent`. The existing `Agent` check matches `*.md` in an `agents/` directory — without this ordering, `CLAUDE.md` inside `agents/` would be misclassified. However, `AGENTS.md` inside an `agents/` directory is an instruction file, not an agent definition. The case-insensitive filename match on the known instruction filenames takes priority.
+
+#### 5.1.3 `SourceContext` for Instructions
+
+Instruction files at arbitrary depths may not be inside `.ai/`, `.claude/`, or `.github/`. The existing `classify_source_context()` already returns `None` for such files, and `source_type_from_path()` returns `"other"`. The rule will use `"project"` as the source type for instruction files outside recognized source directories:
+
+```rust
+// In the rule's check_file():
+let source_type = match scan::source_type_from_path(file_path) {
+    "other" => "project",
+    s => s,
+};
+```
+
+### 5.2 Rule Implementation (`instructions_oversized.rs`)
+
+#### 5.2.1 Rule Struct
+
+Unlike existing zero-sized unit structs, this rule carries configurable state:
+
+```rust
+/// Default line limit for instruction files.
+const DEFAULT_MAX_LINES: usize = 100;
+
+/// Default character limit for instruction files.
+const DEFAULT_MAX_CHARS: usize = 15_000;
+
+/// Checks that instruction files don't exceed line or character limits.
+pub struct Oversized {
+    pub max_lines: usize,
+    pub max_chars: usize,
+    pub resolve_imports: bool,
+}
+```
+
+A `Default` implementation provides the defaults:
+
+```rust
+impl Default for Oversized {
+    fn default() -> Self {
+        Self {
+            max_lines: DEFAULT_MAX_LINES,
+            max_chars: DEFAULT_MAX_CHARS,
+            resolve_imports: false,
+        }
+    }
+}
+```
+
+#### 5.2.2 Rule Trait Implementation
+
+```rust
+impl Rule for Oversized {
+    fn id(&self) -> &'static str { "instructions/oversized" }
+    fn name(&self) -> &'static str { "oversized instruction file" }
+    fn default_severity(&self) -> Severity { Severity::Warning }
+
+    fn help_url(&self) -> Option<&'static str> {
+        Some("https://github.com/TheLarkInn/aipm/blob/main/docs/rules/instructions/oversized.md")
+    }
+
+    fn help_text(&self) -> Option<&'static str> {
+        Some("reduce instruction file size; AI tools re-inject these files every conversation turn")
+    }
+
+    fn check_file(&self, file_path: &Path, fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error> {
+        // ... see detailed logic below
+    }
+
+    fn check(&self, source_dir: &Path, fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error> {
+        // Instruction files are discovered by FeatureKind dispatch,
+        // so check() delegates to check_file() via the default implementation,
+        // or iterates the directory for instruction files.
+        // ...
+    }
+}
+```
+
+#### 5.2.3 `check_file()` Logic
+
+```
+1. Read file content via fs.read_to_string(file_path)
+   - If file doesn't exist or can't be read, return Ok(vec![])
+
+2. Compute direct metrics:
+   - direct_lines = content.lines().count()
+   - direct_chars = content.len()
+
+3. If resolve_imports is enabled:
+   - Parse @imports and relative markdown links from content
+   - Recursively resolve imports (see §5.3)
+   - Compute resolved_lines and resolved_chars (sum of all unique files)
+   - Use resolved totals for threshold comparison
+   - Include both resolved and direct sizes in diagnostic message
+   Else:
+   - Use direct_lines and direct_chars for threshold comparison
+
+4. Emit diagnostics (OR logic — up to 2 per file):
+   a. If effective_lines > max_lines:
+      → Diagnostic with message including line count and limit
+   b. If effective_chars > max_chars:
+      → Diagnostic with message including char count and limit
+
+5. Return collected diagnostics
+```
+
+**Diagnostic message format** (without resolve-imports):
+```
+CLAUDE.md exceeds 100 line limit (247 lines)
+CLAUDE.md exceeds 15000 character limit (23450 chars)
+```
+
+**Diagnostic message format** (with resolve-imports enabled):
+```
+CLAUDE.md exceeds 100 line limit (350 lines resolved from 4 imports, 120 lines in file directly)
+CLAUDE.md exceeds 15000 character limit (23450 chars resolved from 4 imports, 5200 chars in file directly)
+```
+
+### 5.3 Import Resolution (`import_resolver.rs`)
+
+A new module encapsulating import chain resolution logic:
+
+#### 5.3.1 Recognized Import Syntaxes
+
+1. **`@path/to/file` imports** (Claude Code convention):
+   - Regex: `^@([^\s]+\.md)\s*$` (line must start with `@`, path must end in `.md`)
+   - Resolved relative to the directory containing the importing file
+
+2. **Relative markdown inline links** to local `.md` files:
+   - Regex: `\[([^\]]*)\]\(([^)]+\.md)\)` where the URL does not start with `http://` or `https://`
+   - Only links pointing to `.md` files are followed
+   - Resolved relative to the directory containing the importing file
+
+#### 5.3.2 Resolution Algorithm
+
+```
+fn resolve_imports(
+    file_path: &Path,
+    fs: &dyn Fs,
+    visited: &mut HashSet<PathBuf>,
+) -> (usize, usize)  // (total_lines, total_chars)
+{
+    1. Canonicalize file_path
+    2. If visited.contains(file_path), return (0, 0)  // circular ref — skip
+    3. Insert file_path into visited
+    4. Read file content
+    5. Accumulate content.lines().count() and content.len()
+    6. For each @import and relative markdown link found:
+       a. Resolve the target path relative to file_path's parent directory
+       b. Reject paths containing ".." traversal or absolute paths (security)
+       c. Recursively call resolve_imports(target_path, fs, visited)
+       d. Add returned (lines, chars) to accumulator
+    7. Return accumulated totals
+}
+```
+
+**Circular import handling**: Track visited file paths in a `HashSet<PathBuf>`. If a file has already been visited, skip it silently and return `(0, 0)`. No error, no warning — the content is simply not double-counted.
+
+**Path traversal protection**: Reject import targets containing `..` segments or that resolve to absolute paths. This mirrors the existing path traversal protection in `broken_paths.rs`.
+
+### 5.4 Config System Extension
+
+#### 5.4.1 `RuleOverride` Extension (`config.rs`)
+
+Extend the `Detailed` variant to carry optional per-rule options:
+
+```rust
+pub enum RuleOverride {
+    Allow,
+    Level(Severity),
+    Detailed {
+        level: Severity,
+        ignore: Vec<String>,
+        options: BTreeMap<String, toml::Value>,  // NEW: per-rule custom options
+    },
+}
+```
+
+Add a method to extract options:
+
+```rust
+impl RuleOverride {
+    pub fn rule_options(&self) -> &BTreeMap<String, toml::Value> {
+        static EMPTY: BTreeMap<String, toml::Value> = BTreeMap::new();
+        match self {
+            Self::Detailed { options, .. } => options,
+            _ => &EMPTY,
+        }
+    }
+}
+```
+
+#### 5.4.2 Config Loading (`main.rs`)
+
+Extend `load_lint_config()` to parse custom keys from the TOML table. Currently, the function reads `level` and `ignore` from table values. Additional keys are passed through into the `options` map:
+
+```rust
+// When processing a TOML table for a rule:
+// Known keys: "level", "ignore"
+// Everything else: forwarded to options BTreeMap
+for (key, value) in table {
+    match key.as_str() {
+        "level" => { /* existing parsing */ },
+        "ignore" => { /* existing parsing */ },
+        _ => { options.insert(key.clone(), value.clone()); },
+    }
+}
+```
+
+#### 5.4.3 Rule Construction with Config
+
+The lint pipeline needs to pass config options to the rule constructor. Currently, rules are constructed statelessly in `quality_rules_for_kind()`. For the `Instructions` kind, the rule must be constructed with options from config:
+
+```rust
+FeatureKind::Instructions => {
+    let opts = config.rule_options("instructions/oversized");
+    let max_lines = opts.get("lines")
+        .and_then(|v| v.as_integer())
+        .map(|v| v as usize)
+        .unwrap_or(DEFAULT_MAX_LINES);
+    let max_chars = opts.get("characters")
+        .and_then(|v| v.as_integer())
+        .map(|v| v as usize)
+        .unwrap_or(DEFAULT_MAX_CHARS);
+    let resolve_imports = opts.get("resolve-imports")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    vec![Box::new(Oversized { max_lines, max_chars, resolve_imports })]
+}
+```
+
+**Signature change**: `quality_rules_for_kind()` currently takes only `kind: &FeatureKind`. It needs to also accept `config: &Config` to extract rule options. This is a minimal API change since the function is `pub(crate)`.
+
+```rust
+pub(crate) fn quality_rules_for_kind(kind: &FeatureKind, config: &Config) -> Vec<Box<dyn Rule>> {
+    // ... existing arms unchanged (they ignore config) ...
+    // ... new Instructions arm uses config ...
+}
+```
+
+### 5.5 TOML Config Surface
+
+Full example of the configurable options in `aipm.toml`:
+
+```toml
+# Override severity and thresholds
+[workspace.lints."instructions/oversized"]
+level = "error"           # Override severity (default: "warn")
+lines = 200               # Max lines per file (default: 100)
+characters = 20000        # Max characters per file (default: 15000)
+resolve-imports = true    # Follow @imports and markdown links (default: false)
+ignore = ["vendor/**"]    # Skip specific paths
+
+# Or suppress entirely
+[workspace.lints]
+"instructions/oversized" = "allow"
+```
+
+### 5.6 Diagnostic Examples
+
+**Basic (resolve-imports = false):**
+
+```
+warning[instructions/oversized]: CLAUDE.md exceeds 100 line limit (247 lines)
+   --> CLAUDE.md:1
+    |
+  1 | # CLAUDE.md — Project Rules for AI Agents
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: reduce instruction file size; AI tools re-inject these files every conversation turn
+```
+
+**With resolve-imports = true:**
+
+```
+warning[instructions/oversized]: CLAUDE.md exceeds 15000 character limit (23450 chars resolved from 4 imports, 5200 chars in file directly)
+   --> CLAUDE.md:1
+    |
+  1 | # CLAUDE.md — Project Rules for AI Agents
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: reduce instruction file size; AI tools re-inject these files every conversation turn
+```
+
+**Subdirectory file:**
+
+```
+warning[instructions/oversized]: packages/auth/CLAUDE.md exceeds 100 line limit (187 lines)
+   --> packages/auth/CLAUDE.md:1
+```
+
+**Scoped instruction file:**
+
+```
+warning[instructions/oversized]: .github/instructions/frontend.instructions.md exceeds 100 line limit (340 lines)
+   --> .github/instructions/frontend.instructions.md:1
+```
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Reason for Rejection |
+|---|---|---|---|
+| **Standalone scan (no FeatureKind)** | No changes to discovery.rs; fully self-contained rule | Second filesystem traversal per lint run; doesn't reuse SKIP_DIRS; inconsistent with single-pass design | Rejected: violates the single-pass walk principle |
+| **Hardcoded thresholds only** | Simpler config; consistent with all 17 existing rules | Users can't tune for their project; issue explicitly requests configurability | Rejected: issue requirements mandate configurability |
+| **Separate rules for lines vs. chars** | Cleaner rule IDs; independent suppression | Doubles the number of rules; over-engineered for the use case | Rejected: one rule with OR logic is simpler |
+| **Token-based limit instead of chars** | More accurate cost model (tokens ≠ chars) | Requires a tokenizer dependency; different models tokenize differently | Rejected: character counting is a good-enough proxy (skill/oversized uses chars too) |
+| **Stub resolve-imports (defer implementation)** | Faster initial delivery | Import chains are a real source of hidden bloat; users requested full implementation | Rejected per decision in spec wizard |
+| **Depth-limited scan** | Avoids false positives in deeply nested trees | SKIP_DIRS + gitignore already filter junk; depth limits miss legitimate deep instruction files | Rejected: existing filtering is sufficient |
+| **Exact case matching only** | No false positives on differently-cased files | Misses `claude.md`, `Claude.md` etc. on case-sensitive filesystems; confusing UX | Rejected: case-insensitive is more forgiving |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Performance
+
+- **Single-pass walk**: Instruction files are discovered during the existing `discover_features()` walk. No additional filesystem traversal is needed.
+- **resolve-imports cost**: When enabled, each instruction file triggers additional file reads for imports. This is bounded by the `visited` set (each file read at most once) and path traversal rejection. The cost is proportional to the number of unique import targets, not the depth of the import chain.
+- **Case-insensitive matching**: `.to_ascii_lowercase()` on each filename during the walk adds negligible overhead.
+
+### 7.2 Compatibility
+
+- **Config backward compatibility**: Existing `aipm.toml` files that don't mention `instructions/oversized` are unaffected — the rule uses defaults. The config extension (forwarding unknown TOML keys to an `options` map) is backward-compatible since existing rules don't read options.
+- **`quality_rules_for_kind()` signature change**: Adding `config: &Config` parameter is a breaking change to the `pub(crate)` API. All call sites within the crate must be updated. External consumers are unaffected since the function is not `pub`.
+- **`FeatureKind::Instructions` addition**: This is an enum variant addition. All `match` arms on `FeatureKind` must add a new branch. This affects `quality_rules_for_kind()`, `catalog()`, and any display/serialization implementations.
+
+### 7.3 LSP Integration
+
+The new rule must be added to `catalog()` in `rules/mod.rs` so the LSP's `build_rule_index()` (`crates/aipm/src/lsp/helpers.rs:32`) includes it in hover/completion/diagnostic features. The `lint_file()` function in `lsp/helpers.rs` will automatically dispatch the rule for files classified as `FeatureKind::Instructions`.
+
+## 8. Migration, Rollout, and Testing
+
+### 8.1 Deployment Strategy
+
+This is a new lint rule with no migration. It ships as a `Warning` by default. Users can:
+- Suppress: `"instructions/oversized" = "allow"` in `aipm.toml`
+- Escalate: `level = "error"` in `aipm.toml`
+- Tune: Adjust `lines` and `characters` thresholds
+
+### 8.2 Test Plan
+
+#### Unit Tests (`instructions_oversized.rs`)
+
+| Test Case | Description | Expected |
+|---|---|---|
+| `small_file_no_finding` | File under both limits | No diagnostics |
+| `exactly_at_line_limit` | Exactly 100 lines | No diagnostics |
+| `exactly_at_char_limit` | Exactly 15,000 characters | No diagnostics |
+| `over_line_limit` | 101+ lines, under char limit | 1 diagnostic (lines) |
+| `over_char_limit` | Under line limit, 15,001+ characters | 1 diagnostic (chars) |
+| `both_limits_exceeded` | Over both limits | 2 diagnostics |
+| `empty_file` | Empty instruction file | No diagnostics |
+| `missing_file` | File doesn't exist | No diagnostics (empty vec) |
+| `case_insensitive_detection` | `claude.md` (lowercase) detected | File is discovered and checked |
+| `instructions_md_suffix` | `frontend.instructions.md` detected | File is discovered and checked |
+| `subdirectory_detection` | `packages/auth/CLAUDE.md` | File is discovered and checked |
+| `custom_thresholds` | Rule constructed with lines=50 | Triggers at 51 lines |
+| `source_type_project` | File at project root | `source_type == "project"` |
+| `source_type_claude` | File at `.claude/CLAUDE.md` | `source_type == ".claude"` |
+
+#### Import Resolver Tests (`import_resolver.rs`)
+
+| Test Case | Description | Expected |
+|---|---|---|
+| `at_import_basic` | File with `@path/to/file.md` | Follows import, sums sizes |
+| `markdown_link_basic` | File with `[text](./file.md)` | Follows link, sums sizes |
+| `external_url_ignored` | `[text](https://example.com/file.md)` | Not followed |
+| `non_md_link_ignored` | `[text](./config.json)` | Not followed |
+| `circular_import` | A imports B, B imports A | No infinite loop, each file counted once |
+| `path_traversal_rejected` | `@../../etc/passwd` | Import ignored |
+| `absolute_path_rejected` | `@/etc/passwd` | Import ignored |
+| `nested_imports` | A → B → C (chain of 3) | All three files counted |
+| `missing_import_target` | `@nonexistent.md` | Import silently skipped |
+| `mixed_imports` | File with both `@import` and markdown links | Both followed |
+
+#### Discovery Tests (`discovery.rs`)
+
+| Test Case | Description | Expected |
+|---|---|---|
+| `classify_claude_md` | `CLAUDE.md` at root | `FeatureKind::Instructions` |
+| `classify_claude_md_lowercase` | `claude.md` at root | `FeatureKind::Instructions` |
+| `classify_agents_md_in_agents_dir` | `agents/AGENTS.md` | `FeatureKind::Instructions` (not Agent) |
+| `classify_instructions_md_suffix` | `frontend.instructions.md` | `FeatureKind::Instructions` |
+| `classify_regular_agent_unchanged` | `agents/security-reviewer.md` | `FeatureKind::Agent` (unchanged) |
+
+#### Integration Tests
+
+| Test Case | Description |
+|---|---|
+| `lint_discovers_instruction_files` | Full `lint()` call discovers and reports instruction file violations |
+| `lint_config_overrides_thresholds` | Custom `lines`/`characters` in config are respected |
+| `lint_config_allow_suppresses` | `"allow"` in config suppresses the rule |
+
+## 9. Implementation Checklist
+
+Files to create:
+- [ ] `crates/libaipm/src/lint/rules/instructions_oversized.rs` — Rule struct and trait impl
+- [ ] `crates/libaipm/src/lint/rules/import_resolver.rs` — Import resolution module
+
+Files to modify:
+- [ ] `crates/libaipm/src/discovery.rs` — Add `FeatureKind::Instructions`, extend `classify_feature_kind()`
+- [ ] `crates/libaipm/src/lint/rules/mod.rs` — Add module declarations, extend `quality_rules_for_kind()` (with config param), extend `catalog()`
+- [ ] `crates/libaipm/src/lint/config.rs` — Extend `RuleOverride::Detailed` with `options` field, add `rule_options()` method
+- [ ] `crates/libaipm/src/lint/mod.rs` — Pass `config` to `quality_rules_for_kind()` calls
+- [ ] `crates/aipm/src/main.rs` — Extend `load_lint_config()` to forward custom TOML keys to `options`
+- [ ] `crates/aipm/src/lsp/helpers.rs` — Verify `build_rule_index()` picks up new rule via `catalog()` (may need no changes if catalog() is already called generically)
+
+## 10. Open Questions / Unresolved Issues
+
+All questions from the research document have been resolved through the spec wizard. No outstanding questions remain. Decisions are recorded in this spec.
+
+Summary of key decisions:
+1. Character default: **15,000** (matches `skill/oversized` precedent)
+2. Include GEMINI.md: **Yes**
+3. Include `.instructions.md` scoped files: **Yes, same thresholds**
+4. Personal files: **No, project-only**
+5. Architecture: **FeatureKind::Instructions** (extend discovery pipeline)
+6. Config schema: **Inline under rule key** in `aipm.toml`
+7. Trigger logic: **OR** (either limit, up to 2 diagnostics)
+8. Depth limit: **None** (rely on SKIP_DIRS + gitignore)
+9. Case sensitivity: **Case-insensitive**
+10. Scoped threshold: **Same as always-injected**
+11. Import resolution: **Implement now**, `resolve-imports` option, default off
+12. Circular imports: **Track visited, skip duplicates**
+13. Diagnostic reporting: **Both** resolved total and direct size
+14. Import syntax: **@path + relative markdown inline links** to local `.md` files
+15. Markdown link scope: **Inline links** only (not reference-style)
+16. resolve-imports default: **Disabled** (opt-in)


### PR DESCRIPTION
## Summary

- Adds `FeatureKind::Instructions` to the discovery pipeline so CLAUDE.md, AGENTS.md, COPILOT.md, GEMINI.md, INSTRUCTIONS.md, and `*.instructions.md` files are recognized at any depth in the project tree
- Introduces the `instructions/oversized` lint rule with configurable line (default 100) and character (default 15 000) thresholds, plus an opt-in `resolve-imports` mode that follows `@path` and relative markdown links transitively
- Extends `RuleOverride::Detailed` with an `options: BTreeMap<String, toml::Value>` field so rules can consume arbitrary per-rule TOML keys from `aipm.toml`

Closes #185.

## Config surface

```toml
[workspace.lints."instructions/oversized"]
level = "error"
lines = 200
characters = 20000
resolve-imports = true
ignore = ["vendor/**"]
```

## New files

| File | Purpose |
|------|---------|
| `crates/libaipm/src/lint/rules/import_resolver.rs` | `@path` + markdown link resolver with circular-ref and path-traversal protection |
| `crates/libaipm/src/lint/rules/instructions_oversized.rs` | `Oversized` rule struct + `check_file()` emitting up to 2 diagnostics |
| `specs/2026-04-11-lint-instructions-oversized.md` | Technical design doc / RFC |
| `research/tickets/2026-04-11-185-prevent-long-instructions-files.md` | Research document for issue #185 |

## Test plan

- [x] 42 new unit tests in `import_resolver` and `instructions_oversized` modules
- [x] Classification tests for all 5 filename patterns + `*.instructions.md` suffix
- [x] `agents/AGENTS.md` correctly classified as `Instructions`, not `Agent`
- [x] Config system tests: `rule_options()` accessor, backward-compatible `level`/`ignore`-only configs, custom TOML key forwarding
- [x] Integration tests: discovery → lint pipeline, config threshold override, `allow` suppression
- [x] LSP catalog count updated (17 → 18 rules)
- [x] `cargo build --workspace` ✓  `cargo test --workspace` ✓  `cargo clippy -- -D warnings` ✓  `cargo fmt --check` ✓
- [x] Branch coverage: **89.07 %** (gate: ≥ 89 %)