### PR TITLE
chore: release v0.20.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1163,7 +1163,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.20.4"
+version = "0.20.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.20.4" }
+libaipm = { path = "crates/libaipm", version = "0.20.5" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.5] - 2026-04-13
+
+### Bug Fixes
+- Correct aipm-pack module doc comment to list only implemented commands ([#476](https://github.com/TheLarkInn/aipm/pull/476)) (de6ece8)
+
 ## [0.20.4] - 2026-04-12
 
 ### Documentation

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.5] - 2026-04-13
+
+### Testing
+- Cover ws_root != dir branch in cmd_install (6d91f88)
+
 ## [0.20.4] - 2026-04-12
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.5] - 2026-04-13
+
+### Testing
+- Cover Deserialize error path when input is not a string (46d6087)
+- Cover acquire_git clone-failure and git_ref branches (31b0026)
+- Cover emit_extension_files dest.parent() None branch (4d753f0)
+- Cover run_git_clone success path via local repo clone (8202817)
+- Cover acquire_git subdirectory path branches (e399d30)
+- Eliminate dead None-arm branch in register_skips_already_registered (96663da)
+- Cover Error::Manifest branches for invalid manifest and malformed lockfile (1087889)
+
 ## [0.20.4] - 2026-04-12
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.20.4 -> 0.20.5 (✓ API compatible changes)
* `aipm`: 0.20.4 -> 0.20.5
* `aipm-pack`: 0.20.4 -> 0.20.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.20.5] - 2026-04-13

### Testing
- Cover Deserialize error path when input is not a string (46d6087)
- Cover acquire_git clone-failure and git_ref branches (31b0026)
- Cover emit_extension_files dest.parent() None branch (4d753f0)
- Cover run_git_clone success path via local repo clone (8202817)
- Cover acquire_git subdirectory path branches (e399d30)
- Eliminate dead None-arm branch in register_skips_already_registered (96663da)
- Cover Error::Manifest branches for invalid manifest and malformed lockfile (1087889)
</blockquote>

## `aipm`

<blockquote>

## [0.20.5] - 2026-04-13

### Testing
- Cover ws_root != dir branch in cmd_install (6d91f88)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.20.5] - 2026-04-13

### Bug Fixes
- Correct aipm-pack module doc comment to list only implemented commands ([#476](https://github.com/TheLarkInn/aipm/pull/476)) (de6ece8)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).