### PR TITLE
chore: release v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.20.6"
+version = "0.21.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.20.6"
+version = "0.21.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1165,7 +1165,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.20.6"
+version = "0.21.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.20.6"
+version = "0.21.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.20.6" }
+libaipm = { path = "crates/libaipm", version = "0.21.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.21.0] - 2026-04-14
+
+### Refactoring
+- DRY Rust architecture — eliminate duplication across workspace ([#494](https://github.com/TheLarkInn/aipm/pull/494)) (1d27d3d)
+
 ## [0.20.6] - 2026-04-13
 
 ## [0.20.5] - 2026-04-13

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.21.0] - 2026-04-14
+
+### Refactoring
+- DRY Rust architecture — eliminate duplication across workspace ([#494](https://github.com/TheLarkInn/aipm/pull/494)) (1d27d3d)
+
 ## [0.20.6] - 2026-04-13
 
 ### Bug Fixes

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.21.0] - 2026-04-14
+
+### Refactoring
+- DRY Rust architecture — eliminate duplication across workspace ([#494](https://github.com/TheLarkInn/aipm/pull/494)) (1d27d3d)
+
 ## [0.20.6] - 2026-04-13
 
 ## [0.20.5] - 2026-04-13


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.20.6 -> 0.21.0 (⚠ API breaking changes)
* `aipm`: 0.20.6 -> 0.21.0
* `aipm-pack`: 0.20.6 -> 0.21.0

### ⚠ `libaipm` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function libaipm::migrate::skill_common::parse_skill_frontmatter, previously in file /tmp/.tmpiiyvgy/libaipm/src/migrate/skill_common.rs:13

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  libaipm::installer::pipeline::update now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/installer/pipeline.rs:859
  libaipm::lockfile::read now takes 2 parameters instead of 1, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/lockfile/mod.rs:28
  libaipm::installer::manifest_editor::add_dependency now takes 4 parameters instead of 3, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/installer/manifest_editor.rs:26
  libaipm::linker::link_state::read now takes 2 parameters instead of 1, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/link_state.rs:37
  libaipm::workspace::find_workspace_root now takes 2 parameters instead of 1, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/workspace/mod.rs:32
  libaipm::linker::link_state::remove now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/link_state.rs:78
  libaipm::linker::gitignore::add_entry now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/gitignore.rs:26
  libaipm::lockfile::write now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/lockfile/mod.rs:53
  libaipm::installer::manifest_editor::remove_dependency now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/installer/manifest_editor.rs:61
  libaipm::linker::link_state::write now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/link_state.rs:49
  libaipm::workspace::discover_members now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/workspace/mod.rs:79
  libaipm::linker::link_state::clear_all now takes 2 parameters instead of 1, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/link_state.rs:89
  libaipm::installer::pipeline::install now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/installer/pipeline.rs:76
  libaipm::linker::gitignore::remove_entry now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/gitignore.rs:55
  libaipm::linker::link_state::add now takes 3 parameters instead of 2, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/link_state.rs:66
  libaipm::linker::link_state::list now takes 2 parameters instead of 1, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/link_state.rs:98
  libaipm::manifest::load now takes 2 parameters instead of 1, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/manifest/mod.rs:46
  libaipm::linker::gitignore::read_entries now takes 2 parameters instead of 1, in /tmp/.tmpskpbCO/aipm/crates/libaipm/src/linker/gitignore.rs:80

--- failure trait_method_default_impl_removed: pub trait default method impl removed ---

Description:
A method's default impl in an unsealed trait has been removed, breaking trait implementations that relied on that default
        ref: https://doc.rust-lang.org/book/ch10-02-traits.html#default-implementations
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_default_impl_removed.ron

Failed in:
  trait method libaipm::lint::rule::Rule::check_file in file /tmp/.tmpskpbCO/aipm/crates/libaipm/src/lint/rule.rs:40
  trait method libaipm::lint::Rule::check_file in file /tmp/.tmpskpbCO/aipm/crates/libaipm/src/lint/rule.rs:40

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_missing.ron

Failed in:
  method check of trait Rule, previously in file /tmp/.tmpiiyvgy/libaipm/src/lint/rule.rs:40
  method check of trait Rule, previously in file /tmp/.tmpiiyvgy/libaipm/src/lint/rule.rs:40
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.21.0] - 2026-04-14

### Refactoring
- DRY Rust architecture — eliminate duplication across workspace ([#494](https://github.com/TheLarkInn/aipm/pull/494)) (1d27d3d)
</blockquote>

## `aipm`

<blockquote>

## [0.21.0] - 2026-04-14

### Refactoring
- DRY Rust architecture — eliminate duplication across workspace ([#494](https://github.com/TheLarkInn/aipm/pull/494)) (1d27d3d)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.21.0] - 2026-04-14

### Refactoring
- DRY Rust architecture — eliminate duplication across workspace ([#494](https://github.com/TheLarkInn/aipm/pull/494)) (1d27d3d)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).