### PR TITLE
feat: dogfood aipm lint on this repo (#426)

### DIFF
--- a/.ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md
+++ b/.ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md
@@ -11,6 +11,8 @@ Write code that is correct, idiomatic, and efficient on the first pass. Don't ma
 
 **Core principle:** Use the platform. Build maps, not nested loops. Count without allocating. Protect your dictionaries. Keep your shapes monomorphic. Name your types. Hoist your constants.
 
+For violation examples, fix patterns, and extended explanations see `references/anti-pattern-details.md`.
+
 ## The Iron Laws
 
 ```
@@ -29,31 +31,11 @@ Write code that is correct, idiomatic, and efficient on the first pass. Don't ma
 13. ALWAYS accept Iterable<T> (not T[]) when using for...of in helpers
 ```
 
-## Anti-Pattern 1: O(n²) Collection Scanning
+## Anti-Pattern Gates
 
-**The violation:**
-```typescript
-// ❌ BAD: .find() inside .map() = O(n × m)
-const steps = befores.map((b) => {
-  const a = afters.find((x) => x.callId === b.callId);
-  return { ...b, endTime: a?.endTime };
-});
-```
+### AP1: O(n²) Collection Scanning
 
-**Why:** 1,000 events x 1,000 lookups = 1,000,000 comparisons. Pre-build a Map for O(1) lookups.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Pre-build Map, then O(1) lookups
-const afterMap = new Map(afters.map((a) => [a.callId, a]));
-
-const steps = befores.map((b) => {
-  const a = afterMap.get(b.callId!);
-  return { ...b, endTime: a?.endTime };
-});
-```
-
-### Gate Function
+Pre-build a `Map` before the loop; use `.get()` for O(1) lookup instead of `.find()` inside `.map()`.
 
 ```
 BEFORE using .find(), .filter(), or .some() on a collection:
@@ -68,44 +50,9 @@ BEFORE using .find(), .filter(), or .some() on a collection:
     - On a collection known to be tiny (< 10 elements)
 ```
 
-## Anti-Pattern 2: Allocating Arrays Just to Count
+### AP2: Allocating Arrays Just to Count
 
-**The violation:**
-```typescript
-// ❌ BAD: Two temp arrays allocated, only .length is read, then both are discarded
-const expects: Step[] = children.filter((c) => c.method === 'expect');
-const errors: Step[] = expects.filter((e) => e.error);
-return { expectCount: expects.length, expectErrorCount: errors.length };
-```
-
-**Why:** V8 does NOT optimize `.filter().length` into a count. It allocates the full array, copies matching elements, reads `.length`, then the GC reclaims it. Benchmarked at **2.4x slower** than a counting loop on real trace data (6,498 events).
-
-**The fix:**
-```typescript
-// ✅ GOOD: Single pass, zero allocations
-let expectCount: number = 0;
-let expectErrorCount: number = 0;
-for (const c of children) {
-  if (c.method === 'expect') {
-    expectCount++;
-    if (c.error) expectErrorCount++;
-  }
-}
-return { expectCount, expectErrorCount };
-```
-
-For standalone counts, use a `countIf` helper (note: accepts `Iterable`, not just arrays):
-```typescript
-function countIf<T>(items: Iterable<T>, predicate: (item: T) => boolean): number {
-  let count: number = 0;
-  for (const item of items) {
-    if (predicate(item)) count++;
-  }
-  return count;
-}
-```
-
-### Gate Function
+Use a counting loop or `countIf` helper; never `.filter().length` when you only need the count.
 
 ```
 BEFORE writing .filter(...).length:
@@ -119,30 +66,9 @@ BEFORE writing .filter(...).length:
     .filter().length is fine — the array is used
 ```
 
-## Anti-Pattern 3: Multiple Passes When One Will Do
+### AP3: Multiple Passes When One Will Do
 
-**The violation:**
-```typescript
-// ❌ BAD: Four O(n) passes over the same array
-const contextOpts = events.find((e) => e.type === 'context-options');
-const topError = events.find((e) => e.type === 'error');
-const befores = events.filter((e) => e.type === 'before');
-const afters = events.filter((e) => e.type === 'after');
-```
-
-**Why:** 4 full scans when 1 suffices. `Map.groupBy` exists for this.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Single O(n) pass groups everything
-const byType = Map.groupBy(events, (e) => e.type);
-const contextOpts = byType.get('context-options')?.[0];
-const topError = byType.get('error')?.[0];
-const befores = byType.get('before') ?? [];
-const afters = byType.get('after') ?? [];
-```
-
-### Gate Function
+Use `Map.groupBy()` once and call `.get()` for each group.
 
 ```
 BEFORE writing multiple .find() or .filter() calls on the same array:
@@ -152,31 +78,9 @@ BEFORE writing multiple .find() or .filter() calls on the same array:
     STOP — Use Map.groupBy() once, then .get() each group
 ```
 
-## Anti-Pattern 4: Unsafe Dictionaries
+### AP4: Unsafe Dictionaries
 
-**The violation:**
-```typescript
-// ❌ BAD: Plain {} inherits from Object.prototype
-const counts: Record<string, number> = {};
-for (const s of steps) {
-  const m: string = s.method || 'unknown';
-  counts[m] = (counts[m] || 0) + 1;
-}
-```
-
-**Why:** `counts['constructor']` returns `Object.prototype.constructor` (a function, truthy), so `(counts['constructor'] || 0) + 1` produces `NaN`. Also: `Object.fromEntries()` produces prototype-bearing objects — don't use it to build dictionaries.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Null-prototype object — no inherited keys
-const counts: Record<string, number> = Object.create(null);
-for (const s of steps) {
-  const m: string = s.method || 'unknown';
-  counts[m] = (counts[m] || 0) + 1;
-}
-```
-
-### Gate Function
+Use `Object.create(null)` or `new Map()` for any dictionary with dynamic keys.
 
 ```
 BEFORE creating a dictionary with dynamic keys:
@@ -187,23 +91,21 @@ BEFORE creating a dictionary with dynamic keys:
     It silently re-adds Object.prototype
 ```
 
-## Anti-Pattern 5: Hand-Rolling Node.js Built-ins
+### AP5: Hand-Rolling Node.js Built-ins
 
-**The violation:**
-```typescript
-// ❌ BAD: Redundant .trim() — parseInt already skips whitespace per the spec
-const nums = values.map((s: string) => parseInt(s.trim(), 10));
+Prefer `node:path`, `node:util`, `node:url` over hand-rolled string utilities.
+
+```
+BEFORE writing a string manipulation utility:
+  Ask: "Does Node.js or the JS standard library already do this?"
+
+  Check: node:path, node:util, node:url, node:fs, Map.groupBy, structuredClone
+
+  IF a built-in exists:
+    Use it — it handles edge cases you haven't thought of
 ```
 
-**Why:** `parseInt` skips leading whitespace per the ECMAScript spec. `.trim()` allocates a new string for nothing. Benchmarked at **1.3x slower** per call — pure waste.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Drop the redundant work
-const nums = values.map((s: string) => parseInt(s, 10));
-```
-
-### Common built-ins to prefer
+Common substitutions:
 
 | Instead of | Use |
 |---|---|
@@ -214,39 +116,9 @@ const nums = values.map((s: string) => parseInt(s, 10));
 | `require('fs')` in `.mts` | `import fs from 'node:fs'` |
 | Manual URL parsing | `new URL(str)` |
 
-### Gate Function
+### AP6: Verbose Map Checks
 
-```
-BEFORE writing a string manipulation utility:
-  Ask: "Does Node.js or the JS standard library already do this?"
-
-  Check: node:path, node:util, node:url, node:fs, Map.groupBy, structuredClone
-
-  IF a built-in exists:
-    Use it — it handles edge cases you haven't thought of
-
-  Exceptions (rare):
-    - Streaming text decoders that must preserve encoding state across chunks
-    - Cases where the built-in's behavior is subtly wrong for your specific use case
-```
-
-## Anti-Pattern 6: Verbose Map Checks
-
-**The violation:**
-```typescript
-// ❌ BAD: Allocates an empty array on every cache miss just to check .length
-const hasChildren: boolean = (childrenByParent.get(callId) ?? []).length > 0;
-```
-
-**Why:** `Map.groupBy` only creates keys for non-empty groups. The `?? []` creates a throwaway array on every miss. Benchmarked at **1.8x slower** than `.has()`.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Direct existence check — no allocation, clearer intent
-const hasChildren: boolean = childrenByParent.has(callId);
-```
-
-### Gate Function
+Use `map.has(key)` not `(map.get(key) ?? []).length > 0`.
 
 ```
 BEFORE writing (map.get(key) ?? []).length > 0:
@@ -255,37 +127,9 @@ BEFORE writing (map.get(key) ?? []).length > 0:
     Use !map.has(key) for absence
 ```
 
-## Anti-Pattern 7: Duplicate Utility Logic
+### AP7: Duplicate Utility Logic
 
-**The violation:**
-```typescript
-// ❌ BAD: Same 5-line "build a Map keyed by callId" loop copied twice
-const afterMap: Map<string, TraceEvent> = new Map();
-for (const a of afters) {
-  if (a.callId) afterMap.set(a.callId, a);
-}
-// ... 200 lines later, identical loop for befores ...
-```
-
-**Why:** Two copies of the same bug surface. Extract a helper.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Generic helper — accepts Iterable so it works on arrays, Sets, Maps, generators
-function buildMapFromProperty<K, V>(input: Iterable<V>, selector: (value: V) => K | undefined): Map<K, V> {
-  const result: Map<K, V> = new Map();
-  for (const elem of input) {
-    const key: K | undefined = selector(elem);
-    if (key !== undefined) result.set(key, elem);
-  }
-  return result;
-}
-
-const afterMap = buildMapFromProperty(afters, (a) => a.callId);
-const beforeByCallId = buildMapFromProperty(befores, (b) => b.callId);
-```
-
-### Gate Function
+Extract `buildMapFromProperty`, `countByKey`, `countIf` helpers accepting `Iterable<T>`.
 
 ```
 BEFORE writing a loop that builds a Map or counts by key:
@@ -301,33 +145,9 @@ BEFORE writing a loop that builds a Map or counts by key:
     - "Count items matching predicate" → countIf
 ```
 
-## Anti-Pattern 8: `.split()` on Large Strings
+### AP8: `.split()` on Large Strings
 
-**The violation:**
-```typescript
-// ❌ BAD: Materializes every line as a separate string object at once
-const lines = hugeFile.split('\n');
-for (const line of lines) {
-  processLine(line);
-}
-```
-
-**Why:** `.split('\n')` on a 10MB file creates thousands of small string objects in a single burst. Every substring is a heap allocation. The entire array and all its elements must live in memory simultaneously, causing GC pressure spikes. For one-off scripts this is fine, but in hot paths or large inputs, it's wasteful.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Process one line at a time with indexOf/slice — earlier strings can be GC'd
-let pos: number = 0;
-while (pos < content.length) {
-  const nextNewline: number = content.indexOf('\n', pos);
-  const end: number = nextNewline === -1 ? content.length : nextNewline;
-  const line: string = content.slice(pos, end);
-  processLine(line);
-  pos = end + 1;
-}
-```
-
-### Gate Function
+Use an `indexOf`/`slice` loop in hot paths; `.split()` is fine for one-off operations.
 
 ```
 BEFORE using .split() on a string:
@@ -342,52 +162,9 @@ BEFORE using .split() on a string:
   Same principle applies to .split(','), .split('\t'), etc.
 ```
 
-## Anti-Pattern 9: Polymorphic Object Shapes (V8 Deoptimization)
+### AP9: Polymorphic Object Shapes (V8 Deoptimization)
 
-**The violation:**
-```typescript
-// ❌ BAD: Objects created with different property orders or optional properties
-function makeResult(event: TraceEvent) {
-  const result: any = { callId: event.callId };
-  if (event.error) {
-    result.error = event.error;     // sometimes present, sometimes absent
-  }
-  if (event.title) {
-    result.title = event.title;     // same — shape varies per call
-  }
-  return result;
-}
-```
-
-**Why:** V8 assigns a hidden class (called "Map" internally, confusingly) to every object. When a function always produces objects with the same properties in the same order, V8 uses a **monomorphic** inline cache — direct memory offset lookup, extremely fast. When shapes vary:
-
-- **Monomorphic** (1 shape): Direct offset lookup. Fast.
-- **Polymorphic** (2-4 shapes): Linear search through cached shapes. Slower.
-- **Megamorphic** (5+ shapes): Hash table fallback. Slowest.
-
-Adding properties conditionally creates different hidden classes for each combination of present/absent fields. A function called 1,000 times with 3 optional fields can produce up to 8 distinct shapes, pushing V8 into megamorphic mode for every downstream consumer.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Always produce the same shape — use undefined for absent values
-function makeResult(event: TraceEvent) {
-  return {
-    callId: event.callId,
-    error: event.error ?? undefined,
-    title: event.title ?? undefined
-  };
-}
-```
-
-### Key Rules
-
-- **Always initialize all properties**, even if the value is `undefined`. This ensures one hidden class.
-- **Maintain consistent property order** across object literals that share a type.
-- **Never add properties after creation** (e.g., `result.newProp = ...` in an if-block).
-- **Avoid the `delete` operator altogether** — it forces a hidden class transition. Instead, create a new object without the property, or use `Map` which is designed for dynamic key removal.
-- **Prefer interfaces over ad-hoc objects** — the interface definition naturally enforces a consistent shape.
-
-### Gate Function
+Always initialize all properties; use `undefined` for absent values to keep V8 monomorphic.
 
 ```
 BEFORE conditionally adding properties to an object:
@@ -401,32 +178,11 @@ BEFORE conditionally adding properties to an object:
     Conditional properties are fine
 ```
 
-## Anti-Pattern 10: RegExp and Object Allocation in Hot Paths
+Key rules: always initialize all properties; maintain consistent property order; never add properties after creation; avoid `delete` (creates a hidden class transition — use `Map.delete()` or create a new object); prefer interfaces over ad-hoc objects.
 
-**The violation:**
-```typescript
-// ❌ BAD: RegExp compiled on every .find() iteration, callers pass constant strings
-function findFile(dir: string, pattern: string): string | null {
-  const files = fs.readdirSync(dir);
-  return files.find((f) => f.match(new RegExp(pattern))) ?? null;
-}
-```
+### AP10: RegExp and Object Allocation in Hot Paths
 
-**Why:** `new RegExp(pattern)` compiles per iteration. All callers pass constants — hoist to module scope.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Hoisted RegExp constant, function takes RegExp directly
-const TEST_TRACE_PATTERN: RegExp = /^test\.trace$/;
-
-function findFile(dir: string, pattern: RegExp): string | null {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  const match = entries.find((e) => e.isFile() && pattern.test(e.name));
-  return match ? path.join(dir, match.name) : null;
-}
-```
-
-### Gate Function
+Hoist constant RegExp to module scope; accept `RegExp` parameters instead of `string`.
 
 ```
 BEFORE creating a RegExp:
@@ -434,61 +190,17 @@ BEFORE creating a RegExp:
   IF inside a loop or callback: move it outside
 ```
 
-## Anti-Pattern 11: Pretty-Printing Machine-Consumed Data
+### AP11: Pretty-Printing Machine-Consumed Data
 
-**The violation:**
-```typescript
-// ❌ BAD: 2-space indentation for data an LLM or parser will consume
-console.log(JSON.stringify(data, null, 2));
-```
+Use `JSON.stringify(data)` not `JSON.stringify(data, null, 2)` for output piped to parsers or LLMs.
 
-**Why:** Whitespace adds ~30-40% to JSON size. LLMs and parsers don't benefit. For very large data, even compact `JSON.stringify` can hit V8's string length limit (~512MB) — consider streaming serialization in those cases.
+### AP12: Untyped Filesystem APIs
 
-**The fix:**
-```typescript
-// ✅ GOOD: Compact output for machine consumers
-console.log(JSON.stringify(data));
-```
+Always pass `{ withFileTypes: true }` to `readdirSync`; filter with `.isFile()` / `.isDirectory()`.
 
-## Anti-Pattern 12: Untyped Filesystem APIs
+### AP13: Inline Type Literals Instead of Named Interfaces
 
-**The violation:**
-```typescript
-// ❌ BAD: Returns string[], can't tell files from directories
-const files = fs.readdirSync(dir);
-```
-
-**Why:** Without `withFileTypes`, you need a separate `statSync` per entry.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Dirent objects with .isFile()/.isDirectory()
-const entries = fs.readdirSync(dir, { withFileTypes: true });
-const match = entries.find((e) => e.isFile() && pattern.test(e.name));
-```
-
-## Anti-Pattern 13: Inline Type Literals Instead of Named Interfaces
-
-**The violation:**
-```typescript
-// ❌ BAD: Long inline type, unreadable and unreusable
-const frames: Array<{ file: string; fullPath: string; line: number; function: string | undefined }> = [];
-```
-
-**Why:** Hard to read, can't be reused, buries logic changes in diffs.
-
-**The fix:**
-```typescript
-// ✅ GOOD: Named interface. Follow repo conventions (this monorepo enforces `I` prefix).
-interface IErrorStackFrame {
-  file: string;
-  fullPath: string;
-  line: number;
-  function: string | undefined;
-}
-
-const frames: IErrorStackFrame[] = [];
-```
+Extract inline types with 3+ properties to a named `interface` following repo conventions.
 
 ## Quick Reference
 

--- a/.ai/aipm-atomic-plugin/skills/perf-anti-patterns/references/anti-pattern-details.md
+++ b/.ai/aipm-atomic-plugin/skills/perf-anti-patterns/references/anti-pattern-details.md
@@ -1,0 +1,329 @@
+# Anti-Pattern Violation Examples and Fixes
+
+Detailed violation code, why-it-matters explanations, and fix patterns for each of the 13 anti-patterns. The gate functions live in the main SKILL.md; this file is the extended reference.
+
+---
+
+## AP1: O(n²) Collection Scanning
+
+**Violation:**
+```typescript
+// ❌ BAD: .find() inside .map() = O(n × m)
+const steps = befores.map((b) => {
+  const a = afters.find((x) => x.callId === b.callId);
+  return { ...b, endTime: a?.endTime };
+});
+```
+
+**Why:** 1,000 events × 1,000 lookups = 1,000,000 comparisons. Pre-build a Map for O(1) lookups.
+
+**Fix:**
+```typescript
+// ✅ GOOD: Pre-build Map, then O(1) lookups
+const afterMap = new Map(afters.map((a) => [a.callId, a]));
+const steps = befores.map((b) => {
+  const a = afterMap.get(b.callId!);
+  return { ...b, endTime: a?.endTime };
+});
+```
+
+---
+
+## AP2: Allocating Arrays Just to Count
+
+**Violation:**
+```typescript
+// ❌ BAD: Two temp arrays allocated, only .length is read, then both are discarded
+const expects: Step[] = children.filter((c) => c.method === 'expect');
+const errors: Step[] = expects.filter((e) => e.error);
+return { expectCount: expects.length, expectErrorCount: errors.length };
+```
+
+**Why:** V8 does NOT optimize `.filter().length` into a count. It allocates the full array, copies matching elements, reads `.length`, then the GC reclaims it. Benchmarked at **2.4x slower** than a counting loop on real trace data (6,498 events).
+
+**Fix:**
+```typescript
+// ✅ GOOD: Single pass, zero allocations
+let expectCount: number = 0;
+let expectErrorCount: number = 0;
+for (const c of children) {
+  if (c.method === 'expect') {
+    expectCount++;
+    if (c.error) expectErrorCount++;
+  }
+}
+return { expectCount, expectErrorCount };
+```
+
+For standalone counts, use a `countIf` helper (note: accepts `Iterable`, not just arrays):
+```typescript
+function countIf<T>(items: Iterable<T>, predicate: (item: T) => boolean): number {
+  let count: number = 0;
+  for (const item of items) {
+    if (predicate(item)) count++;
+  }
+  return count;
+}
+```
+
+---
+
+## AP3: Multiple Passes When One Will Do
+
+**Violation:**
+```typescript
+// ❌ BAD: Four O(n) passes over the same array
+const contextOpts = events.find((e) => e.type === 'context-options');
+const topError = events.find((e) => e.type === 'error');
+const befores = events.filter((e) => e.type === 'before');
+const afters = events.filter((e) => e.type === 'after');
+```
+
+**Why:** 4 full scans when 1 suffices. `Map.groupBy` exists for this.
+
+**Fix:**
+```typescript
+// ✅ GOOD: Single O(n) pass groups everything
+const byType = Map.groupBy(events, (e) => e.type);
+const contextOpts = byType.get('context-options')?.[0];
+const topError = byType.get('error')?.[0];
+const befores = byType.get('before') ?? [];
+const afters = byType.get('after') ?? [];
+```
+
+---
+
+## AP4: Unsafe Dictionaries
+
+**Violation:**
+```typescript
+// ❌ BAD: Plain {} inherits from Object.prototype
+const counts: Record<string, number> = {};
+for (const s of steps) {
+  const m: string = s.method || 'unknown';
+  counts[m] = (counts[m] || 0) + 1;
+}
+```
+
+**Why:** `counts['constructor']` returns `Object.prototype.constructor` (a function, truthy), so `(counts['constructor'] || 0) + 1` produces `NaN`. Also: `Object.fromEntries()` produces prototype-bearing objects — don't use it to build dictionaries.
+
+**Fix:**
+```typescript
+// ✅ GOOD: Null-prototype object — no inherited keys
+const counts: Record<string, number> = Object.create(null);
+for (const s of steps) {
+  const m: string = s.method || 'unknown';
+  counts[m] = (counts[m] || 0) + 1;
+}
+```
+
+---
+
+## AP5: Hand-Rolling Node.js Built-ins
+
+**Violation:**
+```typescript
+// ❌ BAD: Redundant .trim() — parseInt already skips whitespace per the spec
+const nums = values.map((s: string) => parseInt(s.trim(), 10));
+```
+
+**Why:** `parseInt` skips leading whitespace per the ECMAScript spec. `.trim()` allocates a new string for nothing. Benchmarked at **1.3x slower** per call — pure waste.
+
+**Fix:**
+```typescript
+// ✅ GOOD: Drop the redundant work
+const nums = values.map((s: string) => parseInt(s, 10));
+```
+
+---
+
+## AP6: Verbose Map Checks
+
+**Violation:**
+```typescript
+// ❌ BAD: Allocates an empty array on every cache miss just to check .length
+const hasChildren: boolean = (childrenByParent.get(callId) ?? []).length > 0;
+```
+
+**Why:** `Map.groupBy` only creates keys for non-empty groups. The `?? []` creates a throwaway array on every miss. Benchmarked at **1.8x slower** than `.has()`.
+
+**Fix:**
+```typescript
+// ✅ GOOD: Direct existence check — no allocation, clearer intent
+const hasChildren: boolean = childrenByParent.has(callId);
+```
+
+---
+
+## AP7: Duplicate Utility Logic
+
+**Violation:**
+```typescript
+// ❌ BAD: Same 5-line "build a Map keyed by callId" loop copied twice
+const afterMap: Map<string, TraceEvent> = new Map();
+for (const a of afters) {
+  if (a.callId) afterMap.set(a.callId, a);
+}
+// ... 200 lines later, identical loop for befores ...
+```
+
+**Fix:**
+```typescript
+// ✅ GOOD: Generic helper — accepts Iterable so it works on arrays, Sets, Maps, generators
+function buildMapFromProperty<K, V>(
+  input: Iterable<V>,
+  selector: (value: V) => K | undefined
+): Map<K, V> {
+  const result: Map<K, V> = new Map();
+  for (const elem of input) {
+    const key: K | undefined = selector(elem);
+    if (key !== undefined) result.set(key, elem);
+  }
+  return result;
+}
+
+const afterMap = buildMapFromProperty(afters, (a) => a.callId);
+const beforeByCallId = buildMapFromProperty(befores, (b) => b.callId);
+```
+
+---
+
+## AP8: `.split()` on Large Strings
+
+**Violation:**
+```typescript
+// ❌ BAD: Materializes every line as a separate string object at once
+const lines = hugeFile.split('\n');
+for (const line of lines) { processLine(line); }
+```
+
+**Why:** `.split('\n')` on a 10MB file creates thousands of small string objects in a single burst. Every substring is a heap allocation. The entire array and all its elements must live in memory simultaneously, causing GC pressure spikes.
+
+**Fix:**
+```typescript
+// ✅ GOOD: Process one line at a time with indexOf/slice — earlier strings can be GC'd
+let pos: number = 0;
+while (pos < content.length) {
+  const nextNewline: number = content.indexOf('\n', pos);
+  const end: number = nextNewline === -1 ? content.length : nextNewline;
+  const line: string = content.slice(pos, end);
+  processLine(line);
+  pos = end + 1;
+}
+```
+
+---
+
+## AP9: Polymorphic Object Shapes (V8 Deoptimization)
+
+**Violation:**
+```typescript
+// ❌ BAD: Objects created with different property orders or optional properties
+function makeResult(event: TraceEvent) {
+  const result: any = { callId: event.callId };
+  if (event.error) { result.error = event.error; }
+  if (event.title) { result.title = event.title; }
+  return result;
+}
+```
+
+**Why:** V8 assigns a hidden class to every object. Varying shapes push V8 from monomorphic (fast) to polymorphic or megamorphic (slow hash table). Adding properties conditionally creates different hidden classes for each combination — a function called 1,000 times with 3 optional fields can produce up to 8 distinct shapes.
+
+- **Monomorphic** (1 shape): Direct offset lookup. Fast.
+- **Polymorphic** (2–4 shapes): Linear search through cached shapes. Slower.
+- **Megamorphic** (5+ shapes): Hash table fallback. Slowest.
+
+**Fix:**
+```typescript
+// ✅ GOOD: Always produce the same shape — use undefined for absent values
+function makeResult(event: TraceEvent) {
+  return {
+    callId: event.callId,
+    error: event.error ?? undefined,
+    title: event.title ?? undefined
+  };
+}
+```
+
+---
+
+## AP10: RegExp and Object Allocation in Hot Paths
+
+**Violation:**
+```typescript
+// ❌ BAD: RegExp compiled on every .find() iteration
+function findFile(dir: string, pattern: string): string | null {
+  const files = fs.readdirSync(dir);
+  return files.find((f) => f.match(new RegExp(pattern))) ?? null;
+}
+```
+
+**Fix:**
+```typescript
+// ✅ GOOD: Hoisted RegExp constant, function takes RegExp directly
+const TEST_TRACE_PATTERN: RegExp = /^test\.trace$/;
+
+function findFile(dir: string, pattern: RegExp): string | null {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const match = entries.find((e) => e.isFile() && pattern.test(e.name));
+  return match ? path.join(dir, match.name) : null;
+}
+```
+
+---
+
+## AP11: Pretty-Printing Machine-Consumed Data
+
+**Violation:**
+```typescript
+// ❌ BAD: 2-space indentation for data an LLM or parser will consume
+console.log(JSON.stringify(data, null, 2));
+```
+
+**Why:** Whitespace adds ~30–40% to JSON size. LLMs and parsers don't benefit.
+
+**Fix:**
+```typescript
+// ✅ GOOD: Compact output for machine consumers
+console.log(JSON.stringify(data));
+```
+
+---
+
+## AP12: Untyped Filesystem APIs
+
+**Violation:**
+```typescript
+// ❌ BAD: Returns string[], can't tell files from directories
+const files = fs.readdirSync(dir);
+```
+
+**Fix:**
+```typescript
+// ✅ GOOD: Dirent objects with .isFile()/.isDirectory()
+const entries = fs.readdirSync(dir, { withFileTypes: true });
+const match = entries.find((e) => e.isFile() && pattern.test(e.name));
+```
+
+---
+
+## AP13: Inline Type Literals Instead of Named Interfaces
+
+**Violation:**
+```typescript
+// ❌ BAD: Long inline type, unreadable and unreusable
+const frames: Array<{ file: string; fullPath: string; line: number; function: string | undefined }> = [];
+```
+
+**Fix:**
+```typescript
+// ✅ GOOD: Named interface — follow repo conventions (this monorepo enforces `I` prefix)
+interface IErrorStackFrame {
+  file: string;
+  fullPath: string;
+  line: number;
+  function: string | undefined;
+}
+
+const frames: IErrorStackFrame[] = [];
+```

--- a/.ai/starter-aipm-plugin/.claude-plugin/plugin.json
+++ b/.ai/starter-aipm-plugin/.claude-plugin/plugin.json
@@ -1,5 +1,9 @@
 {
   "name": "starter-aipm-plugin",
   "version": "0.1.0",
-  "description": "Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage"
+  "description": "Default starter plugin — scaffold new plugins, scan your marketplace, and log tool usage",
+  "author": {
+    "name": "Sean Larkin",
+    "email": "thelarkinn@users.noreply.github.com"
+  }
 }

--- a/.ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md
+++ b/.ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: scaffold-plugin
 description: Scaffold a new AI plugin in the .ai/ marketplace directory. Use when the user wants to create a new plugin, skill, agent, or hook package.
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build
         run: cargo build --workspace
 
+      - name: Lint AI plugins
+        run: ./target/debug/aipm lint . --reporter ci-github
+
       - name: Test
         run: cargo test --workspace
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,40 +41,17 @@ All four must pass with zero warnings before any commit.
 
 ## Coverage Commands (MANDATORY before pushing)
 
-Coverage uses nightly Rust for branch-level instrumentation. The coverage check
-is a **correctness gate** — LLM-generated code must hit 89% branch coverage.
+89% branch coverage is required. Prereqs: `rustup toolchain install nightly && rustup component add llvm-tools-preview --toolchain nightly && cargo install cargo-llvm-cov`
 
 ```bash
-# Clean prior coverage data to ensure a fresh run (matches CI behavior)
 cargo +nightly llvm-cov clean --workspace
-
-# 1) Collect workspace test coverage (no report yet)
 cargo +nightly llvm-cov --no-report --workspace --branch
-
-# 2) Collect doctest coverage (no report yet)
 cargo +nightly llvm-cov --no-report --doc
-
-# 3) Generate report — verify TOTAL line branch column shows >= 89%
 cargo +nightly llvm-cov report --doctests --branch \
   --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\.rs|lsp\.rs)'
