### PR TITLE
fix: preserve real serde errors in settings and marketplace parse paths

### DIFF
--- a/crates/libaipm/src/generate/marketplace.rs
+++ b/crates/libaipm/src/generate/marketplace.rs
@@ -97,8 +97,10 @@ pub fn register_all(fs: &dyn Fs, path: &Path, entries: &[Entry<'_>]) -> std::io:
     }
 
     let content = fs.read_to_string(path)?;
+    // Preserve serde_json::Error as the io::Error source so callers can downcast
+    // and distinguish parse failures from structural issues.
     let mut json: serde_json::Value = serde_json::from_str(&content)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
     let plugins =
         json.get_mut("plugins").and_then(serde_json::Value::as_array_mut).ok_or_else(|| {

--- a/crates/libaipm/src/generate/settings.rs
+++ b/crates/libaipm/src/generate/settings.rs
@@ -17,7 +17,7 @@ use crate::fs::Fs;
 pub fn read_or_create(fs: &dyn Fs, path: &Path) -> std::io::Result<serde_json::Value> {
     match fs.read_to_string(path) {
         Ok(content) => serde_json::from_str(&content)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())),
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             Ok(serde_json::Value::Object(serde_json::Map::new()))
         },
@@ -33,7 +33,7 @@ pub fn read_or_create(fs: &dyn Fs, path: &Path) -> std::io::Result<serde_json::V
 /// Returns `io::Error` if the file cannot be written.
 pub fn write(fs: &dyn Fs, path: &Path, value: &serde_json::Value) -> std::io::Result<()> {
     let mut output = serde_json::to_string_pretty(value)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     output.push('\n');
     fs.write_file(path, output.as_bytes())
 }

--- a/crates/libaipm/src/migrate/registrar.rs
+++ b/crates/libaipm/src/migrate/registrar.rs
@@ -32,8 +32,9 @@ pub fn register_plugins(ai_dir: &Path, entries: &[PluginEntry], fs: &dyn Fs) -> 
             // Attempt to recover a typed serde_json::Error.  Save the display string
             // first so that structural-error messages ("missing 'plugins' array in …")
             // are preserved even after into_inner() consumes the original io::Error.
-            // The None arm is reached for structural issues (String-sourced errors
-            // that don't downcast to serde_json::Error); the Some arm for real parse
+            // The None arm is reached for structural issues where into_inner() returns
+            // Some but the downcast to serde_json::Error fails (the source is a plain
+            // string message, not a typed parse error); the Some arm for real parse
             // failures where register_all stored the serde_json::Error as the source.
             let display = e.to_string();
             e.into_inner().and_then(|s| s.downcast::<serde_json::Error>().ok()).map_or_else(

--- a/crates/libaipm/src/migrate/registrar.rs
+++ b/crates/libaipm/src/migrate/registrar.rs
@@ -24,7 +24,18 @@ pub fn register_plugins(ai_dir: &Path, entries: &[PluginEntry], fs: &dyn Fs) -> 
         })
         .collect();
 
-    crate::generate::marketplace::register_all(fs, &marketplace_path, &gen_entries)?;
+    crate::generate::marketplace::register_all(fs, &marketplace_path, &gen_entries).map_err(
+        |e| {
+            if e.kind() == std::io::ErrorKind::InvalidData {
+                Error::MarketplaceJsonParse {
+                    path: marketplace_path.clone(),
+                    source: serde_json::Error::io(e),
+                }
+            } else {
+                Error::Io(e)
+            }
+        },
+    )?;
 
     Ok(())
 }

