### PR TITLE
chore: release v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1165,7 +1165,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.21.0" }
+libaipm = { path = "crates/libaipm", version = "0.21.1" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.21.1] - 2026-04-14
+
+### Documentation
+- Add `instructions/oversized` example to workspace lints in README ([#492](https://github.com/TheLarkInn/aipm/pull/492)) (46c94fb)
+- Update README to reflect 18-rule lint coverage and `instructions/oversized` example ([#487](https://github.com/TheLarkInn/aipm/pull/487)) (3c88808)
+
 ## [0.21.0] - 2026-04-14
 
 ### Refactoring

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.21.1] - 2026-04-14
+
+### Documentation
+- Add `instructions/oversized` example to workspace lints in README ([#492](https://github.com/TheLarkInn/aipm/pull/492)) (46c94fb)
+- Update README to reflect 18-rule lint coverage and `instructions/oversized` example ([#487](https://github.com/TheLarkInn/aipm/pull/487)) (3c88808)
+
 ## [0.21.0] - 2026-04-14
 
 ### Refactoring

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.21.1] - 2026-04-14
+
+### Bug Fixes
+- Preserve real serde errors in settings and marketplace parse paths ([#496](https://github.com/TheLarkInn/aipm/pull/496)) (06bc32f)
+
+### Documentation
+- Add `instructions/oversized` example to workspace lints in README ([#492](https://github.com/TheLarkInn/aipm/pull/492)) (46c94fb)
+- Update README to reflect 18-rule lint coverage and `instructions/oversized` example ([#487](https://github.com/TheLarkInn/aipm/pull/487)) (3c88808)
+
 ## [0.21.0] - 2026-04-14
 
 ### Refactoring


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.21.0 -> 0.21.1 (✓ API compatible changes)
* `aipm`: 0.21.0 -> 0.21.1
* `aipm-pack`: 0.21.0 -> 0.21.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.21.1] - 2026-04-14

### Bug Fixes
- Preserve real serde errors in settings and marketplace parse paths ([#496](https://github.com/TheLarkInn/aipm/pull/496)) (06bc32f)

### Documentation
- Add `instructions/oversized` example to workspace lints in README ([#492](https://github.com/TheLarkInn/aipm/pull/492)) (46c94fb)
- Update README to reflect 18-rule lint coverage and `instructions/oversized` example ([#487](https://github.com/TheLarkInn/aipm/pull/487)) (3c88808)
</blockquote>

## `aipm`

<blockquote>

## [0.21.1] - 2026-04-14

### Documentation
- Add `instructions/oversized` example to workspace lints in README ([#492](https://github.com/TheLarkInn/aipm/pull/492)) (46c94fb)
- Update README to reflect 18-rule lint coverage and `instructions/oversized` example ([#487](https://github.com/TheLarkInn/aipm/pull/487)) (3c88808)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.21.1] - 2026-04-14

### Documentation
- Add `instructions/oversized` example to workspace lints in README ([#492](https://github.com/TheLarkInn/aipm/pull/492)) (46c94fb)
- Update README to reflect 18-rule lint coverage and `instructions/oversized` example ([#487](https://github.com/TheLarkInn/aipm/pull/487)) (3c88808)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).