### PR TITLE
chore: release v0.22.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1146,7 +1146,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.22.1" }
+libaipm = { path = "crates/libaipm", version = "0.22.2" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.2] - 2026-04-15
+
+### Testing
+- Cover MultiSelect format_steps and marketplace-only resolve_defaults (34f896b)
+
 ## [0.22.1] - 2026-04-14
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.2] - 2026-04-15
+
+### Testing
+- Cover empty-slice branch in insert_string_array (3435d55)
+- Cover recursive migration and OtherFileMigrated branches (ae08c43)
+- Cover non-UTF-8 branch in MockFs::write_file (a448676)
+- Cover migrate_recursive non-dry-run path (e4df747)
+- Cover engine=\"both\" branch in make_plugin (e8715d7)
+
 ## [0.22.1] - 2026-04-14
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `aipm`: 0.22.1 -> 0.22.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.22.2] - 2026-04-15

### Testing
- Cover empty-slice branch in insert_string_array (3435d55)
- Cover recursive migration and OtherFileMigrated branches (ae08c43)
- Cover non-UTF-8 branch in MockFs::write_file (a448676)
- Cover migrate_recursive non-dry-run path (e4df747)
- Cover engine=\"both\" branch in make_plugin (e8715d7)
</blockquote>

## `aipm`

<blockquote>

## [0.22.2] - 2026-04-15

### Testing
- Cover MultiSelect format_steps and marketplace-only resolve_defaults (34f896b)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).