### PR TITLE
chore: release v0.20.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.20.5"
+version = "0.20.6"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.20.5"
+version = "0.20.6"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1163,7 +1163,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.20.5"
+version = "0.20.6"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.20.5"
+version = "0.20.6"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.20.5" }
+libaipm = { path = "crates/libaipm", version = "0.20.6" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.6] - 2026-04-13
+
 ## [0.20.5] - 2026-04-13
 
 ### Bug Fixes

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.6] - 2026-04-13
+
+### Bug Fixes
+- Add missing `uninstall` to `aipm` module doc comment ([#486](https://github.com/TheLarkInn/aipm/pull/486)) (3ba374f)
+
 ## [0.20.5] - 2026-04-13
 
 ### Testing

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.20.6] - 2026-04-13
+
 ## [0.20.5] - 2026-04-13
 
 ### Testing


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.20.5 -> 0.20.6
* `aipm`: 0.20.5 -> 0.20.6
* `aipm-pack`: 0.20.5 -> 0.20.6

<details><summary><i><b>Changelog</b></i></summary><p>


## `aipm`

<blockquote>

## [0.20.6] - 2026-04-13

### Bug Fixes
- Add missing `uninstall` to `aipm` module doc comment ([#486](https://github.com/TheLarkInn/aipm/pull/486)) (3ba374f)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).