--- a/crates/libaipm/src/migrate/registrar.rs
+++ b/crates/libaipm/src/migrate/registrar.rs
@@ -26,26 +26,21 @@ pub fn register_plugins(ai_dir: &Path, entries: &[PluginEntry], fs: &dyn Fs) -> 
 
     crate::generate::marketplace::register_all(fs, &marketplace_path, &gen_entries).map_err(
         |e| {
-            // Only map to MarketplaceJsonParse when the underlying cause is a real
-            // serde_json::Error (JSON parse failure). Structural issues like a missing
-            // or non-array "plugins" key, and I/O errors, map to Error::Io.
-            let is_json_parse = e.kind() == std::io::ErrorKind::InvalidData
-                && e.get_ref().and_then(|s| s.downcast_ref::<serde_json::Error>()).is_some();
-            if !is_json_parse {
+            if e.kind() != std::io::ErrorKind::InvalidData {
                 return Error::Io(e);
             }
-            e.into_inner()
-                .and_then(|s| s.downcast::<serde_json::Error>().ok())
-                .map(|b| *b)
-                .map_or_else(
-                    || {
-                        Error::Io(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            "marketplace JSON parse error",
-                        ))
-                    },
-                    |source| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source },
-                )
+            // For InvalidData: try to extract a real serde_json::Error (JSON parse failure).
+            // Structural issues (missing/non-array "plugins" key) have string sources that
+            // won't downcast and fall through to Error::Io.
+            e.into_inner().and_then(|s| s.downcast::<serde_json::Error>().ok()).map_or_else(
+                || {
+                    Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "marketplace structure error",
+                    ))
+                },
+                |b| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source: *b },
+            )
         },
     )?;
 

--- a/crates/libaipm/src/migrate/registrar.rs
+++ b/crates/libaipm/src/migrate/registrar.rs
@@ -29,15 +29,22 @@ pub fn register_plugins(ai_dir: &Path, entries: &[PluginEntry], fs: &dyn Fs) -> 
             if e.kind() != std::io::ErrorKind::InvalidData {
                 return Error::Io(e);
             }
-            // Attempt to recover a typed serde_json::Error.  Save the display string
-            // first so that structural-error messages ("missing 'plugins' array in …")
-            // are preserved even after into_inner() consumes the original io::Error.
-            // The None arm is reached for structural issues (String-sourced errors
-            // that don't downcast to serde_json::Error); the Some arm for real parse
-            // failures where register_all stored the serde_json::Error as the source.
-            let display = e.to_string();
+            // Non-consuming type check: return Error::Io(e) unchanged for structural
+            // failures (missing/non-array "plugins" key) to preserve the full inner
+            // error value.  Only consume e via into_inner() once the type is confirmed.
+            if !e
+                .get_ref()
+                .is_some_and(<dyn std::error::Error + Send + Sync>::is::<serde_json::Error>)
+            {
+                return Error::Io(e);
+            }
             e.into_inner().and_then(|s| s.downcast::<serde_json::Error>().ok()).map_or_else(
-                || Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, display)),
+                || {
+                    Error::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "marketplace json parse error",
+                    ))
+                },
                 |b| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source: *b },
             )
         },

--- a/crates/libaipm/src/migrate/registrar.rs
+++ b/crates/libaipm/src/migrate/registrar.rs
@@ -29,25 +29,17 @@ pub fn register_plugins(ai_dir: &Path, entries: &[PluginEntry], fs: &dyn Fs) -> 
             if e.kind() != std::io::ErrorKind::InvalidData {
                 return Error::Io(e);
             }
-            // Check whether the inner cause is a real serde_json::Error *before* consuming
-            // `e` with into_inner().  Structural issues (missing/non-array "plugins" key)
-            // carry String sources that won't downcast — preserving `e` as Error::Io keeps
-            // the original diagnostic message (e.g., "missing 'plugins' array in …").
-            if e.get_ref()
-                .is_some_and(<dyn std::error::Error + Send + Sync>::is::<serde_json::Error>)
-            {
-                e.into_inner().and_then(|s| s.downcast::<serde_json::Error>().ok()).map_or_else(
-                    || {
-                        Error::Io(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            "marketplace json parse error",
-                        ))
-                    },
-                    |b| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source: *b },
-                )
-            } else {
-                Error::Io(e)
-            }
+            // Attempt to recover a typed serde_json::Error.  Save the display string
+            // first so that structural-error messages ("missing 'plugins' array in …")
+            // are preserved even after into_inner() consumes the original io::Error.
+            // The None arm is reached for structural issues (String-sourced errors
+            // that don't downcast to serde_json::Error); the Some arm for real parse
+            // failures where register_all stored the serde_json::Error as the source.
+            let display = e.to_string();
+            e.into_inner().and_then(|s| s.downcast::<serde_json::Error>().ok()).map_or_else(
+                || Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, display)),
+                |b| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source: *b },
+            )
         },
     )?;
 

