### PR TITLE
chore: release v0.20.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1163,7 +1163,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.20.0" }
+libaipm = { path = "crates/libaipm", version = "0.20.1" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.1] - 2026-04-12
+
 ## [0.20.0] - 2026-04-11
 
 ### Documentation

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.1] - 2026-04-12
+
+### Testing
+- Cover load_lint_config edge-case branches (2a43059)
+- Cover load_installed_registry file-exists and load_lint_config non-NotFound IO error branches (063854f)
+- Cover ignore-only rule override branch in load_lint_config (396b5b3)
+
 ## [0.20.0] - 2026-04-11
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.1] - 2026-04-12
+
+### Testing
+- Cover touch_entry False branch when key absent from index (32ccca9)
+- Cover unsafe markdown link and unclosed paren branches (460deb7)
+- Cover warn-and-skip path for non-regular skill files (899a4e7)
+- Cover resolve_imports char-limit True branch (5aa9a3b)
+- Extract make_temp_dir helper to cover cleanup-guard True branch (ff89580)
+- Cover locate_json_key None path and check_file malformed JSON (f093fe3)
+
 ## [0.20.0] - 2026-04-11
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.20.0 -> 0.20.1 (✓ API compatible changes)
* `aipm`: 0.20.0 -> 0.20.1
* `aipm-pack`: 0.20.0 -> 0.20.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.20.1] - 2026-04-12

### Testing
- Cover touch_entry False branch when key absent from index (32ccca9)
- Cover unsafe markdown link and unclosed paren branches (460deb7)
- Cover warn-and-skip path for non-regular skill files (899a4e7)
- Cover resolve_imports char-limit True branch (5aa9a3b)
- Extract make_temp_dir helper to cover cleanup-guard True branch (ff89580)
- Cover locate_json_key None path and check_file malformed JSON (f093fe3)
</blockquote>

## `aipm`

<blockquote>

## [0.20.1] - 2026-04-12

### Testing
- Cover load_lint_config edge-case branches (2a43059)
- Cover load_installed_registry file-exists and load_lint_config non-NotFound IO error branches (063854f)
- Cover ignore-only rule override branch in load_lint_config (396b5b3)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).