### PR TITLE
chore: release v0.20.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1163,7 +1163,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.20.3"
+version = "0.20.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.20.3" }
+libaipm = { path = "crates/libaipm", version = "0.20.4" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.4] - 2026-04-12
+
+### Documentation
+- Add instruction file patterns to VS Code LSP document selector ([#466](https://github.com/TheLarkInn/aipm/pull/466)) (8497d8d)
+
 ## [0.20.3] - 2026-04-12
 
 ## [0.20.2] - 2026-04-12

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.4] - 2026-04-12
+
+### Documentation
+- Add instruction file patterns to VS Code LSP document selector ([#466](https://github.com/TheLarkInn/aipm/pull/466)) (8497d8d)
+
+### Testing
+- Cover global registry list and update branches in CLI (9ebac2b)
+
 ## [0.20.3] - 2026-04-12
 
 ## [0.20.2] - 2026-04-12

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.4] - 2026-04-12
+
+### Documentation
+- Add instruction file patterns to VS Code LSP document selector ([#466](https://github.com/TheLarkInn/aipm/pull/466)) (8497d8d)
+
+### Testing
+- Cover None branch of dest.parent() in emit_skill_files (227c4f5)
+- Cover False branches of .any() closures in MockFs test helpers (5b76bc6)
+
 ## [0.20.3] - 2026-04-12
 
 ## [0.20.2] - 2026-04-12


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.20.3 -> 0.20.4 (✓ API compatible changes)
* `aipm`: 0.20.3 -> 0.20.4
* `aipm-pack`: 0.20.3 -> 0.20.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.20.4] - 2026-04-12

### Documentation
- Add instruction file patterns to VS Code LSP document selector ([#466](https://github.com/TheLarkInn/aipm/pull/466)) (8497d8d)

### Testing
- Cover None branch of dest.parent() in emit_skill_files (227c4f5)
- Cover False branches of .any() closures in MockFs test helpers (5b76bc6)
</blockquote>

## `aipm`

<blockquote>

## [0.20.4] - 2026-04-12

### Documentation
- Add instruction file patterns to VS Code LSP document selector ([#466](https://github.com/TheLarkInn/aipm/pull/466)) (8497d8d)

### Testing
- Cover global registry list and update branches in CLI (9ebac2b)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.20.4] - 2026-04-12

### Documentation
- Add instruction file patterns to VS Code LSP document selector ([#466](https://github.com/TheLarkInn/aipm/pull/466)) (8497d8d)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).