### PR TITLE
chore: release v0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.19.7"
+version = "0.20.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.19.7"
+version = "0.20.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1163,7 +1163,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.19.7"
+version = "0.20.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.19.7"
+version = "0.20.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.19.7" }
+libaipm = { path = "crates/libaipm", version = "0.20.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.0] - 2026-04-11
+
+### Documentation
+- Add missing install guide links to `aipm install` See also section ([#422](https://github.com/TheLarkInn/aipm/pull/422)) (faa0849)
+- Fix Claude Code LSP artifact listing in README and add v0.19.7 changelog ([#425](https://github.com/TheLarkInn/aipm/pull/425)) (b81ea0d)
+
 ## [0.19.7] - 2026-04-11
 
 ### Documentation

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.0] - 2026-04-11
+
+### Documentation
+- Add missing install guide links to `aipm install` See also section ([#422](https://github.com/TheLarkInn/aipm/pull/422)) (faa0849)
+- Fix Claude Code LSP artifact listing in README and add v0.19.7 changelog ([#425](https://github.com/TheLarkInn/aipm/pull/425)) (b81ea0d)
+
+### Features
+- Add instructions/oversized rule for instruction file size limits ([#434](https://github.com/TheLarkInn/aipm/pull/434)) (064d377)
+
+### Testing
+- Cover --global branches in list and install commands (286c421)
+
 ## [0.19.7] - 2026-04-11
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.0] - 2026-04-11
+
+### Documentation
+- Add missing install guide links to `aipm install` See also section ([#422](https://github.com/TheLarkInn/aipm/pull/422)) (faa0849)
+- Fix Claude Code LSP artifact listing in README and add v0.19.7 changelog ([#425](https://github.com/TheLarkInn/aipm/pull/425)) (b81ea0d)
+
+### Features
+- Add instructions/oversized rule for instruction file size limits ([#434](https://github.com/TheLarkInn/aipm/pull/434)) (064d377)
+
+### Testing
+- Cover MockFs::exists short-circuit branch in cleanup.rs (0e66530)
+
 ## [0.19.7] - 2026-04-11
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.19.7 -> 0.20.0 (⚠ API breaking changes)
* `aipm`: 0.19.7 -> 0.20.0
* `aipm-pack`: 0.19.7 -> 0.20.0

### ⚠ `libaipm` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field options of variant RuleOverride::Detailed in /tmp/.tmpISYOEf/aipm/crates/libaipm/src/lint/config.rs:33

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant FeatureKind:Instructions in /tmp/.tmpISYOEf/aipm/crates/libaipm/src/discovery.rs:25
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.20.0] - 2026-04-11

### Documentation
- Add missing install guide links to `aipm install` See also section ([#422](https://github.com/TheLarkInn/aipm/pull/422)) (faa0849)
- Fix Claude Code LSP artifact listing in README and add v0.19.7 changelog ([#425](https://github.com/TheLarkInn/aipm/pull/425)) (b81ea0d)

### Features
- Add instructions/oversized rule for instruction file size limits ([#434](https://github.com/TheLarkInn/aipm/pull/434)) (064d377)

### Testing
- Cover MockFs::exists short-circuit branch in cleanup.rs (0e66530)
</blockquote>

## `aipm`

<blockquote>

## [0.20.0] - 2026-04-11

### Documentation
- Add missing install guide links to `aipm install` See also section ([#422](https://github.com/TheLarkInn/aipm/pull/422)) (faa0849)
- Fix Claude Code LSP artifact listing in README and add v0.19.7 changelog ([#425](https://github.com/TheLarkInn/aipm/pull/425)) (b81ea0d)

### Features
- Add instructions/oversized rule for instruction file size limits ([#434](https://github.com/TheLarkInn/aipm/pull/434)) (064d377)

### Testing
- Cover --global branches in list and install commands (286c421)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.20.0] - 2026-04-11

### Documentation
- Add missing install guide links to `aipm install` See also section ([#422](https://github.com/TheLarkInn/aipm/pull/422)) (faa0849)
- Fix Claude Code LSP artifact listing in README and add v0.19.7 changelog ([#425](https://github.com/TheLarkInn/aipm/pull/425)) (b81ea0d)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).