### PR TITLE
chore: release v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "aipm-pack"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1165,7 +1165,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.21.1" }
+libaipm = { path = "crates/libaipm", version = "0.22.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm-pack/CHANGELOG.md
+++ b/crates/aipm-pack/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.0] - 2026-04-14
+
+### Documentation
+- Add uninstall guide cross-reference to README `aipm uninstall` section ([#500](https://github.com/TheLarkInn/aipm/pull/500)) (0acf52a)
+- Add `generate` and `wizard` modules to libaipm reference table ([#503](https://github.com/TheLarkInn/aipm/pull/503)) (2de0d46)
+- Add `aipm init` workspace initialization guide ([#505](https://github.com/TheLarkInn/aipm/pull/505)) (3d38565)
+
+### Features
+- Implement `aipm make plugin` foundational scaffolding command ([#363](https://github.com/TheLarkInn/aipm/pull/363)) ([#511](https://github.com/TheLarkInn/aipm/pull/511)) (3440a0f)
+
 ## [0.21.1] - 2026-04-14
 
 ### Documentation

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.0] - 2026-04-14
+
+### Documentation
+- Add uninstall guide cross-reference to README `aipm uninstall` section ([#500](https://github.com/TheLarkInn/aipm/pull/500)) (0acf52a)
+- Add `generate` and `wizard` modules to libaipm reference table ([#503](https://github.com/TheLarkInn/aipm/pull/503)) (2de0d46)
+- Add `aipm init` workspace initialization guide ([#505](https://github.com/TheLarkInn/aipm/pull/505)) (3d38565)
+
+### Features
+- Implement `aipm make plugin` foundational scaffolding command ([#363](https://github.com/TheLarkInn/aipm/pull/363)) ([#511](https://github.com/TheLarkInn/aipm/pull/511)) (3440a0f)
+
 ## [0.21.1] - 2026-04-14
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.0] - 2026-04-14
+
+### Documentation
+- Add uninstall guide cross-reference to README `aipm uninstall` section ([#500](https://github.com/TheLarkInn/aipm/pull/500)) (0acf52a)
+- Add `generate` and `wizard` modules to libaipm reference table ([#503](https://github.com/TheLarkInn/aipm/pull/503)) (2de0d46)
+- Add `aipm init` workspace initialization guide ([#505](https://github.com/TheLarkInn/aipm/pull/505)) (3d38565)
+
+### Features
+- Implement `aipm make plugin` foundational scaffolding command ([#363](https://github.com/TheLarkInn/aipm/pull/363)) ([#511](https://github.com/TheLarkInn/aipm/pull/511)) (3440a0f)
+
 ## [0.21.1] - 2026-04-14
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `aipm`: 0.21.1 -> 0.22.0
* `aipm-pack`: 0.21.1 -> 0.22.0

### ⚠ `libaipm` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant PromptAnswer:MultiSelected in /tmp/.tmpf2QtZy/aipm/crates/libaipm/src/wizard.rs:59
  variant PromptKind:MultiSelect in /tmp/.tmpf2QtZy/aipm/crates/libaipm/src/wizard.rs:41
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.22.0] - 2026-04-14

### Documentation
- Add uninstall guide cross-reference to README `aipm uninstall` section ([#500](https://github.com/TheLarkInn/aipm/pull/500)) (0acf52a)
- Add `generate` and `wizard` modules to libaipm reference table ([#503](https://github.com/TheLarkInn/aipm/pull/503)) (2de0d46)
- Add `aipm init` workspace initialization guide ([#505](https://github.com/TheLarkInn/aipm/pull/505)) (3d38565)

### Features
- Implement `aipm make plugin` foundational scaffolding command ([#363](https://github.com/TheLarkInn/aipm/pull/363)) ([#511](https://github.com/TheLarkInn/aipm/pull/511)) (3440a0f)
</blockquote>

## `aipm`

<blockquote>

## [0.22.0] - 2026-04-14

### Documentation
- Add uninstall guide cross-reference to README `aipm uninstall` section ([#500](https://github.com/TheLarkInn/aipm/pull/500)) (0acf52a)
- Add `generate` and `wizard` modules to libaipm reference table ([#503](https://github.com/TheLarkInn/aipm/pull/503)) (2de0d46)
- Add `aipm init` workspace initialization guide ([#505](https://github.com/TheLarkInn/aipm/pull/505)) (3d38565)

### Features
- Implement `aipm make plugin` foundational scaffolding command ([#363](https://github.com/TheLarkInn/aipm/pull/363)) ([#511](https://github.com/TheLarkInn/aipm/pull/511)) (3440a0f)
</blockquote>

## `aipm-pack`

<blockquote>

## [0.22.0] - 2026-04-14

### Documentation
- Add uninstall guide cross-reference to README `aipm uninstall` section ([#500](https://github.com/TheLarkInn/aipm/pull/500)) (0acf52a)
- Add `generate` and `wizard` modules to libaipm reference table ([#503](https://github.com/TheLarkInn/aipm/pull/503)) (2de0d46)
- Add `aipm init` workspace initialization guide ([#505](https://github.com/TheLarkInn/aipm/pull/505)) (3d38565)

### Features
- Implement `aipm make plugin` foundational scaffolding command ([#363](https://github.com/TheLarkInn/aipm/pull/363)) ([#511](https://github.com/TheLarkInn/aipm/pull/511)) (3440a0f)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).