--- a/crates/libaipm/src/migrate/registrar.rs
+++ b/crates/libaipm/src/migrate/registrar.rs
@@ -26,14 +26,26 @@ pub fn register_plugins(ai_dir: &Path, entries: &[PluginEntry], fs: &dyn Fs) -> 
 
     crate::generate::marketplace::register_all(fs, &marketplace_path, &gen_entries).map_err(
         |e| {
-            if e.kind() == std::io::ErrorKind::InvalidData {
-                Error::MarketplaceJsonParse {
-                    path: marketplace_path.clone(),
-                    source: serde_json::Error::io(e),
-                }
-            } else {
-                Error::Io(e)
+            // Only map to MarketplaceJsonParse when the underlying cause is a real
+            // serde_json::Error (JSON parse failure). Structural issues like a missing
+            // or non-array "plugins" key, and I/O errors, map to Error::Io.
+            let is_json_parse = e.kind() == std::io::ErrorKind::InvalidData
+                && e.get_ref().and_then(|s| s.downcast_ref::<serde_json::Error>()).is_some();
+            if !is_json_parse {
+                return Error::Io(e);
             }
+            e.into_inner()
+                .and_then(|s| s.downcast::<serde_json::Error>().ok())
+                .map(|b| *b)
+                .map_or_else(
+                    || {
+                        Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "marketplace JSON parse error",
+                        ))
+                    },
+                    |source| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source },
+                )
         },
     )?;
 

--- a/crates/libaipm/src/migrate/registrar.rs
+++ b/crates/libaipm/src/migrate/registrar.rs
@@ -29,22 +29,15 @@ pub fn register_plugins(ai_dir: &Path, entries: &[PluginEntry], fs: &dyn Fs) -> 
             if e.kind() != std::io::ErrorKind::InvalidData {
                 return Error::Io(e);
             }
-            // Non-consuming type check: return Error::Io(e) unchanged for structural
-            // failures (missing/non-array "plugins" key) to preserve the full inner
-            // error value.  Only consume e via into_inner() once the type is confirmed.
-            if !e
-                .get_ref()
-                .is_some_and(<dyn std::error::Error + Send + Sync>::is::<serde_json::Error>)
-            {
-                return Error::Io(e);
-            }
+            // Attempt to recover a typed serde_json::Error.  Save the display string
+            // first so that structural-error messages ("missing 'plugins' array in …")
+            // are preserved even after into_inner() consumes the original io::Error.
+            // The None arm is reached for structural issues (String-sourced errors
+            // that don't downcast to serde_json::Error); the Some arm for real parse
+            // failures where register_all stored the serde_json::Error as the source.
+            let display = e.to_string();
             e.into_inner().and_then(|s| s.downcast::<serde_json::Error>().ok()).map_or_else(
-                || {
-                    Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "marketplace json parse error",
-                    ))
-                },
+                || Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, display)),
                 |b| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source: *b },
             )
         },

--- a/crates/libaipm/src/migrate/registrar.rs
+++ b/crates/libaipm/src/migrate/registrar.rs
@@ -29,18 +29,25 @@ pub fn register_plugins(ai_dir: &Path, entries: &[PluginEntry], fs: &dyn Fs) -> 
             if e.kind() != std::io::ErrorKind::InvalidData {
                 return Error::Io(e);
             }
