### PR TITLE
chore: release v0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1146,7 +1146,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.22.0" }
+libaipm = { path = "crates/libaipm", version = "0.22.1" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.1] - 2026-04-14
+
+### Documentation
+- Add `aipm make plugin` command documentation ([#513](https://github.com/TheLarkInn/aipm/pull/513)) (7813296)
+- Add `aipm update` guide and lockfile semantics reference ([#508](https://github.com/TheLarkInn/aipm/pull/508)) (2b94a6c)
+- Add `make` to README command table and missing `See also` links ([#516](https://github.com/TheLarkInn/aipm/pull/516)) (8506b00)
+- Fix init paths, registry caveat, aipm-pack note, and roadmap status markers ([#517](https://github.com/TheLarkInn/aipm/pull/517)) (49a36db)
+
+### Features
+- Merge aipm-pack into aipm ([#417](https://github.com/TheLarkInn/aipm/pull/417)) ([#522](https://github.com/TheLarkInn/aipm/pull/522)) (eab803d)
+
 ## [0.22.0] - 2026-04-14
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.1] - 2026-04-14
+
+### Documentation
+- Add `aipm make plugin` command documentation ([#513](https://github.com/TheLarkInn/aipm/pull/513)) (7813296)
+- Add `aipm update` guide and lockfile semantics reference ([#508](https://github.com/TheLarkInn/aipm/pull/508)) (2b94a6c)
+- Add `make` to README command table and missing `See also` links ([#516](https://github.com/TheLarkInn/aipm/pull/516)) (8506b00)
+- Fix init paths, registry caveat, aipm-pack note, and roadmap status markers ([#517](https://github.com/TheLarkInn/aipm/pull/517)) (49a36db)
+
+### Features
+- Merge aipm-pack into aipm ([#417](https://github.com/TheLarkInn/aipm/pull/417)) ([#522](https://github.com/TheLarkInn/aipm/pull/522)) (eab803d)
+
+### Testing
+- Cover update_engine_settings when marketplace_dir has no parent (2351c9f)
+- Cover non-NotFound I/O error propagation in read_or_create (9ac58ca)
+
 ## [0.22.0] - 2026-04-14
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.22.0 -> 0.22.1 (✓ API compatible changes)
* `aipm`: 0.22.0 -> 0.22.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.22.1] - 2026-04-14

### Documentation
- Add `aipm make plugin` command documentation ([#513](https://github.com/TheLarkInn/aipm/pull/513)) (7813296)
- Add `aipm update` guide and lockfile semantics reference ([#508](https://github.com/TheLarkInn/aipm/pull/508)) (2b94a6c)
- Add `make` to README command table and missing `See also` links ([#516](https://github.com/TheLarkInn/aipm/pull/516)) (8506b00)
- Fix init paths, registry caveat, aipm-pack note, and roadmap status markers ([#517](https://github.com/TheLarkInn/aipm/pull/517)) (49a36db)

### Features
- Merge aipm-pack into aipm ([#417](https://github.com/TheLarkInn/aipm/pull/417)) ([#522](https://github.com/TheLarkInn/aipm/pull/522)) (eab803d)

### Testing
- Cover update_engine_settings when marketplace_dir has no parent (2351c9f)
- Cover non-NotFound I/O error propagation in read_or_create (9ac58ca)
</blockquote>

## `aipm`

<blockquote>

## [0.22.1] - 2026-04-14

### Documentation
- Add `aipm make plugin` command documentation ([#513](https://github.com/TheLarkInn/aipm/pull/513)) (7813296)
- Add `aipm update` guide and lockfile semantics reference ([#508](https://github.com/TheLarkInn/aipm/pull/508)) (2b94a6c)
- Add `make` to README command table and missing `See also` links ([#516](https://github.com/TheLarkInn/aipm/pull/516)) (8506b00)
- Fix init paths, registry caveat, aipm-pack note, and roadmap status markers ([#517](https://github.com/TheLarkInn/aipm/pull/517)) (49a36db)

### Features
- Merge aipm-pack into aipm ([#417](https://github.com/TheLarkInn/aipm/pull/417)) ([#522](https://github.com/TheLarkInn/aipm/pull/522)) (eab803d)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).