-
-# HTML report (visual inspection; uses merged tests + doctests)
-cargo +nightly llvm-cov report --workspace --branch --doctests \
-  --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\.rs|lsp\.rs)' \
-  --html --open
-
-# lcov for VS Code Coverage Gutters extension (uses merged tests + doctests)
-cargo +nightly llvm-cov report --workspace --branch --doctests \
-  --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\.rs|lsp\.rs)' \
-  --lcov --output-path lcov.info
 ```
 
-All coverage commands require the nightly toolchain and llvm-tools-preview:
-```bash
-rustup toolchain install nightly
-rustup component add llvm-tools-preview --toolchain nightly
-cargo install cargo-llvm-cov
-```
+Verify the TOTAL branch column shows ≥ 89%. For HTML or lcov output, append `--html --open` or `--lcov --output-path lcov.info` to the report command.
 
 ## Agentic Workflows
 
@@ -90,13 +67,7 @@ The repository uses [GitHub Agentic Workflows](https://githubnext.com/projects/a
 
 ### Why 45 minutes?
 
-The full agent cycle (Rust nightly toolchain install → build → test → coverage instrumentation → analysis → PR creation) consistently exceeded shorter timeouts. Specifically:
-
-- `improve-coverage` was killed at 30 min with 29+ repeated failures ([issue #367](https://github.com/TheLarkInn/aipm/issues/367))
-- `daily-qa` was killed at 15 min
-- `docs-updater` was killed at the default 20 min
-
-**Do not lower these timeouts.** If a workflow still times out, investigate the agent logic — do not reduce the limit.
+The full agent cycle (nightly toolchain install → build → test → coverage → analysis → PR creation) consistently exceeded shorter limits — `improve-coverage` failed 29+ times at 30 min ([#367](https://github.com/TheLarkInn/aipm/issues/367)), `daily-qa` at 15 min, `docs-updater` at 20 min. **Do not lower these timeouts.** If a workflow still times out, investigate the agent logic — do not reduce the limit.
 
 ### Modifying workflow files
 

--- a/aipm.toml
+++ b/aipm.toml
@@ -1,0 +1,2 @@
+[workspace.lints.ignore]
+paths = ["**/fixtures/**"]

--- a/crates/libaipm/src/lint/mod.rs
+++ b/crates/libaipm/src/lint/mod.rs
@@ -816,16 +816,22 @@ mod tests {
 
     /// Instruction files (CLAUDE.md, AGENTS.md, etc.) live at the repo root by design and
     /// must NOT trigger `source/misplaced-features` even though they are outside `.ai/`.
+    ///
+    /// A skill outside `.ai/` (in `.claude/`) MUST still trigger the rule — this ensures
+    /// the exemption is narrowly scoped to `FeatureKind::Instructions`, not all outside-`.ai/`
+    /// features. The test covers both branches of the `kind != FeatureKind::Instructions` guard.
     #[test]
     fn lint_instruction_files_not_flagged_as_misplaced() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
 
-        // CLAUDE.md at the repo root — an Instructions feature outside .ai/
-        let claude_md = root.join("CLAUDE.md");
-        std::fs::write(&claude_md, "# Project Rules\n\nSome rules here.\n").unwrap();
+        // CLAUDE.md at the repo root — Instructions feature outside .ai/ (must NOT be flagged)
+        std::fs::write(root.join("CLAUDE.md"), "# Project Rules\n\nSome rules here.\n").unwrap();
 
-        // Also create a .ai/ marketplace so we know it's not the missing-.ai/ case
+        // A skill in .claude/ — Skill feature outside .ai/ (MUST still be flagged)
+        write_skill_md(&root.join(".claude").join("skills").join("misplaced"), "misplaced-skill");
+
+        // .ai/ exists so the help text uses "aipm migrate" path
         std::fs::create_dir_all(root.join(".ai").join(".claude-plugin")).unwrap();
 
         let opts = Options {
@@ -838,7 +844,13 @@ mod tests {
         assert!(result.is_ok());
         let outcome = result.unwrap();
 
-        // source/misplaced-features must NOT fire for the instruction file
+        // The skill in .claude/ must still be flagged as misplaced
+        assert!(
+            outcome.diagnostics.iter().any(|d| d.rule_id == "source/misplaced-features"),
+            "source/misplaced-features must still fire for skills outside .ai/"
+        );
+
+        // CLAUDE.md must NOT appear in any misplaced-features diagnostic
         let misplaced_on_claude: Vec<_> = outcome
             .diagnostics
             .iter()

--- a/crates/libaipm/src/lint/mod.rs
+++ b/crates/libaipm/src/lint/mod.rs
@@ -13,7 +13,7 @@ pub mod rules;
 
 use std::path::PathBuf;
 
-use crate::discovery::DiscoveredFeature;
+use crate::discovery::{DiscoveredFeature, FeatureKind};
 use crate::fs::Fs;
 
 pub use diagnostic::{Diagnostic, Severity};
@@ -91,8 +91,10 @@ fn run_rules_for_feature(
         apply_rule_diagnostics(rule.as_ref(), rule_diagnostics, config, diagnostics);
     }
 
-    // 2. Misplaced-features — run on features NOT inside .ai/.
-    if !is_inside_ai {
+    // 2. Misplaced-features — run on features NOT inside .ai/, but NOT on instruction files.
+    // Instruction files (CLAUDE.md, AGENTS.md, etc.) live at the repo root by design and
+    // are not plugin features — flagging them as misplaced would always be a false positive.
+    if !is_inside_ai && feature.kind != FeatureKind::Instructions {
         let rule = rules::misplaced_features_rule(feature, ai_exists);
         if !config.is_suppressed(rule.id()) {
             let rule_diagnostics = rule.check_file(&feature.file_path, fs)?;
@@ -810,6 +812,45 @@ mod tests {
             outcome.diagnostics.iter().find(|d| d.rule_id == "source/misplaced-features").unwrap();
         let help = diag.help_text.as_deref().unwrap_or("");
         assert!(help.contains("aipm init"));
+    }
+
+    /// Instruction files (CLAUDE.md, AGENTS.md, etc.) live at the repo root by design and
+    /// must NOT trigger `source/misplaced-features` even though they are outside `.ai/`.
+    #[test]
+    fn lint_instruction_files_not_flagged_as_misplaced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // CLAUDE.md at the repo root — an Instructions feature outside .ai/
+        let claude_md = root.join("CLAUDE.md");
+        std::fs::write(&claude_md, "# Project Rules\n\nSome rules here.\n").unwrap();
+
+        // Also create a .ai/ marketplace so we know it's not the missing-.ai/ case
+        std::fs::create_dir_all(root.join(".ai").join(".claude-plugin")).unwrap();
+
+        let opts = Options {
+            dir: root.to_path_buf(),
+            source: None,
+            config: config::Config::default(),
+            max_depth: None,
+        };
+        let result = lint(&opts, &crate::fs::Real);
+        assert!(result.is_ok());
+        let outcome = result.unwrap();
+
+        // source/misplaced-features must NOT fire for the instruction file
+        let misplaced_on_claude: Vec<_> = outcome
+            .diagnostics
+            .iter()
+            .filter(|d| {
+                d.rule_id == "source/misplaced-features"
+                    && d.file_path.file_name().is_some_and(|n| n == "CLAUDE.md")
+            })
+            .collect();
+        assert!(
+            misplaced_on_claude.is_empty(),
+            "source/misplaced-features must not fire on CLAUDE.md (instruction files are not plugin features)"
+        );
     }
 
     /// Covers the `is_ignored(&path_str, rule_ignores)` True branch.

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -1,224 +1,104 @@
 [
   {
     "category": "functional",
-    "description": "Add FeatureKind::Instructions variant to discovery.rs enum and extend classify_feature_kind() with case-insensitive matching for CLAUDE.md, AGENTS.md, COPILOT.md, INSTRUCTIONS.md, GEMINI.md, and *.instructions.md at any depth",
+    "description": "Fix plugin/required-fields error: add missing author field to starter-aipm-plugin plugin.json",
     "steps": [
-      "Add Instructions variant to FeatureKind enum in crates/libaipm/src/discovery.rs",
-      "Add INSTRUCTION_FILENAMES constant with lowercase filenames: claude.md, agents.md, copilot.md, instructions.md, gemini.md",
-      "In classify_feature_kind(), add case-insensitive filename check BEFORE existing checks using to_ascii_lowercase()",
-      "Add .instructions.md suffix check using ends_with on the lowercased filename",
-      "Update all existing match arms on FeatureKind throughout the codebase to handle the new Instructions variant",
-      "Verify the ordering ensures CLAUDE.md inside agents/ directory is classified as Instructions, not Agent",
-      "Run cargo build --workspace to confirm compilation"
+      "Read the plugin_required_fields.rs rule implementation to confirm which fields are required and what format the author field expects",
+      "Read .ai/starter-aipm-plugin/.claude-plugin/plugin.json to see current contents",
+      "Read .ai/aipm-atomic-plugin/.claude-plugin/plugin.json as a reference for the author field format",
+      "Add the author field to starter-aipm-plugin/plugin.json matching the repo owner (Sean Larkin / thelarkinn@users.noreply.github.com)",
+      "Run cargo build --workspace && ./target/debug/aipm lint . to verify the plugin/required-fields error is resolved"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Extend RuleOverride::Detailed variant in config.rs with an options BTreeMap<String, toml::Value> for per-rule custom options, and add rule_options() accessor method",
+    "description": "Fix skill/missing-name warning: add name frontmatter field to scaffold-plugin SKILL.md",
     "steps": [
-      "Add options: BTreeMap<String, toml::Value> field to the Detailed variant of RuleOverride in crates/libaipm/src/lint/config.rs",
-      "Add use std::collections::BTreeMap to imports",
-      "Implement rule_options() method on Config that looks up a rule ID and returns its options (empty BTreeMap if not Detailed or rule not found)",
-      "Update all existing construction sites of RuleOverride::Detailed to include options: BTreeMap::new()",
-      "Run cargo build --workspace to confirm compilation"
+      "Read the skill_missing_name.rs rule implementation to confirm the expected frontmatter key name",
+      "Read .ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md to see current frontmatter",
+      "Add a name: field to the YAML frontmatter block (e.g., name: Scaffold Plugin)",
+      "Run ./target/debug/aipm lint . to verify the skill/missing-name warning is resolved"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Extend load_lint_config() in main.rs to forward unknown TOML keys (beyond 'level' and 'ignore') into the RuleOverride options BTreeMap",
+    "description": "Fix skill/oversized warning: reduce perf-anti-patterns SKILL.md below 15,000 characters",
     "steps": [
-      "In crates/aipm/src/main.rs load_lint_config(), when processing a TOML table for a rule, collect all keys that are not 'level' or 'ignore' into a BTreeMap<String, toml::Value>",
-      "Pass the collected options to RuleOverride::Detailed constructor",
-      "Ensure backward compatibility: existing aipm.toml files with only level/ignore continue to work",
-      "Run cargo build --workspace and cargo test --workspace to confirm no regressions"
+      "Read .ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md and measure its character count (currently ~20,036 chars)",
+      "Read .ai/aipm-atomic-plugin/skills/prompt-engineer/ to understand the references/ pattern already in use",
+      "Extract verbose anti-pattern descriptions into a references/ subdirectory, keeping concise summaries and gate function logic in the main SKILL.md",
+      "Verify the refactored SKILL.md is under 15,000 characters (use wc -c or similar)",
+      "Verify the skill's functional value is preserved — detection criteria and gate functions remain in the main file",
+      "Run ./target/debug/aipm lint . to verify the skill/oversized warning is resolved"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Change quality_rules_for_kind() signature to accept &Config parameter and update all call sites in the lint pipeline",
+    "description": "Fix instructions/oversized warning: reduce CLAUDE.md below 15,000 characters and 100 lines",
     "steps": [
-      "Change signature of quality_rules_for_kind() in crates/libaipm/src/lint/rules/mod.rs from (kind: &FeatureKind) to (kind: &FeatureKind, config: &Config)",
-      "Add use super::config::Config to imports in rules/mod.rs",
-      "Update the call in run_rules_for_feature() in crates/libaipm/src/lint/mod.rs to pass config",
-      "Update any other call sites (check with grep for quality_rules_for_kind)",
-      "Existing match arms can ignore the config parameter \u2014 no logic changes needed for current rules",
-      "Run cargo build --workspace to confirm compilation"
+      "Read CLAUDE.md and measure its character count and line count",
+      "Identify the most compressible sections: Coverage Commands block (4 variants), Agentic Workflows 'Why 45 minutes?' prose, and any verbose examples",
+      "Condense the coverage commands section — reduce duplicative shell blocks while preserving the essential commands",
+      "Tighten the agentic workflows prose — 2-3 sentence summary replacing verbose explanation",
+      "Remove or condense any other verbose sections to reach under 15,000 chars and 100 lines total",
+      "Do NOT move CLAUDE.md or remove essential project rules — only reduce verbosity",
+      "Verify the final character count is below 15,000 and line count below 100",
+      "Run ./target/debug/aipm lint . to verify the instructions/oversized warning is resolved"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Create import_resolver.rs module with resolve_imports() function that follows @path imports and relative markdown inline links, with circular reference protection and path traversal rejection",
+    "description": "Create root aipm.toml with workspace lint config and fixture ignore pattern",
     "steps": [
-      "Create crates/libaipm/src/lint/rules/import_resolver.rs",
-      "Implement parse_at_imports() function using regex ^@([^\\s]+\\.md)\\s*$ to extract @path import targets",
-      "Implement parse_markdown_links() function using regex \\[([^\\]]*)\\]\\(([^)]+\\.md)\\) to extract relative markdown links, filtering out http:// and https:// URLs",
-      "Implement resolve_imports(file_path, fs, visited: &mut HashSet<PathBuf>) -> (usize, usize) that recursively resolves imports",
-      "Add circular reference protection: check visited set before processing, insert path before recursing",
-      "Add path traversal protection: reject paths containing '..' segments or absolute paths",
-      "Handle missing import targets gracefully (return (0, 0) for unreadable files)",
-      "Add module declaration in crates/libaipm/src/lint/rules/mod.rs",
-      "Run cargo build --workspace to confirm compilation"
+      "Verify no aipm.toml exists at the repo root yet",
+      "Create aipm.toml at the repo root with [workspace.lints.ignore] paths = [\"**/fixtures/**\"]",
+      "Run ./target/debug/aipm lint . and verify all 35 fixture diagnostics are now excluded",
+      "Verify the remaining diagnostic count matches expectations (should be 0 errors, 0 warnings after prior fixes)"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Create instructions_oversized.rs with Oversized struct (max_lines, max_chars, resolve_imports fields), Default impl, and Rule trait implementation with check_file() logic emitting up to 2 diagnostics per file using OR logic",
+    "description": "Fix source/misplaced-features rule bug: exempt FeatureKind::Instructions from the misplaced-features check",
     "steps": [
-      "Create crates/libaipm/src/lint/rules/instructions_oversized.rs",
-      "Define DEFAULT_MAX_LINES = 100 and DEFAULT_MAX_CHARS = 15_000 constants",
-      "Define Oversized struct with pub max_lines: usize, pub max_chars: usize, pub resolve_imports: bool",
-      "Implement Default for Oversized using the constants and resolve_imports: false",
-      "Implement Rule trait: id() returns 'instructions/oversized', name() returns 'oversized instruction file', default_severity() returns Warning",
-      "Implement help_url() and help_text() with appropriate guidance",
-      "Implement check_file(): read file content, count lines and chars, optionally resolve imports, emit up to 2 diagnostics (one for lines, one for chars) using OR logic",
-      "Use source_type 'project' for files outside .ai/.claude/.github via scan::source_type_from_path() mapping 'other' to 'project'",
-      "When resolve_imports is true, call import_resolver::resolve_imports() and use resolved totals for threshold comparison",
-      "Format diagnostic messages differently for resolve-imports (include both resolved and direct counts) vs direct-only",
-      "Implement check() method that delegates to check_file() or iterates directory for instruction files",
-      "Add module declaration in crates/libaipm/src/lint/rules/mod.rs",
-      "Run cargo build --workspace to confirm compilation"
+      "Confirm source/misplaced-features fires on CLAUDE.md when running aipm lint .",
+      "Read run_rules_for_feature() in crates/libaipm/src/lint/mod.rs — find the !is_inside_ai condition on line 95",
+      "Add FeatureKind to the import: use crate::discovery::{DiscoveredFeature, FeatureKind}",
+      "Add && feature.kind != FeatureKind::Instructions to the misplaced-features condition",
+      "Add a comment explaining why: instruction files live at repo root by design, not in .ai/",
+      "Add lint_instruction_files_not_flagged_as_misplaced() test in lint/mod.rs covering both branches of the new condition",
+      "Rebuild and verify source/misplaced-features no longer fires on CLAUDE.md"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Register instructions/oversized rule in quality_rules_for_kind() under FeatureKind::Instructions arm with config-based construction, and add to catalog() for LSP integration",
+    "description": "Add aipm lint CI step to .github/workflows/ci.yml as an inline blocking step",
     "steps": [
-      "In crates/libaipm/src/lint/rules/mod.rs quality_rules_for_kind(), add FeatureKind::Instructions arm",
-      "Extract options from config using config.rule_options('instructions/oversized')",
-      "Parse 'lines' option as usize with DEFAULT_MAX_LINES fallback",
-      "Parse 'characters' option as usize with DEFAULT_MAX_CHARS fallback",
-      "Parse 'resolve-imports' option as bool with false fallback",
-      "Construct Oversized { max_lines, max_chars, resolve_imports } and return in vec",
-      "Add Oversized::default() to catalog() vec for LSP rule registry",
-      "Run cargo build --workspace to confirm compilation"
+      "Read .github/workflows/ci.yml to understand the current job structure and step ordering",
+      "Identify the position after the existing cargo build --workspace step",
+      "Add a new step: name 'Lint AI plugins', run './target/debug/aipm lint . --reporter ci-github'",
+      "Confirm cargo build --workspace already produces target/debug/aipm — if so, no extra build invocation needed in the lint step",
+      "If cargo build --workspace does NOT produce the aipm binary, add 'cargo build --bin aipm' before the lint command",
+      "Do NOT add continue-on-error — the step should block PRs on lint errors"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Unit tests for FeatureKind::Instructions discovery classification \u2014 case-insensitive matching, instruction files in agents/ dir, *.instructions.md suffix, and ensuring regular agent .md files are unaffected",
-    "steps": [
-      "Add test classify_claude_md: CLAUDE.md at root returns FeatureKind::Instructions",
-      "Add test classify_claude_md_lowercase: claude.md at root returns FeatureKind::Instructions",
-      "Add test classify_agents_md_in_agents_dir: agents/AGENTS.md returns FeatureKind::Instructions (not Agent)",
-      "Add test classify_instructions_md_suffix: frontend.instructions.md returns FeatureKind::Instructions",
-      "Add test classify_regular_agent_unchanged: agents/security-reviewer.md still returns FeatureKind::Agent",
-      "Add test classify_gemini_md: GEMINI.md returns FeatureKind::Instructions",
-      "Add test classify_copilot_md: COPILOT.md returns FeatureKind::Instructions",
-      "Run cargo test --workspace to verify all pass"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Unit tests for import_resolver.rs \u2014 @import syntax, markdown links, circular refs, path traversal, nested imports, missing targets, mixed imports",
-    "steps": [
-      "Add test at_import_basic: file with @path/to/file.md follows import and sums sizes",
-      "Add test markdown_link_basic: file with [text](./file.md) follows link and sums sizes",
-      "Add test external_url_ignored: [text](https://example.com/file.md) not followed",
-      "Add test non_md_link_ignored: [text](./config.json) not followed",
-      "Add test circular_import: A imports B, B imports A \u2014 no infinite loop, each file counted once",
-      "Add test path_traversal_rejected: @../../etc/passwd is ignored",
-      "Add test absolute_path_rejected: @/etc/passwd is ignored",
-      "Add test nested_imports: A -> B -> C chain of 3 all counted",
-      "Add test missing_import_target: @nonexistent.md silently skipped",
-      "Add test mixed_imports: file with both @import and markdown links, both followed",
-      "Run cargo test --workspace to verify all pass"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Unit tests for instructions_oversized rule \u2014 small file, at-limit, over-limit lines, over-limit chars, both exceeded, empty file, missing file, custom thresholds, source_type values",
-    "steps": [
-      "Add test small_file_no_finding: file under both limits emits no diagnostics",
-      "Add test exactly_at_line_limit: exactly 100 lines emits no diagnostics",
-      "Add test exactly_at_char_limit: exactly 15000 characters emits no diagnostics",
-      "Add test over_line_limit: 101+ lines under char limit emits 1 diagnostic for lines",
-      "Add test over_char_limit: under line limit 15001+ chars emits 1 diagnostic for chars",
-      "Add test both_limits_exceeded: over both limits emits 2 diagnostics",
-      "Add test empty_file: empty instruction file emits no diagnostics",
-      "Add test missing_file: non-existent file returns empty vec",
-      "Add test case_insensitive_detection: claude.md lowercase is discovered and checked",
-      "Add test instructions_md_suffix: frontend.instructions.md is discovered and checked",
-      "Add test subdirectory_detection: packages/auth/CLAUDE.md is discovered and checked",
-      "Add test custom_thresholds: rule with lines=50 triggers at 51 lines",
-      "Add test source_type_project: file at project root has source_type 'project'",
-      "Add test source_type_claude: file at .claude/CLAUDE.md has source_type '.claude'",
-      "Run cargo test --workspace to verify all pass"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Unit tests for resolve-imports integration in the oversized rule \u2014 basic import resolution, circular refs, both resolved and direct sizes in diagnostic messages",
-    "steps": [
-      "Add test resolve_imports_basic: Oversized with resolve_imports=true follows @import and checks resolved total",
-      "Add test resolve_imports_circular: circular import chain does not infinite loop and counts each file once",
-      "Add test resolve_imports_diagnostic_message: diagnostic message includes both resolved total and direct size",
-      "Add test resolve_imports_under_limit: resolved total under limit emits no diagnostic",
-      "Add test resolve_imports_markdown_link: follows relative markdown links when resolve_imports=true",
-      "Add test resolve_imports_disabled_by_default: Oversized::default() does not follow imports",
-      "Run cargo test --workspace to verify all pass"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Config system tests \u2014 RuleOverride with options BTreeMap, rule_options() accessor, load_lint_config() forwarding custom TOML keys",
-    "steps": [
-      "Add test rule_override_detailed_with_options: Detailed variant stores and returns options",
-      "Add test rule_options_empty_for_non_detailed: Allow and Level variants return empty options",
-      "Add test config_rule_options_accessor: Config.rule_options() returns options for a known rule",
-      "Add test config_rule_options_missing_rule: Config.rule_options() returns empty for unknown rule",
-      "Add test load_lint_config_custom_keys: TOML with lines/characters/resolve-imports keys are parsed into options",
-      "Add test load_lint_config_backward_compatible: existing TOML with only level/ignore still works",
-      "Run cargo test --workspace to verify all pass"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Integration tests \u2014 full lint() pipeline discovers instruction files, config overrides thresholds, allow suppresses rule",
-    "steps": [
-      "Add test lint_discovers_instruction_files: full lint() call with MockFs containing oversized CLAUDE.md produces diagnostics",
-      "Add test lint_config_overrides_thresholds: custom lines/characters in config are respected by the rule",
-      "Add test lint_config_allow_suppresses: 'allow' in config suppresses instructions/oversized rule entirely",
-      "Run cargo test --workspace to verify all pass"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Verify LSP integration \u2014 catalog() includes instructions/oversized, build_rule_index() picks it up, lint_file() dispatches for FeatureKind::Instructions files",
-    "steps": [
-      "Verify catalog() in rules/mod.rs includes Oversized::default()",
-      "Check crates/aipm/src/lsp/helpers.rs build_rule_index() \u2014 confirm it calls catalog() generically",
-      "Verify lint_file() in lsp/helpers.rs will dispatch rules for FeatureKind::Instructions files",
-      "If needed, update lint_file() to handle Instructions classification",
-      "Run cargo build --workspace to confirm compilation"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Run all four build gates (cargo build, test, clippy, fmt) with zero warnings and verify branch coverage >= 89%",
+    "description": "End-to-end verification: aipm lint produces 0 errors 0 warnings, all build gates pass",
     "steps": [
       "Run cargo build --workspace and verify zero errors",
       "Run cargo test --workspace and verify all tests pass",
       "Run cargo clippy --workspace -- -D warnings and verify zero warnings",
       "Run cargo fmt --check and verify formatting is correct",
-      "Run cargo +nightly llvm-cov clean --workspace",
-      "Run cargo +nightly llvm-cov --no-report --workspace --branch",
-      "Run cargo +nightly llvm-cov --no-report --doc",
-      "Run cargo +nightly llvm-cov report --doctests --branch --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\\.rs|lsp\\.rs)' and verify TOTAL branch column >= 89%",
-      "Fix any clippy warnings, formatting issues, or coverage gaps before marking complete"
+      "Run ./target/debug/aipm lint . and verify 0 errors, 0 warnings",
+      "Run ./target/debug/aipm lint . --reporter json and inspect output for completeness",
+      "Verify aipm lint fixtures/ still produces expected fixture violations (ignore pattern only applies via root config)"
     ],
     "passes": true
   }

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -1,3 +1,8 @@
-Iteration 1 complete - all 15 features implemented and verified
+Iteration 2 complete - added missing test coverage for Instructions exemption
 Build gates: cargo build ✓, cargo test ✓, cargo clippy ✓, cargo fmt ✓
-Coverage: 89.07% branch (≥89% required)
+Coverage: 89.20% branch (≥89% required) ✓
+aipm lint .: 0 errors, 0 warnings ✓
+
+All 8 features pass. Added in iteration 2:
+- crates/libaipm/src/lint/mod.rs: lint_instruction_files_not_flagged_as_misplaced() test
+  covering the new FeatureKind::Instructions exemption branch

--- a/research/tickets/2026-04-11-426-dogfood-aipm-lint.md
+++ b/research/tickets/2026-04-11-426-dogfood-aipm-lint.md
@@ -1,0 +1,296 @@
+---
+date: 2026-04-11 21:17:18 UTC
+researcher: Claude Code (Opus 4.6)
+git_commit: 796ace8014cd381324b954c5ac7b5883b9cdf394
+branch: main
+repository: aipm
+topic: "[dogfood] enable 'aipm lint' in this repo (Issue #426)"
+tags: [research, lint, dogfood, aipm-toml, fixtures, ci-cd, vscode]
+status: complete
+last_updated: 2026-04-11
+last_updated_by: Claude Code (Opus 4.6)
+---
+
+# Research: Dogfood `aipm lint` in This Repo (Issue #426)
+
+## Research Question
+
+How does `aipm lint` currently work, what does an `aipm.toml` manifest look like, and what changes are needed to dogfood linting in this repo — including fixture exclusion, CI integration, and VSCode plugin support?
+
+Issue checklist from [#426](https://github.com/TheLarkInn/aipm/issues/426):
+
+- [ ] Ensure repo AI integrations are up to standard
+- [ ] Protect plugin changes in CI/CD
+- [ ] Dogfood the VSCode plugin locally (requires root `aipm.toml` with lint settings only)
+- [ ] Lint rules should ignore `./fixtures/` (used for e2e / functional tests)
+- [ ] If `aipm lint` can't support ignoring fixtures, it's a bug
+
+## Summary
+
+The `aipm lint` system is fully implemented with 18 rules, 4 output reporters, glob-based ignore patterns (global and per-rule), and config via `[workspace.lints]` in `aipm.toml`. The repo currently has **no root `aipm.toml`** and **`aipm lint` is not in CI**. Running `aipm lint .` today produces **40 diagnostics (18 errors, 22 warnings)** — of which **35 come from `fixtures/`** and only **5 from real code** (1 error, 4 warnings). The existing `[workspace.lints.ignore].paths` mechanism with `**/fixtures/**` glob patterns can exclude fixtures. The VSCode extension activates on the presence of `aipm.toml` and launches `aipm lsp` for inline diagnostics.
+
+## Detailed Findings
+
+### 1. Current Lint Output (Baseline)
+
+Running `aipm lint .` at the repo root at commit `796ace8` produces:
+
+| Source | Errors | Warnings | Total |
+|--------|--------|----------|-------|
+| `fixtures/` | 17 | 18 | 35 |
+| Real code (`.ai/`, root) | 1 | 4 | 5 |
+| **Total** | **18** | **22** | **40** |
+
+**Real code diagnostics (5):**
+
+| Severity | Rule | File |
+|----------|------|------|
+| warning | `skill/oversized` | [`.ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/.ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md) |
+| error | `plugin/required-fields` | [`.ai/starter-aipm-plugin/.claude-plugin/plugin.json`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/.ai/starter-aipm-plugin/.claude-plugin/plugin.json) |
+| warning | `skill/missing-name` | [`.ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/.ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md) |
+| warning | `source/misplaced-features` | [`CLAUDE.md`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/CLAUDE.md) |
+| warning | `instructions/oversized` | [`CLAUDE.md`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/CLAUDE.md) |
+
+### 2. `aipm lint` Architecture
+
+The lint pipeline is implemented across three crates:
+
+- **CLI entry**: [`crates/aipm/src/main.rs:666-746`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/aipm/src/main.rs#L666-L746) — `cmd_lint()` orchestrates config loading, lint execution, and reporting.
+- **Core pipeline**: [`crates/libaipm/src/lint/mod.rs:115-162`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/lint/mod.rs#L115-L162) — `lint()` performs discovery, rule dispatch, and diagnostic collection.
+- **Feature discovery**: [`crates/libaipm/src/discovery.rs:299-369`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/discovery.rs#L299-L369) — `discover_features()` uses the `ignore` crate's `WalkBuilder` for a single gitignore-aware recursive walk.
+
+**Data flow:**
+1. CLI parses args and validates `--source`, `--reporter`, `--color`
+2. `load_lint_config(&dir)` reads `aipm.toml` and parses `[workspace.lints]` ([`main.rs:748-845`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/aipm/src/main.rs#L748-L845))
+3. `discover_features()` walks the directory tree, classifying files by name/parent into `FeatureKind` variants (Skill, Agent, Hook, Plugin, Marketplace, PluginJson, Instructions)
+4. `run_rules_for_feature()` dispatches kind-appropriate rules from the registry
+5. `apply_rule_diagnostics()` filters results through global and per-rule ignore patterns
+6. Reporter formats output; exit code is `FAILURE` if `error_count > 0`
+
+**Hardcoded skip directories** ([`discovery.rs:178-179`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/discovery.rs#L178-L179)):
+`node_modules`, `target`, `.git`, `vendor`, `__pycache__`, `dist`, `build` — **`fixtures` is not in this list**.
+
+### 3. The 18 Lint Rules
+
+| Rule ID | Default Severity | Applies To |
+|---------|-----------------|------------|
+| `skill/missing-name` | warning | Skill |
+| `skill/missing-description` | warning | Skill |
+| `skill/oversized` | warning | Skill |
+| `skill/name-too-long` | warning | Skill |
+| `skill/name-invalid-chars` | warning | Skill |
+| `skill/description-too-long` | warning | Skill |
+| `skill/invalid-shell` | error | Skill |
+| `plugin/broken-paths` | error | Skill, Plugin |
+| `agent/missing-tools` | warning | Agent |
+| `hook/unknown-event` | error | Hook |
+| `hook/legacy-event-name` | warning | Hook |
+| `marketplace/source-resolve` | error | Marketplace |
+| `marketplace/plugin-field-mismatch` | error | Marketplace |
+| `plugin/missing-registration` | error | Marketplace |
+| `plugin/missing-manifest` | error | Marketplace |
+| `plugin/required-fields` | error | PluginJson |
+| `instructions/oversized` | warning | Instructions |
+| `source/misplaced-features` | warning | (any outside `.ai/`) |
+
+Rule implementations live in [`crates/libaipm/src/lint/rules/`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/lint/rules/).
+
+### 4. Ignore Pattern Support (Fixture Exclusion)
+
+**The system already supports fixture exclusion.** Two ignore mechanisms exist:
+
+#### Global ignore paths (`[workspace.lints.ignore].paths`)
+
+Defined in [`lint/config.rs:9-14`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/lint/config.rs#L9-L14). Parsed at [`main.rs:790-798`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/aipm/src/main.rs#L790-L798). Applied to all rules via `is_ignored()` at [`lint/mod.rs:23-41`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/lint/mod.rs#L23-L41).
+
+```toml
+[workspace.lints.ignore]
+paths = ["**/fixtures/**"]
+```
+
+#### Per-rule ignore paths (`[workspace.lints."rule-id"].ignore`)
+
+```toml
+[workspace.lints."plugin/broken-paths"]
+ignore = ["**/fixtures/**"]
+```
+
+#### How matching works
+
+`is_ignored()` uses `glob::Pattern::matches()` against the **full absolute path** string of the diagnostic's `file_path`. Patterns must use `**/` prefixes to match at any depth. A pattern like `fixtures/**` would **NOT** match `/workspaces/aipm/fixtures/...` — it must be `**/fixtures/**`.
+
+#### Where filtering happens
+
+Ignore patterns are applied **post-discovery, post-rule-execution** in `apply_rule_diagnostics()` ([`lint/mod.rs:45-65`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/lint/mod.rs#L45-L65)). Rules still run on fixture files — only the resulting diagnostics are suppressed. This is sufficient for correctness but does unnecessary work.
+
+**Verdict: `aipm lint` CAN support ignoring fixtures via `[workspace.lints.ignore].paths`. This is not a bug — it just needs an `aipm.toml` configured with the right glob.**
+
+### 5. `aipm.toml` Manifest Format
+
+The manifest struct is defined at [`crates/libaipm/src/manifest/types.rs:10-42`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/manifest/types.rs#L10-L42). Key sections:
+
+| Section | Purpose |
+|---------|---------|
+| `[package]` | Plugin metadata (name, version, type, description, engines) |
+| `[workspace]` | Workspace config (members, plugins_dir) |
+| `[workspace.lints]` | Lint rule configuration (parsed separately via `toml::Value`) |
+| `[workspace.lints.ignore]` | Global ignore paths |
+| `[dependencies]` | Direct dependencies |
+| `[components]` | Component file declarations |
+| `[environment]` | Environment requirements |
+| `[install]` | Installation behavior |
+
+For dogfooding, only `[workspace.lints]` (and optionally a minimal `[workspace]`) is needed. The `Workspace` struct does **not** use `#[serde(deny_unknown_fields)]` ([`types.rs:88-99`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/crates/libaipm/src/manifest/types.rs#L88-L99)), which allows the `lints` key to pass through typed deserialization while being parsed separately.
+
+### 6. Minimal `aipm.toml` for Dogfooding
+
+Based on the 5 real diagnostics and the issue requirements, a suitable root `aipm.toml` would contain only lint settings:
+
+```toml
+[workspace.lints.ignore]
+paths = ["**/fixtures/**"]
+```
+
+This would:
+- Exclude all 35 fixture diagnostics
+- Leave the 5 real-code diagnostics visible for fixing
+- Activate the VSCode extension (which triggers on `workspaceContains:**/aipm.toml`)
+- Serve as input for `aipm lint --reporter ci-github` in CI
+
+Additional overrides could suppress or adjust specific rules for the real diagnostics, depending on what the team considers acceptable (e.g., allowing `source/misplaced-features` for `CLAUDE.md` since it's a project-level instruction file, not a plugin feature).
+
+### 7. CI/CD Integration
+
+**Current CI** ([`.github/workflows/ci.yml`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/.github/workflows/ci.yml)):
+- Job `ci`: `cargo build`, `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check`
+- Job `coverage`: nightly branch coverage gate at 89%
+- **No `aipm lint` step exists.**
+
+The lint guide ([`docs/guides/lint.md:144-149`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/docs/guides/lint.md#L144-L149)) documents the recommended CI pattern:
+
+```yaml
+- name: Lint AI plugins
+  run: aipm lint --reporter ci-github
+```
+
+The `ci-github` reporter emits `::error` / `::warning` workflow commands that create inline PR annotations. The `aipm` binary would need to be built or installed in CI before the lint step runs.
+
+### 8. VSCode Extension
+
+The [`vscode-aipm/`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/vscode-aipm/) extension:
+
+- **Activates on** `workspaceContains:**/aipm.toml` ([`package.json:11`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/vscode-aipm/package.json#L11))
+- **Launches** `aipm lsp` as a stdio language server ([`extension.ts:18-21`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/vscode-aipm/src/extension.ts#L18-L21))
+- **Settings**: `aipm.lint.enable` (default `true`), `aipm.path` (default `"aipm"`)
+- **Linted file types**: `aipm.toml`, `SKILL.md`, agent `.md`, `hooks.json`, `plugin.json`, `marketplace.json`
+- **Schema validation**: TOML schema at [`schemas/aipm.toml.schema.json`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/schemas/aipm.toml.schema.json) provides IDE-level validation for `[workspace.lints]` via the Taplo TOML extension
+
+Adding a root `aipm.toml` is the only prerequisite for the VSCode extension to activate and provide inline lint diagnostics.
+
+### 9. Existing Lintable Content in `.ai/`
+
+The repo has a live `.ai/` marketplace ([`.ai/.claude-plugin/marketplace.json`](https://github.com/TheLarkInn/aipm/blob/796ace8014cd381324b954c5ac7b5883b9cdf394/.ai/.claude-plugin/marketplace.json)) with two plugins:
+
+| Plugin | Contents |
+|--------|----------|
+| `aipm-atomic-plugin` | 7 agents, 3 skills (perf-anti-patterns, prompt-engineer, testing-anti-patterns), 7 commands |
+| `starter-aipm-plugin` | 1 agent, 1 skill (scaffold-plugin), 1 hooks.json, 1 MCP config, 1 script |
+
+These are already being linted and produce the 5 real diagnostics listed above.
+
+## Code References
+
+- `crates/aipm/src/main.rs:158-182` — `Lint` CLI subcommand definition (clap derive)
+- `crates/aipm/src/main.rs:666-746` — `cmd_lint()` handler
+- `crates/aipm/src/main.rs:748-845` — `load_lint_config()` parses `[workspace.lints]`
+- `crates/libaipm/src/lint/mod.rs:23-41` — `is_ignored()` glob matching
+- `crates/libaipm/src/lint/mod.rs:45-65` — `apply_rule_diagnostics()` with ignore filtering
+- `crates/libaipm/src/lint/mod.rs:68-104` — `run_rules_for_feature()` rule dispatch
+- `crates/libaipm/src/lint/mod.rs:115-162` — `lint()` main pipeline
+- `crates/libaipm/src/lint/config.rs:8-72` — `Config`, `RuleOverride` types
+- `crates/libaipm/src/lint/rules/mod.rs:41-87` — `quality_rules_for_kind()` registry
+- `crates/libaipm/src/discovery.rs:178-179` — `SKIP_DIRS` constant
+- `crates/libaipm/src/discovery.rs:243-297` — `classify_feature_kind()`
+- `crates/libaipm/src/discovery.rs:299-369` — `discover_features()` walk
+- `crates/libaipm/src/manifest/types.rs:10-42` — `Manifest` struct
+- `crates/libaipm/src/manifest/types.rs:88-99` — `Workspace` struct (no `deny_unknown_fields`)
+- `.github/workflows/ci.yml` — current CI pipeline (no `aipm lint`)
+- `vscode-aipm/package.json:11` — extension activation event
+- `vscode-aipm/src/extension.ts:12-55` — extension entry point
+- `schemas/aipm.toml.schema.json` — JSON Schema for lint config
+- `docs/guides/lint.md` — user-facing lint documentation
+
+## Architecture Documentation
+
+### Lint Pipeline Flow
+
+```
+CLI (main.rs)
+  |
+  ├─ load_lint_config() ─── reads aipm.toml ─── parses [workspace.lints]
+  |                                               ├─ ignore.paths → Config.ignore_paths
+  |                                               └─ rule overrides → Config.rule_overrides
+  |
+  └─ lint::lint(opts, fs)
+       |
+       ├─ discover_features(dir, max_depth)
+       |    └─ ignore::WalkBuilder (gitignore-aware, SKIP_DIRS filter)
+       |         └─ classify_feature_kind() for each file
+       |
+       ├─ Optional --source filter
+       |
+       ├─ For each feature:
+       |    └─ run_rules_for_feature()
+       |         ├─ quality_rules_for_kind() → applicable rules
+       |         ├─ Skip suppressed rules (config.is_suppressed)
+       |         ├─ rule.check_file(path, fs) → Vec<Diagnostic>
+       |         └─ apply_rule_diagnostics()
+       |              ├─ Effective severity (config override or default)
+       |              ├─ is_ignored() check (global + per-rule)
+       |              └─ Attach help text/URL
+       |
+       └─ Sort, count, return Outcome
+            └─ Reporter formats to stdout
+                 └─ Exit code: FAILURE if error_count > 0
+```
+
+### Config File Discovery
+
+- **Lint config**: `load_lint_config()` looks for `aipm.toml` in the **given directory only** (no upward walk). Returns `Config::default()` (empty) if file is missing or unparseable.
+- **Workspace root**: `find_workspace_root()` walks **upward** from CWD, looking for `aipm.toml` with a `[workspace]` section.
+- **VSCode extension**: Activates when any `aipm.toml` exists anywhere in the workspace (`workspaceContains:**/aipm.toml`).
+
+### Ignore Pattern Semantics
+
+- Patterns use `glob::Pattern` (not gitignore-style)
+- Matching is against the **full absolute path** string of the diagnostic's `file_path`
+- `**/fixtures/**` matches any path containing a `fixtures/` component at any depth
+- Patterns like `fixtures/**` (no `**/` prefix) will NOT match absolute paths
+- Invalid patterns are silently skipped (logged at `tracing::warn` level)
+- Filtering happens post-rule-execution — rules still run, only diagnostics are suppressed
+
+## Historical Context (from research/)
+
+- `research/tickets/2026-03-28-110-aipm-lint.md` — Original `aipm lint` command research (Issue #110)
+- `research/docs/2026-03-31-110-aipm-lint-architecture-research.md` — Comprehensive lint architecture research
+- `research/docs/2026-04-02-aipm-lint-configuration-research.md` — Lint configuration and rule override research
+- `research/docs/2026-04-10-377-vscode-support-aipm-lint.md` — VSCode extension integration research (Issue #377)
+- `research/docs/2026-04-07-lint-rules-287-288-289-290.md` — Marketplace/plugin rule implementations
+- `research/tickets/2026-04-11-185-prevent-long-instructions-files.md` — Instructions oversized rule research
+
+No prior research exists for "dogfooding" specifically.
+
+## Related Research
+
+- [`research/docs/2026-03-09-manifest-format-comparison.md`](../docs/2026-03-09-manifest-format-comparison.md) — Why TOML was chosen for manifests
+- [`research/docs/2026-03-24-aipm-toml-generation-in-init-and-migrate.md`](../docs/2026-03-24-aipm-toml-generation-in-init-and-migrate.md) — How `aipm init` generates manifests
+- [`research/docs/2026-03-16-rust-cross-platform-release-distribution.md`](../docs/2026-03-16-rust-cross-platform-release-distribution.md) — CI/CD binary distribution
+- [`research/docs/2026-04-10-vscode-extension-launch-debug.md`](../docs/2026-04-10-vscode-extension-launch-debug.md) — VSCode extension debugging
+
+## Open Questions
+
+1. **Should `CLAUDE.md` warnings be suppressed?** The `source/misplaced-features` and `instructions/oversized` rules fire on `CLAUDE.md`. This is a project-level instruction file, not a plugin feature — suppressing `source/misplaced-features` for `CLAUDE.md` via ignore pattern or `"allow"` may be appropriate.
+2. **Should the `plugin/required-fields` error on `starter-aipm-plugin` be fixed?** The `plugin.json` is missing an `author` field. This is a real issue in the live plugin.
+3. **Should the `skill/oversized` warning on `perf-anti-patterns` be addressed?** The skill is 20,036 chars vs the 15,000 limit. It could be allowed, split, or the threshold could be overridden.
+4. **CI binary availability**: The CI lint step needs `aipm` built before it can run. The simplest approach is to add the lint step after `cargo build --workspace` and use `cargo run --bin aipm --` or `target/debug/aipm`.
+5. **Pre-discovery exclusion**: Currently fixtures are still walked and rules still execute — only diagnostics are suppressed. For large fixture directories this is wasted work, but for this repo's fixture count it's negligible.

--- a/specs/2026-04-12-dogfood-aipm-lint.md
+++ b/specs/2026-04-12-dogfood-aipm-lint.md
@@ -1,0 +1,271 @@
+# Dogfood `aipm lint` in This Repository — Issue #426
+
+| Document Metadata | Details |
+| --- | --- |
+| Author(s) | Sean Larkin |
+| Status | Draft (WIP) |
+| Team / Owner | aipm core |
+| Created / Last Updated | 2026-04-12 |
+| Related Issues | [#426](https://github.com/TheLarkInn/aipm/issues/426) |
+| Research | [`research/tickets/2026-04-11-426-dogfood-aipm-lint.md`](../research/tickets/2026-04-11-426-dogfood-aipm-lint.md) |
+
+---
+
+## 1. Executive Summary
+
+This spec establishes `aipm lint` as a first-class CI gate for this repository's own AI plugin integrations in `.ai/`. The repo currently has no root `aipm.toml`, no lint step in CI, and five live diagnostic violations in real plugin files. Adding a root `aipm.toml` with a fixture ignore pattern, fixing the five violations, and wiring `aipm lint --reporter ci-github` into the build pipeline will complete the dogfooding loop: the tool validates real-world plugins, the VSCode extension activates locally, and any future regression in `.ai/` fails the PR. Total impact: zero new infrastructure, one config file, four file edits, and one CI step.
+
+---
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+The repository ships `aipm lint`, a 18-rule static analysis tool for AI plugin files. It has been used to validate third-party plugins but has never been run against this repo's own `.ai/` directory — the "eat your own dog food" step was deferred.
+
+The live `.ai/` marketplace contains two plugins:
+
+| Plugin | Contents |
+|---|---|
+| `starter-aipm-plugin` | 1 skill, 1 agent, 1 hook, 1 script |
+| `aipm-atomic-plugin` | 7 agents, 3 skills, 7 commands |
+
+Running `aipm lint .` at the current repo root produces **40 diagnostics**:
+
+| Source | Errors | Warnings | Total |
+|---|---|---|---|
+| `fixtures/` (test data) | 17 | 18 | 35 |
+| Real code (`.ai/`, `CLAUDE.md`) | 1 | 4 | **5** |
+| **Total** | **18** | **22** | **40** |
+
+The five real violations are:
+
+| Severity | Rule | File |
+|---|---|---|
+| error | `plugin/required-fields` | `.ai/starter-aipm-plugin/.claude-plugin/plugin.json` |
+| warning | `skill/missing-name` | `.ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md` |
+| warning | `skill/oversized` | `.ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md` |
+| warning | `source/misplaced-features` | `CLAUDE.md` |
+| warning | `instructions/oversized` | `CLAUDE.md` |
+
+There is currently **no root `aipm.toml`** and **no `aipm lint` step in CI**. The VSCode extension (`vscode-aipm`) only activates when `workspaceContains:**/aipm.toml` — so contributors working on `.ai/` files get no inline diagnostics.
+
+See the [research document](../research/tickets/2026-04-11-426-dogfood-aipm-lint.md) for a full baseline analysis including the lint pipeline architecture, ignore pattern semantics, and CI integration details.
+
+### 2.2 The Problem
+
+- **Regression risk**: Without a CI gate, broken plugin files (missing fields, bad paths, oversized skills) can be merged undetected.
+- **No IDE feedback**: Contributors editing `.ai/` files receive no inline diagnostics because the VSCode extension is dormant (no `aipm.toml`).
+- **Existing violations**: The one error (`plugin/required-fields`) would currently cause `aipm lint` to exit non-zero and would immediately fail any CI gate we add, if left unfixed.
+- **Fixture noise**: 35 of the 40 diagnostics come from `fixtures/` (intentionally malformed files used for integration tests). These must be excluded or the output is unusable.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] **G1** — A root `aipm.toml` exists with a global ignore pattern that excludes `**/fixtures/**` from all lint output.
+- [ ] **G2** — `aipm lint .` produces zero errors and zero warnings against real plugin files (`.ai/` and `CLAUDE.md`), with no suppression overrides used.
+- [ ] **G3** — `aipm lint . --reporter ci-github` runs as an inline CI step after `cargo build --bin aipm`, and fails the PR build on any lint error.
+- [ ] **G4** — The VSCode extension activates automatically on this repository (achieved by G1 — the presence of `aipm.toml`).
+
+### 3.2 Non-Goals
+
+- [ ] We will **NOT** add `aipm.toml` package manifests to `starter-aipm-plugin` or `aipm-atomic-plugin` — that work is tracked separately and is not required for linting.
+- [ ] We will **NOT** add `fixtures` to `SKIP_DIRS` in `discovery.rs` — the glob-based ignore in `aipm.toml` is the correct mechanism per the project's architecture. A code-level change is unnecessary for this repo's fixture count.
+- [ ] We will **NOT** update documentation in `docs/` — the dogfooding work itself is the example; no additional guide updates are warranted.
+- [ ] We will **NOT** create new lint rules as part of this ticket.
+
+---
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 Deliverable Overview
+
+```mermaid
+flowchart LR
+    A["Root aipm.toml\n(new file)"] --> B["fixtures/** excluded\nfrom all rules"]
+    A --> C["VSCode extension\nactivates"]
+
+    D["Fix plugin/required-fields\nstarter-aipm-plugin/plugin.json"] --> E
+    F["Fix skill/missing-name\nscaffold-plugin/SKILL.md"] --> E
+    G["Fix skill/oversized\nperf-anti-patterns/SKILL.md"] --> E
+    H["Shrink CLAUDE.md\nbelow 15k chars"] --> E
+
+    E["aipm lint . = 0 errors\n0 warnings"] --> I["CI step: aipm lint\n--reporter ci-github"]
+    I --> J["PR fails on\nany lint error"]
+```
+
+### 4.2 Key Components
+
+| Deliverable | Change Type | Files Affected |
+|---|---|---|
+| Root `aipm.toml` | New file | `aipm.toml` (repo root) |
+| Fix `plugin/required-fields` | File edit | `.ai/starter-aipm-plugin/.claude-plugin/plugin.json` |
+| Fix `skill/missing-name` | File edit | `.ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md` |
+| Fix `skill/oversized` | File edit | `.ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md` |
+| Fix `instructions/oversized` | File edit | `CLAUDE.md` |
+| CI integration | Workflow edit | `.github/workflows/ci.yml` |
+
+---
+
+## 5. Detailed Design
+
+### 5.1 Root `aipm.toml`
+
+Create `aipm.toml` at the repository root. This file is intentionally minimal — it contains only lint workspace configuration, no package metadata.
+
+```toml
+[workspace.lints.ignore]
+paths = ["**/fixtures/**"]
+```
+
+**Why only this?** The `Workspace` struct does not use `#[serde(deny_unknown_fields)]` ([`types.rs:88-99`](../crates/libaipm/src/manifest/types.rs)), so an `aipm.toml` with only `[workspace.lints.*]` keys passes typed deserialization cleanly. The `load_lint_config()` function ([`main.rs:748-845`](../crates/aipm/src/main.rs)) reads this section independently.
+
+**Ignore pattern semantics**: The `is_ignored()` function ([`lint/mod.rs:23-41`](../crates/libaipm/src/lint/mod.rs)) matches glob patterns against the **full absolute path** of each diagnostic's `file_path`. The pattern `**/fixtures/**` correctly matches any path containing a `fixtures/` directory component at any depth (e.g., `/workspaces/aipm/fixtures/plugins/...`). A pattern without the leading `**/` would fail to match absolute paths.
+
+**VSCode side effect**: The extension activates on `workspaceContains:**/aipm.toml` ([`package.json:11`](../vscode-aipm/package.json)). Adding this file is the only prerequisite for inline lint diagnostics in VS Code; no other extension configuration is needed.
+
+### 5.2 Fix `plugin/required-fields` (Error)
+
+**File**: `.ai/starter-aipm-plugin/.claude-plugin/plugin.json`
+
+The `RequiredFields` rule ([`rules/plugin_required_fields.rs`](../crates/libaipm/src/lint/rules/plugin_required_fields.rs)) validates that `plugin.json` contains all mandatory top-level fields. The `aipm-atomic-plugin` already declares an `author` field; `starter-aipm-plugin` is missing it.
+
+**Fix**: Add an `author` field to `starter-aipm-plugin/.claude-plugin/plugin.json` with an appropriate value matching the repo owner. The exact field schema accepted by `RequiredFields` should be confirmed by reading the rule implementation before editing.
+
+This is the only **error**-severity diagnostic. Without this fix, the CI step would immediately exit non-zero on the first run.
+
+### 5.3 Fix `skill/missing-name` (Warning)
+
+**File**: `.ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md`
+
+The `MissingName` rule ([`rules/skill_missing_name.rs`](../crates/libaipm/src/lint/rules/skill_missing_name.rs)) checks for a `name` key in the SKILL.md YAML frontmatter.
+
+**Fix**: Add a `name:` field to the frontmatter block at the top of `scaffold-plugin/SKILL.md`. The value should be a short, human-readable name for the skill (e.g., `Scaffold Plugin`).
+
+### 5.4 Fix `skill/oversized` (Warning)
+
+**File**: `.ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md`
+
+The `Oversized` rule ([`rules/skill_oversized.rs`](../crates/libaipm/src/lint/rules/skill_oversized.rs)) enforces a 15,000-character limit on SKILL.md files. The `perf-anti-patterns` skill is currently 20,036 chars — 5,036 chars over the limit.
+
+**Fix strategy**: Reduce the skill's content to below 15,000 characters. Recommended approaches (in order of preference):
+
+1. **Extract reference material** — Move the detailed anti-pattern descriptions into a `references/` subdirectory (as `prompt-engineer` already does) and replace them in SKILL.md with concise one-line summaries. The gate functions / detection logic in the main skill body can be kept, while verbose explanations move to reference files.
+2. **Condense anti-pattern definitions** — Combine overlapping anti-patterns or shorten prose descriptions while preserving the key detection criteria.
+
+The goal is to keep the skill's functional value while meeting the size constraint, not to arbitrarily truncate content. Read the current file content before deciding which approach fits better.
+
+### 5.5 Fix `instructions/oversized` on `CLAUDE.md` (Warning)
+
+**File**: `CLAUDE.md`
+
+The `instructions/oversized` rule fires on CLAUDE.md because it exceeds the default 15,000-character limit (configured via `DEFAULT_MAX_CHARS = 15_000` in [`rules/instructions_oversized.rs`](../crates/libaipm/src/lint/rules/instructions_oversized.rs)).
+
+**Fix strategy**: Reduce CLAUDE.md to below 15,000 characters. Recommended approaches:
+
+1. **Trim the build commands section** — The `Build Commands` and `Coverage Commands` sections contain extensive shell command blocks. Consider linking to an external reference or condensing the coverage command block (which has four variants).
+2. **Compress the agentic workflows table** — The `Why 45 minutes?` prose block under `Agentic Workflows` is verbose; a tighter 2-3 sentence summary would preserve the intent.
+3. **Condense the spec template** — The existing spec template in `Agentic Workflows` or any embedded examples can be removed or shortened.
+
+Do **not** move CLAUDE.md into `.ai/` — instruction files belong at the repo root and are not plugin features. The `source/misplaced-features` rule is not expected to fire on `FeatureKind::Instructions` files; if it does, that is a separate rule-behavior issue tracked independently.
+
+> **Risk note**: The research baseline (commit `796ace8`) recorded a `source/misplaced-features` warning on `CLAUDE.md`. This may have been corrected in subsequent commits. Verify by running `aipm lint .` before and after adding `aipm.toml` to confirm the actual diagnostic count. If `source/misplaced-features` still fires on `CLAUDE.md`, that is a bug in the rule (instructions are not misplaced features) and should be filed as a separate issue — do **not** add a suppress override to `aipm.toml`.
+
+### 5.6 CI Integration
+
+**File**: `.github/workflows/ci.yml`
+
+Add an inline lint step to the existing `ci` job, after the `cargo build --workspace` step (which already exists). The lint step reuses the just-built debug binary:
+
+```yaml
+- name: Lint AI plugins
+  run: |
+    cargo build --bin aipm
+    ./target/debug/aipm lint . --reporter ci-github
+```
+
+**Rationale for inline step (not a separate job):**
+
+- No artifact upload/download overhead
+- The binary is already compiled by `cargo build --workspace` earlier in the job; `cargo build --bin aipm` will be a no-op if the workspace build already succeeded
+- Keeps CI configuration simple
+
+**Reporter choice**: `ci-github` emits `::error file=...,line=...,col=...::message` and `::warning` workflow commands, which GitHub Actions renders as inline PR annotations on the diff view. This is the format documented in [`docs/guides/lint.md:144-149`](../docs/guides/lint.md).
+
+**Exit behavior**: `cmd_lint()` ([`main.rs:739-744`](../crates/aipm/src/main.rs)) returns an error string if `outcome.error_count > 0`. The CI step will exit non-zero on any `error`-severity diagnostic, failing the PR. Warning-severity diagnostics produce annotations but do not block the build.
+
+---
+
+## 6. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|---|---|---|---|
+| Suppress `plugin/required-fields` via `aipm.toml` | No plugin file changes needed | Hides a real defect in the live plugin | Rejected — fix the underlying issue |
+| Override `skill/oversized` threshold to 25,000 chars | No skill file changes | The skill is genuinely too large for context; size limit exists for a reason | Rejected — fix the skill |
+| Suppress `instructions/oversized` on `CLAUDE.md` | No CLAUDE.md changes | CLAUDE.md is growing and a size signal is valuable | Rejected — shrink CLAUDE.md instead |
+| Add `fixtures` to `SKIP_DIRS` in `discovery.rs` | Pre-discovery exclusion, no wasted rule execution | Code change for a problem solvable with config; hardcodes a project-specific convention into the library | Rejected — use `aipm.toml` ignore pattern |
+| Start CI in advisory mode (`continue-on-error: true`) | Lower risk on first merge | Defers accountability; the one existing error must be fixed anyway | Rejected — fix errors first, then gate hard |
+| Add `aipm.toml` manifests to both plugins | Full dogfooding of the package manifest format | Those plugins predate `aipm.toml` adoption; out of scope for this ticket | Deferred to a separate issue |
+
+---
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Fixture Exclusion Semantics
+
+The ignore pattern `**/fixtures/**` is applied **post-rule-execution** in `apply_rule_diagnostics()` ([`lint/mod.rs:45-65`](../crates/libaipm/src/lint/mod.rs)). Rules still run against fixture files; only the resulting diagnostics are suppressed. For this repo's fixture count this is negligible overhead. Adding `fixtures` to `SKIP_DIRS` would be a performance optimization but is explicitly out of scope.
+
+### 7.2 `source/misplaced-features` on Instruction Files
+
+The `source/misplaced-features` rule fires in Phase 2 of `run_rules_for_feature()` ([`lint/mod.rs:95`](../crates/libaipm/src/lint/mod.rs)) for any feature not inside `.ai/`. Instruction files (`CLAUDE.md`, `AGENTS.md`, etc.) have `FeatureKind::Instructions` — they are not plugin features and should be exempt from this rule. If the rule fires on `CLAUDE.md`, the correct fix is to update `run_rules_for_feature()` to skip the misplaced-features check for `FeatureKind::Instructions`, not to add a suppress override to `aipm.toml`. This potential bug fix is tracked separately and is out of scope here.
+
+### 7.3 `aipm.toml` Discovery
+
+`load_lint_config()` ([`main.rs:748`](../crates/aipm/src/main.rs)) looks for `aipm.toml` in the **directory passed to `aipm lint`**, not via upward walk. Running `aipm lint .` from the repo root will find `aipm.toml` at the root. Running from a subdirectory will not. The CI step must always use `.` (repo root) to ensure the config is picked up.
+
+### 7.4 VSCode Extension PATH
+
+The VSCode extension launches `aipm lsp` using the binary at `aipm.path` (default `"aipm"`). For the extension to work locally, `aipm` must be on `PATH` (e.g., via `cargo install --path crates/aipm` or adding `target/debug` to PATH). This is a local dev setup concern, not a spec deliverable, but contributors should be aware.
+
+---
+
+## 8. Migration, Rollout, and Testing
+
+### 8.1 Deployment Order
+
+The five changes must be applied in this order to avoid introducing a broken CI step:
+
+1. Fix the four plugin/instruction file violations (G2 prerequisite)
+2. Add root `aipm.toml` (enables VSCode activation, verifies zero warnings locally)
+3. Add CI lint step (only after step 1 and 2 are verified clean)
+
+Alternatively, steps 1 and 2 can be combined in a single PR, with the CI step added in the same PR — as long as `aipm lint .` produces zero errors locally before the PR is opened.
+
+### 8.2 Verification Checklist
+
+Before merging:
+
+- [ ] `aipm lint .` produces **0 errors, 0 warnings** (run from repo root with root `aipm.toml` present)
+- [ ] `aipm lint . --reporter text` shows no fixture diagnostics
+- [ ] `aipm lint fixtures/ --reporter text` still shows the expected fixture violations (ignore only applies at root config scope, not when targeting fixture dir directly — verify this behavior)
+- [ ] The VSCode extension activates when opening the workspace (check the Output panel for `aipm lsp`)
+- [ ] CI passes with the new lint step on a test PR
+
+### 8.3 Test Plan
+
+- **Manual**: Run `aipm lint .` before and after each file fix to confirm each diagnostic is resolved individually.
+- **CI**: Open a draft PR with only the `aipm.toml` (before fixing violations) to confirm CI fails as expected, then add the fixes and confirm CI passes.
+- **VSCode**: Open the workspace in VS Code with `vscode-aipm` installed. Confirm the extension activates and shows no diagnostics on `.ai/` files.
+
+No new unit or integration tests are required — the changes being made are configuration and content edits, not logic changes.
+
+---
+
+## 9. Open Questions / Unresolved Issues
+
+- [ ] **`source/misplaced-features` on `CLAUDE.md`**: Verify whether this warning still fires at the current HEAD. If it does, file a separate bug report rather than suppressing it in `aipm.toml`.
+- [ ] **`cargo build --bin aipm` in CI**: Confirm whether `cargo build --workspace` (the existing step) already produces `target/debug/aipm`, making the additional `cargo build --bin aipm` a no-op. If so, the lint step can simply be `./target/debug/aipm lint . --reporter ci-github` with no extra build invocation.
+- [ ] **`skill/oversized` refactor scope**: Confirm with the team whether the `references/` pattern (as used by `prompt-engineer`) is the preferred approach for large skills before restructuring `perf-anti-patterns`.


### PR DESCRIPTION
## Summary

- Adds a root `aipm.toml` with `**/fixtures/**` ignore pattern, enabling the VSCode extension and silencing 35 fixture diagnostics
- Fixes all 5 live lint violations in `.ai/` plugins and `CLAUDE.md` (1 error + 4 warnings → 0 errors + 0 warnings)
- Fixes a rule bug: `source/misplaced-features` was incorrectly firing on instruction files (CLAUDE.md); now exempted via `FeatureKind::Instructions` check with a covering test
- Wires `aipm lint . --reporter ci-github` into CI as a blocking step after `cargo build --workspace`

Closes #426

## Changes

| File | Change |
|---|---|
| `aipm.toml` | New — root lint config with fixture ignore |
| `.ai/starter-aipm-plugin/.claude-plugin/plugin.json` | Add missing `author` field (`plugin/required-fields` error) |
| `.ai/starter-aipm-plugin/skills/scaffold-plugin/SKILL.md` | Add `name:` frontmatter (`skill/missing-name` warning) |
| `.ai/aipm-atomic-plugin/skills/perf-anti-patterns/SKILL.md` | Extract verbose examples to `references/`; 20,036 → 10,130 chars (`skill/oversized` warning) |
| `.ai/aipm-atomic-plugin/skills/perf-anti-patterns/references/anti-pattern-details.md` | New reference file with full violation/fix examples |
| `CLAUDE.md` | Condense 121 → 92 lines (`instructions/oversized` warning) |
| `crates/libaipm/src/lint/mod.rs` | Exempt `FeatureKind::Instructions` from `source/misplaced-features`; add `lint_instruction_files_not_flagged_as_misplaced` test |
| `.github/workflows/ci.yml` | Add `Lint AI plugins` CI step |

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes (all 76 BDD scenarios + unit tests)
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] `./target/debug/aipm lint .` → 0 errors, 0 warnings
- [ ] `./target/debug/aipm lint fixtures/` → 17 errors, 18 warnings (fixtures still fire correctly)
- [ ] Branch coverage ≥ 89% (currently 89.20%)