-            // For InvalidData: try to extract a real serde_json::Error (JSON parse failure).
-            // Structural issues (missing/non-array "plugins" key) have string sources that
-            // won't downcast and fall through to Error::Io.
-            e.into_inner().and_then(|s| s.downcast::<serde_json::Error>().ok()).map_or_else(
-                || {
-                    Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "marketplace structure error",
-                    ))
-                },
-                |b| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source: *b },
-            )
+            // Check whether the inner cause is a real serde_json::Error *before* consuming
+            // `e` with into_inner().  Structural issues (missing/non-array "plugins" key)
+            // carry String sources that won't downcast — preserving `e` as Error::Io keeps
+            // the original diagnostic message (e.g., "missing 'plugins' array in …").
+            if e.get_ref()
+                .is_some_and(<dyn std::error::Error + Send + Sync>::is::<serde_json::Error>)
+            {
+                e.into_inner().and_then(|s| s.downcast::<serde_json::Error>().ok()).map_or_else(
+                    || {
+                        Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "marketplace json parse error",
+                        ))
+                    },
+                    |b| Error::MarketplaceJsonParse { path: marketplace_path.clone(), source: *b },
+                )
+            } else {
+                Error::Io(e)
+            }
         },
     )?;
 
@@ -292,25 +299,33 @@ mod tests {
     #[test]
     fn register_returns_error_when_plugins_key_missing() {
         // marketplace.json exists and is valid JSON, but has no "plugins" array.
-        // This covers the ok_or_else branch that returns Error::Io with InvalidData.
+        // This is a structural error (not a parse error) so it must be Error::Io,
+        // not Error::MarketplaceJsonParse — the original error message is preserved.
         let fs = MockFs::new();
         fs.set_file(marketplace_path(), r#"{"name":"my-marketplace"}"#.to_string());
 
         let entries = vec![entry("deploy", None)];
         let result = register_plugins(Path::new("/ai"), &entries, &fs);
-        assert!(result.is_err());
+        assert!(
+            matches!(result, Err(Error::Io(_))),
+            "missing 'plugins' key should produce Error::Io, not Error::MarketplaceJsonParse"
+        );
     }
 
     #[test]
     fn register_returns_error_when_plugins_is_not_array() {
         // marketplace.json has "plugins" but it's a string, not an array.
         // This also hits the ok_or_else branch (as_array_mut returns None).
+        // Structural error → must be Error::Io, not Error::MarketplaceJsonParse.
         let fs = MockFs::new();
         fs.set_file(marketplace_path(), r#"{"plugins":"not-an-array"}"#.to_string());
 
         let entries = vec![entry("deploy", None)];
         let result = register_plugins(Path::new("/ai"), &entries, &fs);
-        assert!(result.is_err());
+        assert!(
+            matches!(result, Err(Error::Io(_))),
+            "'plugins' as non-array should produce Error::Io, not Error::MarketplaceJsonParse"
+        );
     }
 
     #[test]
@@ -339,14 +354,18 @@ mod tests {
 
     #[test]
     fn register_returns_error_when_marketplace_json_invalid() {
-        // marketplace.json content is not valid JSON, causing from_str to fail
-        // and covering the Err branch of the `?` on the serde_json::from_str call.
+        // marketplace.json content is not valid JSON, causing from_str to fail.
+        // register_all preserves the serde_json::Error as the io::Error source, so
+        // the mapping in register_plugins must produce Error::MarketplaceJsonParse.
         let fs = MockFs::new();
         fs.set_file(marketplace_path(), "not valid json {{{".to_string());
 
         let entries = vec![entry("deploy", None)];
         let result = register_plugins(Path::new("/ai"), &entries, &fs);
-        assert!(result.is_err());
+        assert!(
+            matches!(result, Err(Error::MarketplaceJsonParse { .. })),
+            "invalid JSON should produce Error::MarketplaceJsonParse, not Error::Io"
+        );
     }
 
     #[test]

--- a/crates/libaipm/src/workspace_init/adaptors/claude.rs
+++ b/crates/libaipm/src/workspace_init/adaptors/claude.rs
@@ -327,10 +327,37 @@ mod tests {
         cleanup(&tmp);
     }
 
-    /// A MockFs that fails all reads with PermissionDenied.
-    struct FailReadFs;
+    /// Configurable Fs stub for testing error paths in `apply()` without touching
+    /// the filesystem.  Using function-pointer fields means all method bodies are
+    /// shared across configurations, so a single struct covers every failure scenario.
+    struct TestFs {
+        read: fn() -> std::io::Result<String>,
+        write: fn() -> std::io::Result<()>,
+    }
 
-    impl crate::fs::Fs for FailReadFs {
+    impl TestFs {
+        /// Simulates a non-NotFound read error (e.g., PermissionDenied).
+        fn read_denied() -> Self {
+            Self {
+                read: || {
+                    Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "read denied"))
+                },
+                write: || Ok(()),
+            }
+        }
+
+        /// Simulates a missing settings file (NotFound read) followed by a write failure.
+        fn write_denied() -> Self {
+            Self {
+                read: || Err(std::io::Error::new(std::io::ErrorKind::NotFound, "not found")),
+                write: || {
+                    Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "write denied"))
+                },
+            }
+        }
+    }
+
+    impl crate::fs::Fs for TestFs {
         fn exists(&self, _: &Path) -> bool {
             false
         }
@@ -340,11 +367,11 @@ mod tests {
         }
 
         fn write_file(&self, _: &Path, _: &[u8]) -> std::io::Result<()> {
-            Ok(())
+            (self.write)()
         }
 
         fn read_to_string(&self, _: &Path) -> std::io::Result<String> {
-            Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied"))
+            (self.read)()
         }
 
         fn read_dir(&self, _: &Path) -> std::io::Result<Vec<crate::fs::DirEntry>> {
@@ -356,11 +383,39 @@ mod tests {
     fn claude_settings_io_error_on_read_propagates_as_io_variant() {
         // Covers the `Err(e)` (non-NotFound) arm of the read_to_string match.
         let adaptor = Adaptor;
-        let result = adaptor.apply(Path::new("/tmp"), false, "test", &FailReadFs);
-        assert!(result.is_err());
+        let result = adaptor.apply(Path::new("/tmp"), false, "test", &TestFs::read_denied());
         assert!(
             result.is_err_and(|e| matches!(e, Error::Io(_))),
             "non-NotFound I/O error should produce Error::Io"
         );
+    }
+
+    #[test]
+    fn claude_settings_write_failure_propagates_as_io_variant() {
+        // Covers the Err branch of `generate::settings::write(…)?` in apply().
+        // The file is absent (NotFound → default empty object), so apply() proceeds
+        // to the write step and hits the injected write failure.
+        let adaptor = Adaptor;
+        let result = adaptor.apply(Path::new("/tmp"), false, "test", &TestFs::write_denied());
+        assert!(
+            result.is_err_and(|e| matches!(e, Error::Io(_))),
+            "write failure should produce Error::Io"
+        );
+    }
+
+    #[test]
+    fn claude_settings_create_dir_failure_propagates_as_io_variant() {
+        // Covers the Err branch of `fs.create_dir_all(…)?` in apply().
+        // Passing a regular file as the workspace root forces create_dir_all to fail
+        // because it cannot create a directory inside a file.
+        let tmp = make_temp_dir("create-dir-fail");
+        std::fs::write(tmp.join("not-a-dir"), b"").ok();
+        let adaptor = Adaptor;
+        let result = adaptor.apply(&tmp.join("not-a-dir"), false, "test", &Real);
+        assert!(
+            result.is_err_and(|e| matches!(e, Error::Io(_))),
+            "create_dir_all failure should produce Error::Io"
+        );
+        cleanup(&tmp);
     }
 }

--- a/crates/libaipm/src/workspace_init/adaptors/claude.rs
+++ b/crates/libaipm/src/workspace_init/adaptors/claude.rs
@@ -28,16 +28,15 @@ impl ToolAdaptor for Adaptor {
 
         fs.create_dir_all(&settings_dir)?;
 
-        let content = match fs.read_to_string(&settings_path) {
-            Ok(s) => s,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        // Read and parse settings.json. Only default to an empty object when the file
+        // does not exist yet; an existing but empty or malformed file is a parse error.
+        let mut settings: serde_json::Value = match fs.read_to_string(&settings_path) {
+            Ok(content) => serde_json::from_str(&content)
+                .map_err(|source| Error::JsonParse { path: settings_path.clone(), source })?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                serde_json::Value::Object(serde_json::Map::new())
+            },
             Err(e) => return Err(Error::Io(e)),
-        };
-        let mut settings: serde_json::Value = if content.is_empty() {
-            serde_json::Value::Object(serde_json::Map::new())
-        } else {
-            serde_json::from_str(&content)
-                .map_err(|source| Error::JsonParse { path: settings_path.clone(), source })?
         };
 
         // For merge path: reject non-object root

--- a/crates/libaipm/src/workspace_init/adaptors/claude.rs
+++ b/crates/libaipm/src/workspace_init/adaptors/claude.rs
@@ -326,4 +326,41 @@ mod tests {
 
         cleanup(&tmp);
     }
+
+    /// A MockFs that fails all reads with PermissionDenied.
+    struct FailReadFs;
+
+    impl crate::fs::Fs for FailReadFs {
+        fn exists(&self, _: &Path) -> bool {
+            false
+        }
+
+        fn create_dir_all(&self, _: &Path) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn write_file(&self, _: &Path, _: &[u8]) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn read_to_string(&self, _: &Path) -> std::io::Result<String> {
+            Err(std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied"))
+        }
+
+        fn read_dir(&self, _: &Path) -> std::io::Result<Vec<crate::fs::DirEntry>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn claude_settings_io_error_on_read_propagates_as_io_variant() {
+        // Covers the `Err(e)` (non-NotFound) arm of the read_to_string match.
+        let adaptor = Adaptor;
+        let result = adaptor.apply(Path::new("/tmp"), false, "test", &FailReadFs);
+        assert!(result.is_err());
+        assert!(
+            result.is_err_and(|e| matches!(e, Error::Io(_))),
+            "non-NotFound I/O error should produce Error::Io"
+        );
+    }
 }

--- a/crates/libaipm/src/workspace_init/adaptors/claude.rs
+++ b/crates/libaipm/src/workspace_init/adaptors/claude.rs
@@ -28,10 +28,17 @@ impl ToolAdaptor for Adaptor {
 
         fs.create_dir_all(&settings_dir)?;
 
-        let mut settings =
-            crate::generate::settings::read_or_create(fs, &settings_path).map_err(|e| {
-                Error::JsonParse { path: settings_path.clone(), source: serde_json::Error::io(e) }
-            })?;
+        let content = match fs.read_to_string(&settings_path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => return Err(Error::Io(e)),
+        };
+        let mut settings: serde_json::Value = if content.is_empty() {
+            serde_json::Value::Object(serde_json::Map::new())
+        } else {
+            serde_json::from_str(&content)
+                .map_err(|source| Error::JsonParse { path: settings_path.clone(), source })?
+        };
 
         // For merge path: reject non-object root
         if !settings.is_object() {


### PR DESCRIPTION
## Summary

Follow-up to #494 addressing Copilot review comments about lossy error wrapping:

- **`generate/settings.rs`**: Attach `serde_json::Error` directly to `io::Error` source (not `e.to_string()`) in both `read_or_create` and `write`, so callers can surface structured diagnostics
- **`workspace_init/adaptors/claude.rs`**: Inline the read + JSON parse instead of calling `read_or_create` + wrapping through `serde_json::Error::io(e)`, preserving the real `serde_json::Error` in `Error::JsonParse`
- **`migrate/registrar.rs`**: Map `io::Error(InvalidData)` from `register_all` to the typed `Error::MarketplaceJsonParse { path, source }` variant instead of falling through to `Error::Io`

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes (76 BDD scenarios, 1 doc-test)
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `cargo fmt --check` clean