### PR TITLE
feat(nuget): automatic nuget.org publishing pipeline

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -1,0 +1,171 @@
+# Publish aipm to nuget.org as a multi-RID native package.
+#
+# Initial trigger is workflow_dispatch ONLY. The release:published trigger is
+# deliberately omitted until Phase 1 dry-run validates end-to-end packing
+# (see specs/2026-04-22-nuget-publishing-pipeline.md section 8.1).
+#
+# To enable automatic publish on stable releases, add this block under `on:`
+# in a follow-up PR after Phase 1:
+#
+#   release:
+#     types: [published]
+#
+# and the job's `if:` guard already accepts that event:
+#   if: ${{ github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'aipm-v') && !github.event.release.prerelease) }}
+#
+# Rollback: nuget.org does not allow package deletion, only unlisting. See
+# RELEASING.md for the broken-version runbook.
+
+name: Publish to NuGet
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., aipm-v0.22.3). Must already have a published GitHub Release with platform archives.'
+        required: true
+        type: string
+
+concurrency:
+  group: release-nuget-${{ inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Pack & push aipm to nuget.org
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch'
+          || (startsWith(github.event.release.tag_name, 'aipm-v')
+              && !github.event.release.prerelease) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required for NuGet Trusted Publishing (OIDC)
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Resolve tag and version
+        id: ver
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$EVENT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::No tag resolved from workflow_dispatch input or release event"
+            exit 1
+          fi
+          case "$TAG" in
+            aipm-v*) ;;
+            *) echo "::error::Tag '$TAG' does not start with 'aipm-v'"; exit 1 ;;
+          esac
+          VERSION="${TAG#aipm-v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag='$TAG' version='$VERSION'"
+
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p archives
+          gh release download "${{ steps.ver.outputs.tag }}" \
+            --pattern 'aipm-*.tar.xz' \
+            --pattern 'aipm-*.zip' \
+            --dir archives \
+            --repo "${{ github.repository }}"
+          ls -la archives
+
+      - name: Unpack into runtimes/<RID>/native layout
+        run: |
+          set -euo pipefail
+          mkdir -p pkg/runtimes
+          declare -A RID_MAP=(
+            [x86_64-unknown-linux-gnu]=linux-x64
+            [x86_64-apple-darwin]=osx-x64
+            [aarch64-apple-darwin]=osx-arm64
+            [x86_64-pc-windows-msvc]=win-x64
+          )
+          for triple in "${!RID_MAP[@]}"; do
+            rid="${RID_MAP[$triple]}"
+            mkdir -p "pkg/runtimes/$rid/native"
+            if [[ "$triple" == *windows* ]]; then
+              archive="archives/aipm-${triple}.zip"
+              test -f "$archive" || { echo "::error::Missing $archive"; exit 1; }
+              unzip -j "$archive" '*/aipm.exe' -d "pkg/runtimes/$rid/native/"
+            else
+              archive="archives/aipm-${triple}.tar.xz"
+              test -f "$archive" || { echo "::error::Missing $archive"; exit 1; }
+              mkdir -p "/tmp/unpack-$rid"
+              tar -xf "$archive" --strip-components=1 -C "/tmp/unpack-$rid"
+              install -m 755 "/tmp/unpack-$rid/aipm" "pkg/runtimes/$rid/native/aipm"
+            fi
+          done
+          cp README.md LICENSE pkg/
+          echo "Staged runtimes/ tree:"
+          find pkg/runtimes -type f -printf '%p (%s bytes)\n'
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'
+
+      - name: Set up NuGet CLI
+        uses: nuget/setup-nuget@v2
+
+      - name: Pack
+        working-directory: pkg
+        run: |
+          set -euo pipefail
+          nuget pack ../packaging/aipm.nuspec \
+            -Version "${{ steps.ver.outputs.version }}" \
+            -Properties "version=${{ steps.ver.outputs.version }};commit=${{ github.sha }}" \
+            -NoDefaultExcludes \
+            -NonInteractive \
+            -OutputDirectory ../out
+
+      - name: Inspect nupkg (sanity check)
+        run: |
+          set -euo pipefail
+          ls -la out/
+          nupkg="out/aipm.${{ steps.ver.outputs.version }}.nupkg"
+          test -f "$nupkg" || { echo "::error::nupkg not produced at $nupkg"; exit 1; }
+          echo "Contents of $nupkg:"
+          unzip -l "$nupkg"
+          runtime_count=$(unzip -l "$nupkg" | grep -cE '^\s+[0-9]+.*runtimes/.*/native/aipm')
+          if [ "$runtime_count" -lt 4 ]; then
+            echo "::error::Expected at least 4 runtimes/<RID>/native/aipm entries, found $runtime_count"
+            exit 1
+          fi
+          echo "Found $runtime_count runtimes/<RID>/native/aipm entries (>=4 required)"
+
+      - name: NuGet OIDC login (Trusted Publishing)
+        id: nuget_login
+        continue-on-error: true
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USERNAME }}
+
+      - name: Push to nuget.org (OIDC)
+        if: steps.nuget_login.outcome == 'success'
+        run: |
+          dotnet nuget push out/*.nupkg \
+            --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      - name: Push to nuget.org (API-key fallback)
+        if: steps.nuget_login.outcome != 'success'
+        run: |
+          echo "::warning::OIDC Trusted Publishing failed; falling back to NUGET_API_KEY secret"
+          dotnet nuget push out/*.nupkg \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -139,12 +139,12 @@ jobs:
           test -f "$nupkg" || { echo "::error::nupkg not produced at $nupkg"; exit 1; }
           echo "Contents of $nupkg:"
           unzip -l "$nupkg"
-          runtime_count=$(unzip -l "$nupkg" | grep -cE '^\s+[0-9]+.*runtimes/.*/native/aipm')
+          runtime_count=$(unzip -l "$nupkg" | grep -cE '^\s+[0-9]+.*runtimes/.*/native/aipm(\.exe)?$')
           if [ "$runtime_count" -lt 4 ]; then
-            echo "::error::Expected at least 4 runtimes/<RID>/native/aipm entries, found $runtime_count"
+            echo "::error::Expected at least 4 runtimes/<RID>/native/aipm[.exe] entries, found $runtime_count"
             exit 1
           fi
-          echo "Found $runtime_count runtimes/<RID>/native/aipm entries (>=4 required)"
+          echo "Found $runtime_count runtimes/<RID>/native/aipm[.exe] entries (>=4 required)"
 
       - name: NuGet OIDC login (Trusted Publishing)
         id: nuget_login

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/TheLarkInn/aipm/actions/workflows/ci.yml/badge.svg)](https://github.com/TheLarkInn/aipm/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/TheLarkInn/aipm/graph/badge.svg)](https://codecov.io/gh/TheLarkInn/aipm)
+[![NuGet](https://img.shields.io/nuget/v/aipm)](https://www.nuget.org/packages/aipm)
 
 A production-grade package manager for AI plugin primitives (skills, agents, MCP servers, hooks). Think npm/Cargo, but purpose-built for the AI plugin ecosystem.
 
@@ -28,6 +29,47 @@ powershell -ExecutionPolicy Bypass -c "irm https://github.com/thelarkinn/aipm/re
 ```
 
 > Installers are provided by [cargo-dist](https://opensource.axo.dev/cargo-dist/). Run `aipm-update` to self-update.
+
+### Azure DevOps Pipeline (NuGet)
+
+For Azure DevOps pipelines that prefer NuGet over `curl | sh`, restore `aipm` from [nuget.org](https://www.nuget.org/packages/aipm) into the global packages folder and prepend the correct per-RID binary directory to `PATH`:
+
+```yaml
+variables:
+  AIPM_VERSION: '0.22.3'
+  NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
+
+steps:
+  - task: UseDotNet@2
+    inputs: { packageType: sdk, version: 8.x }
+
+  - pwsh: |
+      @'
+      <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+        <PropertyGroup>
+          <TargetFramework>net8.0</TargetFramework>
+          <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+        </PropertyGroup>
+        <ItemGroup>
+          <PackageDownload Include="aipm" Version="[$(env:AIPM_VERSION)]" />
+        </ItemGroup>
+      </Project>
+      '@ | Set-Content "$(Agent.TempDirectory)/aipm-fetch/fetch.csproj"
+    displayName: 'Generate aipm download-only project'
+
+  - script: dotnet restore "$(Agent.TempDirectory)/aipm-fetch/fetch.csproj"
+
+  - pwsh: |
+      switch ("$(Agent.OS)") { 'Windows_NT'{$o='win';$x='aipm.exe'} 'Linux'{$o='linux';$x='aipm'} 'Darwin'{$o='osx';$x='aipm'} }
+      $a = if ("$(Agent.OSArchitecture)".ToLower() -eq 'arm64') { 'arm64' } else { 'x64' }
+      $bin = "$env:NUGET_PACKAGES/aipm/$env:AIPM_VERSION/runtimes/$o-$a/native"
+      if ("$(Agent.OS)" -ne 'Windows_NT') { chmod +x "$bin/$x" }
+      Write-Host "##vso[task.prependpath]$bin"
+
+  - script: aipm --version
+```
+
+Public nuget.org needs no service connection or `NuGetAuthenticate@1`. The package ships binaries for `win-x64`, `linux-x64`, `osx-x64`, `osx-arm64`. See [`research/docs/2026-04-22-ado-pipeline-nuget-consume.md`](research/docs/2026-04-22-ado-pipeline-nuget-consume.md) for the full consumer walkthrough.
 
 ### Build from Source
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ steps:
     inputs: { packageType: sdk, version: 8.x }
 
   - pwsh: |
+      New-Item -ItemType Directory -Force -Path "$(Agent.TempDirectory)/aipm-fetch" | Out-Null
       @'
       <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
         <PropertyGroup>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,85 @@
+# Releasing `aipm`
+
+Operational runbook for cutting and rolling back releases.
+
+## Release flow (normal path)
+
+1. Commits land on `main` with conventional-commit messages.
+2. `release-plz.yml` opens a "Release PR" bumping versions in every member crate's `Cargo.toml` and updating the per-crate `CHANGELOG.md` via `git-cliff`.
+3. Merging the Release PR triggers `release-plz.yml` again, which:
+   - Publishes each workspace crate to [crates.io](https://crates.io/crates/aipm)
+   - Creates per-crate git tags (e.g., `aipm-v0.22.4`, `libaipm-v0.22.4`)
+4. The `aipm-v<semver>` tag push triggers `release.yml` (cargo-dist), which:
+   - Cross-compiles 4 targets (win-x64, linux-x64, osx-x64, osx-arm64)
+   - Produces `.tar.xz` / `.zip` archives, `sha256` checksums, `aipm-installer.{sh,ps1}`
+   - Creates a GitHub Release with all artifacts attached
+5. `update-latest-release.yml` fires on `release:published` and republishes the installer scripts to the rolling `latest` GitHub Release.
+6. *(Pending Phase 2 activation)* `release-nuget.yml` fires on `release:published` and publishes `aipm.<version>.nupkg` to [nuget.org](https://www.nuget.org/packages/aipm).
+
+## NuGet publish — current status
+
+`release-nuget.yml` ships with **`workflow_dispatch` only**. The `release:published` trigger will be enabled in a follow-up PR after Phase 1 dry-run validates. To run a dry-run or one-off publish:
+
+1. Ensure [`NUGET_USERNAME`](https://github.com/TheLarkInn/aipm/settings/secrets/actions) (public nuget.org handle) and `NUGET_API_KEY` (fallback) secrets exist.
+2. Go to **Actions → Publish to NuGet → Run workflow**.
+3. Enter `tag` as an existing `aipm-v<semver>` tag whose GitHub Release contains platform archives.
+4. The workflow downloads the 4 archives, repacks into `runtimes/<RID>/native/` inside a `.nupkg`, and pushes to nuget.org via OIDC Trusted Publishing (falling back to `NUGET_API_KEY` if OIDC fails).
+
+## Rollback — broken nuget.org version
+
+**nuget.org does not permit package deletion.** The only operation is **unlist**, which hides the version from search but leaves it resolvable to anyone who pinned to that exact version. This is a property of the NuGet protocol, not a policy choice.
+
+Procedure if a broken version ships:
+
+1. **Unlist immediately.**
+   - Navigate to `https://www.nuget.org/packages/aipm/<broken-version>`.
+   - Sign in as the package owner.
+   - Click **Manage Package** → **Listing**.
+   - Uncheck "List in search results" and save.
+   - The version disappears from the gallery within minutes; no new consumer can find it via `dotnet add package aipm` without an explicit version.
+2. **Cut a patch release via the normal flow.**
+   - Land the fix on `main` (conventional-commit message).
+   - Merge the next release-plz Release PR.
+   - The `aipm-v<semver+1>` tag triggers `release.yml` and `release-nuget.yml`.
+3. **Verify the patch publishes and is listed.**
+   - Confirm the new version appears at `https://www.nuget.org/packages/aipm`.
+   - Confirm `dotnet add package aipm` picks up the patched version by default.
+4. **Communicate.**
+   - Add a CHANGELOG entry explicitly calling out the broken version and its unlisting.
+   - If the issue is security-relevant, see [`SECURITY.md`](SECURITY.md) and file a GitHub Security Advisory.
+
+## Rollback — broken GitHub Release
+
+Unlike nuget.org, GitHub Releases can be deleted or edited. To remove a broken release:
+
+```bash
+gh release delete aipm-v<broken-version> --yes
+git push origin :refs/tags/aipm-v<broken-version>
+```
+
+Note: crates.io also does not permit deletion — `cargo yank` is the equivalent of nuget.org's unlist. Always run `cargo yank --version <broken>` for the affected crate in addition to the steps above.
+
+## Rollback — broken crates.io publish
+
+```bash
+cargo yank --version <broken> aipm
+cargo yank --version <broken> libaipm   # also yank the library crate if published in lockstep
+```
+
+Yanked versions remain downloadable for anyone who has them in a lockfile but cannot be picked up by new resolution.
+
+## Version scheme
+
+- Workspace is versioned in **lockstep**: all member crates share the same version, set in [`Cargo.toml:10`](Cargo.toml) `[workspace.package]`.
+- release-plz creates **per-crate tags** (`aipm-v*`, `libaipm-v*`), not a single `v*` tag.
+- The `aipm-v*` tag is the authoritative trigger for binary/NuGet publishing. The `libaipm-v*` tag has no publishing side effect beyond `cargo publish`.
+- Pre-release suffixes (`-alpha.N`, `-beta.N`, `-rc.N`) are honored by SemVer 2.0 but are **not** published to nuget.org (the workflow's `if:` guard skips `prerelease` releases).
+
+## References
+
+- [`specs/2026-04-22-nuget-publishing-pipeline.md`](specs/2026-04-22-nuget-publishing-pipeline.md) — NuGet publishing spec
+- [`specs/2026-03-16-ci-cd-release-automation.md`](specs/2026-03-16-ci-cd-release-automation.md) — original CI/CD spec
+- [`specs/2026-03-19-cargo-dist-installers.md`](specs/2026-03-19-cargo-dist-installers.md) — cargo-dist integration spec
+- [`release-plz.toml`](release-plz.toml) — release-plz config
+- [`dist-workspace.toml`](dist-workspace.toml) — cargo-dist target matrix
+- [`cliff.toml`](cliff.toml) — changelog template

--- a/packaging/aipm.nuspec
+++ b/packaging/aipm.nuspec
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>aipm</id>
+    <version>$version$</version>
+    <authors>Sean Larkin</authors>
+    <description>aipm - AI plugin manager. Manages AI plugins (Claude, Copilot, Cursor, etc.) across .claude / .github / .ai directories. Distributed as a native Rust CLI for Windows, macOS, and Linux. Consume from an Azure DevOps pipeline via dotnet restore + PackageDownload.</description>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/TheLarkInn/aipm</projectUrl>
+    <repository type="git"
+                url="https://github.com/TheLarkInn/aipm.git"
+                branch="main"
+                commit="$commit$" />
+    <readme>docs\README.md</readme>
+    <tags>ai claude copilot plugin-manager cli rust native cross-platform azure-devops</tags>
+    <copyright>Copyright (c) 2026 Sean Larkin</copyright>
+  </metadata>
+  <files>
+    <file src="runtimes\**" target="runtimes" />
+    <file src="README.md" target="docs\" />
+    <file src="LICENSE" target="" />
+  </files>
+</package>

--- a/research/docs/2026-04-22-ado-pipeline-nuget-consume.md
+++ b/research/docs/2026-04-22-ado-pipeline-nuget-consume.md
@@ -1,0 +1,288 @@
+---
+date: 2026-04-22 16:14:50 UTC
+researcher: Sean Larkin
+git_commit: 5616fd4db5d41b77df55686365308cf12701af2a
+branch: main
+repository: aipm
+topic: "Azure DevOps pipeline consumption of a multi-RID native NuGet CLI tool"
+tags: [research, azure-devops, ado, nuget, pipeline, PackageDownload, NuGetAuthenticate, consume, distribution]
+status: complete
+last_updated: 2026-04-22
+last_updated_by: Sean Larkin
+---
+
+# ADO pipeline consumption of a NuGet native CLI tool
+
+## Summary
+
+Consuming a NuGet package containing a pre-built multi-RID native CLI binary from an Azure DevOps YAML pipeline is fully supported and well-documented. The cleanest 2025-era pattern: use `NuGetAuthenticate@1` + `dotnet restore` (or plain `nuget restore`) against a tiny "tool wrapper" csproj that uses `<PackageDownload>` (not `<PackageReference>`), then compute the RID from `Agent.OS` / `Agent.OSArchitecture`, then emit `##vso[task.prependpath]` to add `runtimes/<RID>/native/` to PATH for subsequent steps. No authentication is required for public nuget.org, and the same YAML works across `ubuntu-latest`, `windows-latest`, and `macOS-latest`.
+
+## Detailed Findings
+
+### 1. Restore from nuget.org in ADO
+
+**`NuGetCommand@2` `restore` vs `DotNetCoreCLI@2` `restore`**
+
+Per the [NuGetCommand@2 reference](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-command-v2?view=azure-pipelines):
+
+- `NuGetCommand@2` uses `NuGet.exe` (full .NET Framework on Windows, or mono on Linux/macOS). Docs explicitly warn: *"Starting with Ubuntu 24.04, Microsoft-hosted agents will not ship with mono which is required to run the underlying NuGet client that powers `NuGetCommand@2`. Users of this task on Ubuntu should migrate to the long term supported cross-platform task `NuGetAuthenticate@1` with .NET CLI."*
+- Both `NuGetCommand@2` and restore/push commands of `DotNetCoreCLI@2` are in maintenance mode.
+- `DotNetCoreCLI@2` ([reference](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/dotnet-core-cli-v2?view=azure-pipelines)) uses the `dotnet` SDK's built-in NuGet client — correct choice for SDK-style `PackageReference` csproj.
+
+For aipm (multi-RID native), `DotNetCoreCLI@2` with `command: restore` on a wrapper csproj, or a plain `- script: dotnet restore` after `NuGetAuthenticate@1`, is the cross-platform path.
+
+**Packaging style: `packages.config` vs `PackageReference` vs `<PackageDownload>`**
+
+Per [NuGet PackageDownload docs](https://learn.microsoft.com/en-us/nuget/consume-packages/packagedownload-functionality):
+
+> "PackageDownload is a utility feature for all .NET SDK-style projects, and it works alongside PackageReference. [...] The primary application of PackageDownload is downloading packages that do not follow the traditional NuGet package structure and primarily carry build time dependencies."
+
+This is exactly aipm's use case. Key properties:
+- Only exact versions allowed: `Version="[1.2.3]"` (brackets mandatory).
+- No assets added to project; nothing passed to compiler.
+- Dependencies are **not** resolved (plus for a leaf tool).
+- Packages extracted into NuGet global-packages folder.
+
+Canonical download-only wrapper csproj:
+
+```xml
+<Project Sdk="Microsoft.Build.NoTargets/1.0.80">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageDownload Include="Aipm" Version="[1.0.0]" />
+  </ItemGroup>
+</Project>
+```
+
+`PackageDownload` **cannot** live in `Directory.Packages.props` — it must be in a regular csproj's `<ItemGroup>`. `packages.config` is legacy (non-SDK projects) and does not belong in any new pipeline.
+
+**`GlobalPackageReference`** (from `Directory.Packages.props`) is an alternative, but requires at least one `PackageReference`-style project in the repo. For a pipeline that only needs the CLI, the `NoTargets` + `PackageDownload` wrapper is cleaner.
+
+**Does `NuGetAuthenticate@1` help for public nuget.org?**
+
+No. Per [NuGetAuthenticate@1 remarks](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-authenticate-v1?view=azure-pipelines):
+
+> "This task must run before you use a NuGet tool to restore or push packages to **an authenticated package source** such as Azure Artifacts."
+> "Some package sources such as nuget.org use API keys for authentication when pushing packages, rather than username/password credentials."
+
+nuget.org is **anonymous for read** (restore), so no authentication task or service connection is needed.
+
+### 2. Locating the binary after restore
+
+**Where packages end up.** Per [global-packages docs](https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders):
+
+| OS | Default global-packages location |
+| --- | --- |
+| Windows | `%userprofile%\.nuget\packages` |
+| macOS / Linux | `~/.nuget/packages` |
+
+Override precedence: `NUGET_PACKAGES` env var > `globalPackagesFolder` in `nuget.config` > `RestorePackagesPath` MSBuild property > default.
+
+On Microsoft-hosted agents, defaults resolve to:
+- `ubuntu-latest`: `/home/vsts/.nuget/packages`
+- `macOS-latest`: `/Users/runner/.nuget/packages`
+- `windows-latest`: `C:\Users\VssAdministrator\.nuget\packages`
+
+**Recommendation:** set `NUGET_PACKAGES` to a path under `$(Pipeline.Workspace)`:
+
+```yaml
+variables:
+  NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
+```
+
+After restore, the aipm binary is at:
+```
+$(NUGET_PACKAGES)/aipm/<version>/runtimes/<RID>/native/aipm(.exe)
+```
+
+(NuGet always lowercases the package id and version in this path.)
+
+**Adding to PATH.** Use the `task.prependpath` logging command ([Logging commands docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops)):
+
+> "`##vso[task.prependpath]local file path` — Update the PATH environment variable by prepending to the PATH. The updated environment variable will be reflected in subsequent tasks."
+
+Must be a single line to stdout, UTF-8, absolute path.
+
+### 3. Cross-platform pipeline support
+
+Per [Predefined variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops):
+
+- `Agent.OS`: `Windows_NT`, `Darwin`, `Linux`
+- `Agent.OSArchitecture`: `X86`, `X64`, `ARM` (docs don't explicitly list `ARM64` but ARM64 agents do report `ARM64` in practice)
+
+**RID lookup table**:
+
+| Agent.OS | Agent.OSArchitecture | RID | Binary |
+| --- | --- | --- | --- |
+| `Windows_NT` | `X64` | `win-x64` | `aipm.exe` |
+| `Windows_NT` | `ARM64` | `win-arm64` | `aipm.exe` |
+| `Linux` | `X64` | `linux-x64` | `aipm` |
+| `Linux` | `ARM64` | `linux-arm64` | `aipm` |
+| `Darwin` | `X64` | `osx-x64` | `aipm` |
+| `Darwin` | `ARM64` | `osx-arm64` | `aipm` |
+
+### 4. Alternative: `dotnet tool install`
+
+Per [dotnet tool install docs](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install): .NET tool packages require a **managed** `.dll` entry point with `DotnetToolSettings.xml`. Not suitable for arbitrary native Rust binaries.
+
+.NET 10 preview introduced self-contained / native-AOT .NET tools ([Andrew Lock's article](https://andrewlock.net/exploring-dotnet-10-preview-features-7-packaging-self-contained-and-native-aot-dotnet-tools-for-nuget/), [dotnet/sdk#9503](https://github.com/dotnet/sdk/issues/9503)) — but these are for AOT-compiled .NET CLIs. **Not aipm's path.**
+
+**Why we're not using `dotnet tool install`:**
+1. aipm is a Rust binary, not .NET.
+2. Tool package format assumes a dotnet-host entry point.
+3. Forcing consumers to install .NET SDK is a bigger dependency than necessary.
+
+### 5. Example `azure-pipelines.yml`
+
+```yaml
+# azure-pipelines.yml — consume the public `Aipm` NuGet package as a build-step CLI
+trigger: [main]
+
+strategy:
+  matrix:
+    linux:
+      imageName: 'ubuntu-latest'
+    windows:
+      imageName: 'windows-latest'
+    macos:
+      imageName: 'macOS-latest'
+
+pool:
+  vmImage: $(imageName)
+
+variables:
+  AIPM_VERSION: '1.0.0'
+  NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
+
+steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET 8 SDK'
+    inputs:
+      packageType: sdk
+      version: 8.x
+
+  - pwsh: |
+      $proj = @'
+      <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+        <PropertyGroup>
+          <TargetFramework>net8.0</TargetFramework>
+          <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+          <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+        </PropertyGroup>
+        <ItemGroup>
+          <PackageDownload Include="Aipm" Version="[$(env:AIPM_VERSION)]" />
+        </ItemGroup>
+      </Project>
+      '@
+      New-Item -ItemType Directory -Force -Path "$(Agent.TempDirectory)/aipm-fetch" | Out-Null
+      Set-Content -Path "$(Agent.TempDirectory)/aipm-fetch/fetch.csproj" -Value $proj -Encoding UTF8
+
+      $cfg = @'
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <clear />
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+      </configuration>
+      '@
+      Set-Content -Path "$(Agent.TempDirectory)/aipm-fetch/nuget.config" -Value $cfg -Encoding UTF8
+    displayName: 'Generate aipm download-only project'
+
+  - script: dotnet restore "$(Agent.TempDirectory)/aipm-fetch/fetch.csproj"
+    displayName: 'Restore Aipm from nuget.org'
+
+  - pwsh: |
+      $os = "$(Agent.OS)"
+      $arch = "$(Agent.OSArchitecture)".ToLowerInvariant()
+
+      switch ($os) {
+        'Windows_NT' { $ridOs = 'win';   $exe = 'aipm.exe' }
+        'Linux'      { $ridOs = 'linux'; $exe = 'aipm'     }
+        'Darwin'     { $ridOs = 'osx';   $exe = 'aipm'     }
+        default      { throw "Unsupported Agent.OS: $os" }
+      }
+      $ridArch = if ($arch -eq 'arm64') { 'arm64' } else { 'x64' }
+      $rid = "$ridOs-$ridArch"
+
+      $binDir = Join-Path $env:NUGET_PACKAGES "aipm/$env:AIPM_VERSION/runtimes/$rid/native"
+      $binary = Join-Path $binDir $exe
+
+      if (-not (Test-Path $binary)) {
+        throw "aipm binary not found at $binary"
+      }
+
+      if ($os -ne 'Windows_NT') {
+        chmod +x $binary
+      }
+
+      Write-Host "Resolved RID: $rid"
+      Write-Host "Binary: $binary"
+      Write-Host "##vso[task.prependpath]$binDir"
+    displayName: 'Resolve RID and prepend aipm to PATH'
+
+  - script: aipm --version
+    displayName: 'aipm smoke test'
+```
+
+**Notes:**
+- `Microsoft.Build.NoTargets` is a well-known MSBuild SDK on nuget.org, designed for "project that doesn't build anything, just orchestrates NuGet".
+- Version brackets `[1.0.0]` are **mandatory** for `<PackageDownload>`; floating versions not supported.
+- RID resolution is the only platform-aware step.
+- `chmod +x` on non-Windows is defensive.
+
+**Real-world examples:** no public repo found demonstrating this exact pattern end-to-end. Closest references:
+- [microsoft/winget-cli `azure-pipelines.yml`](https://github.com/microsoft/winget-cli/blob/master/azure-pipelines.yml) — uses `NuGetCommand@2 restore` on a native solution.
+- [LanceMcCarthy/DevOpsExamples `azure-pipelines.yml`](https://github.com/LanceMcCarthy/DevOpsExamples/blob/main/azure-pipelines.yml) — `NuGetCommand@2 restore` with custom `nuget.config`.
+
+### 6. Service connections / auth
+
+**Public nuget.org (current target):** No service connection, no `NuGetAuthenticate@1`, no secrets.
+
+**Private Azure Artifacts (future-state):**
+1. **Same organization** — no service connection needed; build identity is used automatically.
+2. **Different organization** — create NuGet service connection, reference it in `NuGetAuthenticate@1`:
+   ```yaml
+   - task: NuGetAuthenticate@1
+     inputs:
+       nuGetServiceConnections: OtherOrgFeedConnection
+   ```
+3. **Workload identity (2025+)** — use `workloadIdentityServiceConnection` for PAT-less cross-org auth.
+
+Caveats: doesn't work from external forks (no secrets); cross-project feeds require grants.
+
+## Additional Resources
+
+- [Restore NuGet packages with Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/packages/nuget-restore?view=azure-devops)
+- [Cache NuGet packages](https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/caching-nuget?view=azure-devops) — use `Cache@2` keyed on `$(NUGET_PACKAGES)` + lockfile hash.
+- [Agent directory structure](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/agents#agent-directory-structure)
+
+## Gaps / Limitations
+
+- **`Agent.OSArchitecture` ARM64 documentation.** Not explicitly listed in docs; fallback: `$env:PROCESSOR_ARCHITECTURE` on Windows or `uname -m` on POSIX.
+- **No public ADO pipeline found** demonstrating exact `PackageDownload`-multi-RID-native-CLI pattern end-to-end. Snippet above synthesized from canonical docs.
+- **`NoTargets` SDK version** should be kept current.
+- **First-run `dotnet restore` warm-up cost** (~20-40s). Cache `$(NUGET_PACKAGES)` with `Cache@2`.
+
+## Sources
+
+- [NuGetCommand@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-command-v2?view=azure-pipelines)
+- [DotNetCoreCLI@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/dotnet-core-cli-v2?view=azure-pipelines)
+- [NuGetAuthenticate@1](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-authenticate-v1?view=azure-pipelines)
+- [Restore NuGet packages with Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/packages/nuget-restore?view=azure-devops)
+- [Publish NuGet packages with Azure Pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/nuget?view=azure-devops)
+- [Logging commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops)
+- [Predefined variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops)
+- [PackageDownload](https://learn.microsoft.com/en-us/nuget/consume-packages/packagedownload-functionality)
+- [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management)
+- [Native files in .NET packages](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages)
+- [Global packages folder](https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders)
+- [RID catalog](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog)
+- [dotnet tool install](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install)
+- [Andrew Lock — Self-contained .NET 10 tools](https://andrewlock.net/exploring-dotnet-10-preview-features-7-packaging-self-contained-and-native-aot-dotnet-tools-for-nuget/)
+- [microsoft/winget-cli azure-pipelines.yml](https://github.com/microsoft/winget-cli/blob/master/azure-pipelines.yml)
+- [LanceMcCarthy/DevOpsExamples](https://github.com/LanceMcCarthy/DevOpsExamples/blob/main/azure-pipelines.yml)

--- a/research/docs/2026-04-22-github-actions-nuget-publish.md
+++ b/research/docs/2026-04-22-github-actions-nuget-publish.md
@@ -1,0 +1,481 @@
+---
+date: 2026-04-22 16:14:50 UTC
+researcher: Sean Larkin
+git_commit: 5616fd4db5d41b77df55686365308cf12701af2a
+branch: main
+repository: aipm
+topic: "End-to-end GitHub Actions pipeline for publishing a Rust CLI to nuget.org on git tag"
+tags: [research, github-actions, nuget, cross-compilation, oidc, trusted-publishing, cargo-zigbuild, release-engineering, rust]
+status: complete
+last_updated: 2026-04-22
+last_updated_by: Sean Larkin
+---
+
+# GitHub Actions -> nuget.org publishing for a Rust CLI
+
+## Summary
+
+The pipeline breaks into five stages:
+
+1. **Matrix-based cross-compilation** on native runners (preferred) or `cargo-zigbuild`/`cross` from a single Linux runner.
+2. **Upload per-target binaries** as artifacts; fan-in to a single packaging job that lays files out under `runtimes/<RID>/native/`.
+3. **Pack** with `dotnet pack` (preferred, .NET 10+ supports `-p:NuspecFile`) or `nuget pack <nuspec>`.
+4. **Publish** with `dotnet nuget push` using **NuGet Trusted Publishing (OIDC)**, GA since **September 22, 2025**. No long-lived API keys required.
+5. **Derive the package version** from `Cargo.toml`/git tag using `SebRollen/toml-action` or `cargo-get`.
+
+The major 2025-2026 development: **Trusted Publishing (OIDC)** removes the NuGet API-key-in-secret model for GitHub Actions workflows. This should be the default choice for new pipelines.
+
+---
+
+## 1. Cross-Compilation Strategy
+
+### Recommended: Native-runner matrix
+
+Run `cargo build --release --target <triple>` per-OS using GitHub's hosted runners. This is the most robust approach.
+
+| RID | Triple | Runner |
+|---|---|---|
+| `win-x64` | `x86_64-pc-windows-msvc` | `windows-latest` |
+| `win-arm64` | `aarch64-pc-windows-msvc` | `windows-latest` (cross-compile) or `windows-11-arm` |
+| `linux-x64` | `x86_64-unknown-linux-musl` | `ubuntu-latest` |
+| `linux-arm64` | `aarch64-unknown-linux-musl` | `ubuntu-24.04-arm` (native) or `ubuntu-latest` + cross |
+| `osx-x64` | `x86_64-apple-darwin` | `macos-13` (last Intel runner) |
+| `osx-arm64` | `aarch64-apple-darwin` | `macos-latest` (now arm64) or `macos-14` |
+
+Key runner facts (2025-2026):
+- `macos-latest` points to Apple silicon (macos-14/15), so Intel builds now need an explicitly pinned `macos-13`.
+- GitHub ships `ubuntu-24.04-arm` and `windows-11-arm` as free arm64 runners for public repos.
+
+### Alternatives
+
+**`cross` (cross-rs)** — Docker-based; widely used. Best when you have complex native deps. Requires Docker on the runner.
+
+**`cargo-zigbuild`** — uses Zig as a cross-linker, no Docker. Supports only Linux and macOS targets (no Windows). Supports pinning glibc via `aarch64-unknown-linux-gnu.2.17`.
+
+**`cargo-dist` (axodotdev)** — As of v0.31.0 (Feb 2026), supported installers/formats are: shell, PowerShell, Homebrew, npm, and MSI. **cargo-dist does NOT emit a NuGet package natively.**
+
+Related Rust -> NuGet projects:
+- `KodrAus/cargo-nuget` — packages Rust *libraries* (cdylibs) as NuGet nupkgs. Not aimed at CLI tools.
+- `rylev/cargo-nuget` — installs NuGet deps into a Rust project (opposite direction).
+
+**Conclusion:** you must author the NuGet packaging step yourself; there is no off-the-shelf Rust-CLI-to-NuGet tool.
+
+### Static linking for Linux portability
+
+Use `x86_64-unknown-linux-musl` / `aarch64-unknown-linux-musl` rather than `-gnu`. Add to `.cargo/config.toml`:
+
+```toml
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]
+```
+
+Pin OpenSSL vendoring if used: `openssl = { version = "*", features = ["vendored"] }`.
+
+### Matrix YAML sketch
+
+```yaml
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x64
+            target: x86_64-pc-windows-msvc
+            os: windows-latest
+            ext: .exe
+          - rid: win-arm64
+            target: aarch64-pc-windows-msvc
+            os: windows-latest
+            ext: .exe
+          - rid: linux-x64
+            target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - rid: linux-arm64
+            target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+          - rid: osx-x64
+            target: x86_64-apple-darwin
+            os: macos-13
+          - rid: osx-arm64
+            target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Install musl-tools
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get install -y musl-tools
+      - run: cargo build --release --target ${{ matrix.target }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bin-${{ matrix.rid }}
+          path: target/${{ matrix.target }}/release/aipm${{ matrix.ext || '' }}
+          if-no-files-found: error
+          retention-days: 1
+```
+
+---
+
+## 2. Artifact Aggregation
+
+`actions/upload-artifact@v4` and `actions/download-artifact@v4` (v4 is mandatory — v3 was deprecated in 2024). Matrix-spawned artifacts must have unique names.
+
+```yaml
+  package:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: bin-staging
+          pattern: bin-*
+          merge-multiple: false   # keep each RID in its own subfolder
+      - name: Stage runtimes/ layout
+        run: |
+          mkdir -p pkg/runtimes
+          for rid in win-x64 win-arm64 linux-x64 linux-arm64 osx-x64 osx-arm64; do
+            mkdir -p pkg/runtimes/$rid/native
+            cp bin-staging/bin-$rid/* pkg/runtimes/$rid/native/
+            chmod +x pkg/runtimes/$rid/native/* || true
+          done
+```
+
+The `runtimes/<RID>/native/` path is the NuGet convention per ["Native files in .NET packages"](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages). The .NET SDK **flattens** the directory structure under `runtimes/<rid>/native/` when copying to output.
+
+---
+
+## 3. Packing & Signing
+
+### .nuspec (recommended for CLI-with-native-binaries)
+
+Minimal nuspec:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>aipm</id>
+    <version>$version$</version>
+    <authors>Sean Larkin</authors>
+    <description>Cross-platform Rust CLI distributed as a NuGet package.</description>
+    <projectUrl>https://github.com/TheLarkInn/aipm</projectUrl>
+    <license type="expression">MIT</license>
+    <readme>docs\README.md</readme>
+    <icon>images\icon.png</icon>
+    <tags>cli tool rust cross-platform ai</tags>
+    <repository type="git" url="https://github.com/TheLarkInn/aipm.git" commit="$commit$" />
+  </metadata>
+  <files>
+    <file src="runtimes\**" target="runtimes" />
+    <file src="README.md" target="docs\" />
+    <file src="icon.png" target="images\" />
+    <file src="LICENSE" target="" />
+  </files>
+</package>
+```
+
+Note: `readme` requires NuGet 5.10+; `icon` requires NuGet 5.3+. License must be either an SPDX expression or a packaged file.
+
+### dotnet pack vs nuget pack
+
+- `nuget pack my.nuspec -Version 1.2.3 -OutputDirectory ./out` — straight path, no project needed. Install via `nuget/setup-nuget@v2`.
+- `dotnet pack` — prefers SDK-style csproj. As of **.NET 10** (2025), `dotnet pack -p:NuspecFile=my.nuspec -p:NuspecBasePath=.` works without a csproj stub.
+
+Recommendation: `nuget pack` with `setup-nuget@v2` for simplicity.
+
+### Signing
+
+Two distinct things:
+
+1. **Repository signature** — nuget.org **automatically signs every package** on ingest. No opt-in needed.
+2. **Author signature** — requires commercial code-signing certificate. Use `nuget sign my.nupkg -CertificatePath cert.pfx -Timestamper http://timestamp.digicert.com`. Windows-only in practice.
+
+**For open-source Rust CLIs, rely solely on the repository signature.**
+
+---
+
+## 4. Pushing to nuget.org — Trusted Publishing (OIDC)
+
+**Status:** GA since **September 22, 2025** (announced on the .NET blog).
+
+### Why use it
+
+- Zero long-lived secrets in GitHub.
+- Tokens are short-lived (~1 hour) and single-use.
+- Policy is bound to `repo owner + repo name + workflow filename + optional environment`.
+
+### Required permissions
+
+```yaml
+permissions:
+  contents: read
+  id-token: write   # MANDATORY
+```
+
+### Policy configuration (one-time, on nuget.org)
+
+Log into nuget.org -> username dropdown -> Trusted Publishing -> **Add policy**:
+
+- Policy owner: you or your org
+- Repository Owner: e.g. `TheLarkInn`
+- Repository: e.g. `aipm`
+- Workflow File: **filename only** (e.g. `release.yml`)
+- Environment: optional; bind to a specific GitHub Environment if using environment protection rules.
+
+For private repos: policy is "temporarily active for 7 days" until first successful publish fuses it to immutable GitHub repo/owner IDs.
+
+### Workflow step
+
+```yaml
+- name: NuGet login (OIDC -> temp API key)
+  uses: NuGet/login@v1
+  id: nuget_login
+  with:
+    user: ${{ secrets.NUGET_USERNAME }}   # your nuget.org profile name (NOT email)
+
+- name: Push to nuget.org
+  run: |
+    dotnet nuget push out/*.nupkg \
+      --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
+      --source https://api.nuget.org/v3/index.json \
+      --skip-duplicate
+```
+
+### Legacy API-key path (fallback)
+
+- Create API key on nuget.org with glob pattern matching your package ID
+- Store as `secrets.NUGET_API_KEY`
+- Same `dotnet nuget push` command, just `--api-key ${{ secrets.NUGET_API_KEY }}`
+
+### `--skip-duplicate` and idempotency
+
+Treats HTTP 409 Conflict responses as warnings. Makes workflow re-runs safe.
+
+Known bug: `.snupkg` (symbol) packages can cause failures ([NuGet/Home#10475](https://github.com/NuGet/Home/issues/10475)) — avoid pushing symbols alongside main package.
+
+### Package ID reservation
+
+No prior reservation required — just pick a unique ID (<= 128 chars). Prefix reservations (for `MyCompany.*` patterns) are requested via `account@nuget.org` and require >= 4 characters.
+
+---
+
+## 5. Versioning
+
+### Reading version from Cargo.toml
+
+**(a) `SebRollen/toml-action`** — simplest:
+```yaml
+- id: version
+  uses: SebRollen/toml-action@v1.2.0
+  with:
+    file: Cargo.toml
+    field: package.version
+```
+
+**(b) `cargo metadata` + `jq`:**
+```yaml
+- run: |
+    VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+    echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+```
+
+**(c) `cargo-get`:**
+```yaml
+- uses: nicolaiunrein/cargo-get@master
+  id: meta
+```
+
+### Matching git tag `v1.2.3` to version
+
+```yaml
+on:
+  push:
+    tags: ['v*.*.*']
+
+jobs:
+  release:
+    steps:
+      - id: tagver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Verify Cargo.toml matches tag
+        run: |
+          CARGO_VER=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          if [ "$CARGO_VER" != "${{ steps.tagver.outputs.version }}" ]; then
+            echo "::error::Tag ${{ steps.tagver.outputs.version }} does not match Cargo.toml $CARGO_VER"
+            exit 1
+          fi
+```
+
+For this repo specifically: release-plz creates tags like `aipm-v0.22.3` (see `release-plz.toml`) — so the tag filter should be `'aipm-v*.*.*'` or similar, and stripping the prefix needs adjustment.
+
+### SemVer & pre-release conventions
+
+- NuGet honors SemVer 2.0.0 since 4.3.0+.
+- Pre-release suffix: `1.2.3-alpha`, `1.2.3-beta.1`, `1.2.3-rc.1` map 1:1 from Cargo.
+- **Pitfall:** use zero-padded numeric suffixes (`beta01`, `beta02`) for pre-NuGet-4.3.0 consumers. Dotted form (`beta.2`) only works with SemVer 2.0 clients.
+- `version` field is capped at **64 characters** on nuget.org.
+
+### `nuget pack -Version` vs nuspec token
+
+```bash
+nuget pack aipm.nuspec -Version "${VERSION}" -Properties commit="${GITHUB_SHA}" -OutputDirectory out/
+```
+
+The `$version$` and `$commit$` tokens in the nuspec are substituted.
+
+---
+
+## 6. End-to-End Example Workflow
+
+### Real-world references
+
+**No fully public Rust-CLI-to-NuGet workflow found** in standard search surface. Closest adjacent:
+- [KodrAus/cargo-nuget](https://github.com/KodrAus/cargo-nuget) — Rust cdylibs as NuGet (libraries, not CLIs).
+- [axodotdev/cargo-dist](https://github.com/axodotdev/cargo-dist) — no NuGet output as of v0.31.0.
+- Microsoft native-binary packages: `Microsoft.Web.Webview2`, `Microsoft.Data.Sqlite.Core` follow the same `runtimes/<RID>/native/` pattern.
+
+### Complete workflow
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rid: win-x64,     target: x86_64-pc-windows-msvc,     os: windows-latest, ext: .exe }
+          - { rid: win-arm64,   target: aarch64-pc-windows-msvc,    os: windows-latest, ext: .exe }
+          - { rid: linux-x64,   target: x86_64-unknown-linux-musl,  os: ubuntu-latest }
+          - { rid: linux-arm64, target: aarch64-unknown-linux-musl, os: ubuntu-24.04-arm }
+          - { rid: osx-x64,     target: x86_64-apple-darwin,        os: macos-13 }
+          - { rid: osx-arm64,   target: aarch64-apple-darwin,       os: macos-latest }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - if: contains(matrix.target, 'linux-musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - run: cargo build --release --target ${{ matrix.target }} --bin aipm
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bin-${{ matrix.rid }}
+          path: target/${{ matrix.target }}/release/aipm${{ matrix.ext || '' }}
+          if-no-files-found: error
+
+  package-and-publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release          # optional: gate with an environment
+    permissions:
+      contents: read
+      id-token: write             # REQUIRED for NuGet Trusted Publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - uses: nuget/setup-nuget@v2
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: bin-staging
+          pattern: bin-*
+
+      - id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Stage runtimes layout
+        run: |
+          for rid in win-x64 win-arm64 linux-x64 linux-arm64 osx-x64 osx-arm64; do
+            mkdir -p pkg/runtimes/$rid/native
+            cp bin-staging/bin-$rid/* pkg/runtimes/$rid/native/
+            chmod +x pkg/runtimes/$rid/native/* || true
+          done
+          cp README.md LICENSE icon.png pkg/
+
+      - name: Pack
+        working-directory: pkg
+        run: nuget pack ../packaging/aipm.nuspec -Version "${{ steps.version.outputs.value }}" -Properties commit=${{ github.sha }} -OutputDirectory ../out
+
+      - name: NuGet OIDC login
+        id: nuget_login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USERNAME }}
+
+      - name: Push
+        run: |
+          dotnet nuget push out/*.nupkg \
+            --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+```
+
+---
+
+## Gaps / Caveats
+
+1. **No reference Rust -> NuGet workflow exists in the wild.** Test against `*-alpha` versions first.
+2. **NuGet consumers expect a managed assembly.** A nupkg with only `runtimes/<RID>/native/` is unusual — consider wrapping in a `dotnet tool` with a C# shim, or shipping `build/<id>.targets`.
+3. **`cargo-dist` does not emit NuGet output** as of v0.31.0. File a feature request or keep hand-rolled.
+4. **`nuget sign` is Windows-only** in practice.
+5. **Symbol packages can break `--skip-duplicate`** re-runs.
+6. **.NET 8 RID graph change** — use only portable RIDs.
+7. **macOS Intel runner deprecation** — `macos-13` is the last Intel runner; plan for cross-compile via `cargo-zigbuild` or removal of `osx-x64`.
+
+---
+
+## Sources
+
+Cross-compilation:
+- [Cross Compiling Rust Projects in GitHub Actions](https://blog.urth.org/2023/03/05/cross-compiling-rust-projects-in-github-actions/)
+- [Rust Cross-Compilation With GitHub Actions](https://reemus.dev/tldr/rust-cross-compilation-github-actions)
+- [cross-rs/cross](https://github.com/cross-rs/cross)
+- [rust-cross/cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild)
+- [emk/rust-musl-builder](https://github.com/emk/rust-musl-builder)
+
+cargo-dist:
+- [axodotdev/cargo-dist](https://github.com/axodotdev/cargo-dist)
+- [cargo-dist CHANGELOG](https://github.com/axodotdev/cargo-dist/blob/main/CHANGELOG.md)
+
+NuGet native packaging:
+- [Including native libraries in .NET packages](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages)
+- [.nuspec File Reference](https://learn.microsoft.com/en-us/nuget/reference/nuspec)
+- [.NET RID catalog](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog)
+- [KodrAus/cargo-nuget](https://github.com/KodrAus/cargo-nuget)
+
+Trusted Publishing / OIDC:
+- [Trusted Publishing on nuget.org — Microsoft Learn](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
+- [New Trusted Publishing enhances security on NuGet.org — .NET Blog (Sep 22, 2025)](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/)
+- [NuGet/login GitHub Action](https://github.com/NuGet/login)
+- [Publishing NuGet packages from GitHub actions — Andrew Lock](https://andrewlock.net/easily-publishing-nuget-packages-from-github-actions-with-trusted-publishing/)
+- [Switching to NuGet trusted publishing — Damir's Corner](https://www.damirscorner.com/blog/posts/20251003-SwitchingToNuGetTrustedPublishing.html)
+
+Publishing:
+- [dotnet nuget push command](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-push)
+- [NuGet Package ID prefix reservation](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation)
+- [Signed Packages reference](https://learn.microsoft.com/en-us/nuget/reference/signed-packages-reference)
+
+Versioning:
+- [SebRollen/toml-action](https://github.com/SebRollen/toml-action)
+- [cargo pkgid](https://doc.rust-lang.org/cargo/commands/cargo-pkgid.html)
+- [NuGet Package Versioning](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning)
+
+Artifacts:
+- [actions/upload-artifact](https://github.com/actions/upload-artifact)
+- [Get started with v4 of GitHub Actions Artifacts](https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/)

--- a/research/docs/2026-04-22-nuget-native-multi-rid-packaging.md
+++ b/research/docs/2026-04-22-nuget-native-multi-rid-packaging.md
@@ -1,0 +1,404 @@
+---
+date: 2026-04-22 16:14:50 UTC
+researcher: Sean Larkin
+git_commit: 5616fd4db5d41b77df55686365308cf12701af2a
+branch: main
+repository: aipm
+topic: "Packaging a non-.NET native CLI binary (Rust-compiled) as a multi-RID NuGet package for Azure DevOps restore"
+tags: [research, nuget, packaging, distribution, azure-devops, native, rust, multi-rid, runtimes, nuspec]
+status: complete
+last_updated: 2026-04-22
+last_updated_by: Sean Larkin
+---
+
+# Packaging a Rust-compiled CLI as a multi-RID NuGet package
+
+## TL;DR
+
+- The **canonical folder convention** for native bits in a NuGet package is `runtimes/<RID>/native/<binary>`. This is a first-class layout understood by the .NET SDK and the NuGet asset-selection engine (`ManagedCodeConventions.cs`). See Microsoft Learn, "Native files in .NET packages" ([link](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages)).
+- That layout was designed for **P/Invoke scenarios** (managed wrapper DLL + per-RID native library). For a **pure native CLI** (no managed entry point) consumed by `NuGetCommand@2 restore` in Azure Pipelines, the `runtimes/<RID>/native/` folder is still a valid place to store the binaries, but NuGet will not auto-select one binary for you — you need a `build/<id>.props` (or `.targets`) to pick the right RID and surface it as an MSBuild property / add it to `PATH`, OR you treat the package like a classic `tools/` package. Microsoft's docs explicitly state the "best option" for non-P/Invoke native scenarios is to "package your own MSBuild props and targets files" ([link](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages)).
+- The closest real-world precedent to what `aipm` needs is **`Grpc.Tools`**, which ships `protoc.exe` / `protoc` / `grpc_csharp_plugin` per-RID under a `tools/<os>_<arch>/` folder (not `runtimes/`) and hooks them up via `build/_protobuf/Google.Protobuf.Tools.targets` ([link](https://github.com/grpc/grpc/blob/master/src/csharp/BUILD-INTEGRATION.md)). `Esbuild.Native.linux-x64` on nuget.org shows the other common pattern: one RID per published package ID, selected at consumer time by project RID ([link](https://www.nuget.org/packages/Esbuild.Native.linux-x64/)).
+- For a pipeline-only consumer (`NuGetCommand@2 restore`, no .NET SDK required), you do **not** want `packageType=DotnetTool` (that is reserved for `dotnet tool install`, requires a managed entry point, and ties you to the .NET tool runner). Leave the package as the **default `Dependency`** type and provide a `build/<id>.targets` that sets `$(AipmToolPath)` / prepends the right `runtimes/<RID>/native/` directory to `PATH` for downstream tasks. `DotnetTool` + RID-specific tools (introduced in .NET 10) still require a .NET entry point and a `DotnetToolSettings.xml`, so it's the wrong shape for a pure Rust binary ([Andrew Lock, Apr 2025](https://andrewlock.net/exploring-dotnet-10-preview-features-7-packaging-self-contained-and-native-aot-dotnet-tools-for-nuget/); [Microsoft Learn, "Create RID-specific tools"](https://learn.microsoft.com/en-us/dotnet/core/tools/rid-specific-tools)).
+- nuget.org hard limits: **250 MB per .nupkg** ([NuGet FAQ](https://learn.microsoft.com/en-us/nuget/nuget-org/nuget-org-faq)). A stripped `aipm` binary x 7 RIDs is well under this. ID `aipm` does not need prefix reservation to be published — prefix reservation is an anti-squatting / visual-indicator feature, and nuget.org explicitly warns against reserving prefixes shorter than four characters ([ID prefix reservation docs](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation)). Claim the ID by being first to publish.
+- Build the package with **`nuget pack aipm.nuspec`** (classic nuget.exe). `dotnet pack` is SDK-style-project-only; `nuget pack` on a pure `.nuspec` is still the supported path for non-.NET packages. Starting with NuGet 6.5 `nuget pack` will error on PackageReference projects, but it still packs `.nuspec` files fine ([cli-ref-pack](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-pack)).
+
+---
+
+## 1. `.nuspec` schema for native multi-RID packages
+
+### 1.1 Canonical `runtimes/<RID>/native/` layout
+
+From the official doc ([Microsoft Learn, "Native files in .NET packages"](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages)):
+
+> "NuGet will select native assets from the `runtimes/{rid}/native/` directory."
+>
+> "The .NET SDK flattens any directory structure under `runtimes/{rid}/native/` when copying to the output directory."
+
+For a binary that has no managed wrapper, the nupkg layout is simply:
+
+```text
+aipm.0.1.0.nupkg
+ - aipm.nuspec
+ - runtimes/
+    - win-x64/native/aipm.exe
+    - win-arm64/native/aipm.exe
+    - linux-x64/native/aipm
+    - linux-arm64/native/aipm
+    - linux-musl-x64/native/aipm
+    - osx-x64/native/aipm
+    - osx-arm64/native/aipm
+ - build/
+    - aipm.targets        # MSBuild glue so consumers can reference $(AipmToolPath)
+ - README.md
+ - LICENSE.txt
+```
+
+### 1.2 `<files>` section
+
+```xml
+<files>
+  <!-- per-RID native executables -->
+  <file src="dist/win-x64/aipm.exe"        target="runtimes/win-x64/native/" />
+  <file src="dist/win-arm64/aipm.exe"      target="runtimes/win-arm64/native/" />
+  <file src="dist/linux-x64/aipm"          target="runtimes/linux-x64/native/" />
+  <file src="dist/linux-arm64/aipm"        target="runtimes/linux-arm64/native/" />
+  <file src="dist/linux-musl-x64/aipm"     target="runtimes/linux-musl-x64/native/" />
+  <file src="dist/osx-x64/aipm"            target="runtimes/osx-x64/native/" />
+  <file src="dist/osx-arm64/aipm"          target="runtimes/osx-arm64/native/" />
+
+  <!-- MSBuild integration (convention: build/<packageId>.targets) -->
+  <file src="build/aipm.targets"           target="build/" />
+
+  <!-- docs / license -->
+  <file src="README.md"                    target="" />
+  <file src="LICENSE.txt"                  target="" />
+</files>
+```
+
+The directly analogous pattern in the wild is `LibSassHost.Native.win-x64.nuspec`, which uses `<file src="../../lib/win-x64/libsass.dll" target="runtimes/win-x64/native/" />` ([source](https://github.com/Taritsyn/LibSassHost/blob/master/src/LibSassHost.Native.win-x64/LibSassHost.Native.win-x64.nuspec)).
+
+### 1.3 Supported RIDs
+
+All seven portable RIDs are defined in [`PortableRuntimeIdentifierGraph.json`](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/PortableRuntimeIdentifierGraph.json) in `dotnet/runtime`. From the [.NET RID catalog](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog):
+
+| RID             | Notes |
+|-----------------|-------|
+| `win-x64`       | Windows 10+, x64 |
+| `win-arm64`     | Windows 11 on ARM |
+| `linux-x64`     | Most glibc distros (Ubuntu/Debian/Fedora/...) |
+| `linux-arm64`   | ARM64 glibc (Ubuntu on RPi 3+, Azure ARM VMs) |
+| `linux-musl-x64`| Alpine/musl distros (used heavily in Docker base images) |
+| `osx-x64`       | macOS 10.12+ on Intel (note: the doc says "osx" — NOT "macos") |
+| `osx-arm64`     | Apple Silicon macOS |
+
+Per .NET 8+ breaking changes ([rid-graph compatibility note](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/rid-graph)), use only **portable** (non-versioned, non-distro) RIDs. Do NOT use `ubuntu.22.04-x64`, `alpine.3.18-x64`, etc.
+
+### 1.4 `tools/` vs `runtimes/<RID>/native/`
+
+Three real-world patterns:
+
+**A. `tools/<rid>/...` with MSBuild glue — used by Grpc.Tools.** De-facto industry pattern for shipping a native CLI invoked during a build.
+
+**B. `runtimes/<RID>/native/...` with a managed stub assembly — what the official docs describe.** Designed for P/Invoke and the .NET runtime's default probing paths.
+
+**C. One package per RID (plus an optional meta-package).** Used by `Esbuild.Native.<rid>` on nuget.org.
+
+**Recommendation for `aipm`:** Pattern **A** (`tools/` + MSBuild targets) is cleanest for the user's constraints: no .NET SDK at install time, no P/Invoke, single package ID `aipm`. If you want the documented SDK-native layout, keep the binaries at `runtimes/<RID>/native/` and have `build/aipm.targets` resolve them there — functionally equivalent.
+
+### 1.5 Required `<metadata>` fields for nuget.org
+
+From the [.nuspec reference](https://learn.microsoft.com/en-us/nuget/reference/nuspec) and the [ID-prefix-reservation criteria](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation):
+
+**Required (nuget.org rejects the upload without these):**
+- `<id>` — <= 128 chars
+- `<version>` — SemVer, <= 64 chars
+- `<authors>` — comma-separated
+- `<description>` — <= 4000 chars
+
+**Strongly recommended:**
+- `<license type="expression">MIT</license>` — OSI/FSF-approved SPDX ID. `licenseUrl` is **deprecated**.
+- `<projectUrl>` — homepage
+- `<repository type="git" url="..." branch="..." commit="..." />` — links the .nupkg to its source commit; required for the nuget.org "source code" button.
+- `<readme>README.md</readme>` — embedded README (Markdown only).
+- `<icon>images/icon.png</icon>` — embedded 128x128 PNG/JPEG, <= 1 MB.
+- `<tags>` — space-delimited
+- `<releaseNotes>` — <= 35 000 chars
+- `<copyright>`
+- `<packageTypes>` — see section 1.6
+
+### 1.6 `<packageTypes>` — which type for a native CLI
+
+Canonical list ([Microsoft Learn, "Set a NuGet package type"](https://learn.microsoft.com/en-us/nuget/create-packages/set-package-type)):
+
+| Type          | Purpose                                                                 | Fit for `aipm`?                                    |
+|---------------|-------------------------------------------------------------------------|----------------------------------------------------|
+| `Dependency`  | Default. Added to projects via `<PackageReference>`. **Restored by `NuGetCommand@2 restore`.** | **Yes — use this (or omit `<packageTypes>` entirely).** |
+| `DotnetTool`  | For `dotnet tool install -g <id>`. Requires `tools/<tfm>/<rid>/` + `DotnetToolSettings.xml` + managed entry point. | No — requires .NET tool runner + `dotnet` CLI at install time. |
+| `MSBuildSdk`  | Custom project SDK                                                       | No.                                                |
+| `Template`    | `dotnet new` template                                                    | No.                                                |
+| `McpServer`   | MCP server                                                               | No.                                                |
+
+**Conclusion:** omit the `<packageTypes>` element entirely. A missing `<packageTypes>` defaults to `Dependency`, which is exactly what `NuGetCommand@2 restore` expects.
+
+> "Packages not marked with a type, including all packages created with earlier versions of NuGet, default to the `Dependency` type." — [set-package-type docs](https://learn.microsoft.com/en-us/nuget/create-packages/set-package-type)
+
+Do **not** invent a `NativeTool` or `AipmTool` custom type — `nuget.exe` (the engine behind `NuGetCommand@2`) will refuse to install it.
+
+---
+
+## 2. Build / pack step
+
+### 2.1 `nuget pack` vs `dotnet pack`
+
+| Command                            | Needs `.csproj`? | Works with pure `.nuspec`? | Recommended for native-only package |
+|------------------------------------|------------------|----------------------------|-------------------------------------|
+| `nuget pack aipm.nuspec`           | No               | Yes (canonical)            | **Yes**                              |
+| `dotnet pack aipm.csproj`          | Yes              | No (via csproj flow)       | Only if you have a .NET wrapper     |
+| `dotnet pack aipm.nuspec`          | Partially        | Yes, but still uses MSBuild | Works but non-canonical              |
+| `msbuild -t:pack`                  | Yes              | No                         | No                                   |
+
+The [`nuget pack` CLI reference](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-pack) explicitly shows `nuget pack foo.nuspec` as the supported usage for non-project-based packaging.
+
+### 2.2 Do we need a minimal C# wrapper csproj?
+
+**No.** Precedents:
+- `LibSassHost.Native.win-x64` — pure `.nuspec`, built with `nuget pack`.
+- `Esbuild.Native.linux-x64` on nuget.org — native-only, no managed assembly.
+- The [NNanomsg.NETStandard walkthrough](https://rendered-obsolete.github.io/2018/08/15/nupkg-with-native.html) uses `nuget pack foo.nuspec` with nothing else.
+
+### 2.3 Recommended pack command
+
+```bash
+# Working directory contains aipm.nuspec, dist/<rid>/..., build/aipm.targets, README.md, LICENSE.txt
+nuget pack aipm.nuspec \
+  -OutputDirectory ./artifacts \
+  -Version "0.1.0" \
+  -NoDefaultExcludes \
+  -NonInteractive
+```
+
+`-NoDefaultExcludes` is needed because nuget.exe by default excludes dotfiles (`.something`).
+
+### 2.4 Complete example `aipm.nuspec`
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>aipm</id>
+    <version>0.1.0</version>
+    <authors>Sean Larkin</authors>
+    <description>aipm - AI plugin manager. Manages AI plugins (Claude, Copilot, Cursor, etc.) across .claude/.github/.ai directories. Native CLI.</description>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/TheLarkInn/aipm</projectUrl>
+    <repository type="git"
+                url="https://github.com/TheLarkInn/aipm.git"
+                branch="main"
+                commit="5616fd4" />
+    <readme>README.md</readme>
+    <tags>ai claude copilot plugin-manager cli rust native</tags>
+    <copyright>Copyright (c) 2026 Sean Larkin</copyright>
+    <!-- No <packageTypes> element => defaults to Dependency -->
+  </metadata>
+  <files>
+    <file src="dist/win-x64/aipm.exe"        target="runtimes/win-x64/native/" />
+    <file src="dist/win-arm64/aipm.exe"      target="runtimes/win-arm64/native/" />
+    <file src="dist/linux-x64/aipm"          target="runtimes/linux-x64/native/" />
+    <file src="dist/linux-arm64/aipm"        target="runtimes/linux-arm64/native/" />
+    <file src="dist/linux-musl-x64/aipm"     target="runtimes/linux-musl-x64/native/" />
+    <file src="dist/osx-x64/aipm"            target="runtimes/osx-x64/native/" />
+    <file src="dist/osx-arm64/aipm"          target="runtimes/osx-arm64/native/" />
+    <file src="build/aipm.targets"           target="build/" />
+    <file src="README.md"                    target="" />
+    <file src="LICENSE.txt"                  target="" />
+  </files>
+</package>
+```
+
+### 2.5 Example `build/aipm.targets` (the MSBuild glue)
+
+```xml
+<Project>
+  <PropertyGroup>
+    <_AipmPackageDir>$(MSBuildThisFileDirectory)..\</_AipmPackageDir>
+
+    <!-- Host-OS detection (Windows vs Unix) -->
+    <_AipmOs Condition=" '$(OS)' == 'Windows_NT' ">win</_AipmOs>
+    <_AipmOs Condition=" '$([MSBuild]::IsOSPlatform(`Linux`))' == 'true' ">linux</_AipmOs>
+    <_AipmOs Condition=" '$([MSBuild]::IsOSPlatform(`OSX`))' == 'true' ">osx</_AipmOs>
+
+    <!-- Arch detection -->
+    <_AipmArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'   ">x64</_AipmArch>
+    <_AipmArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64' ">arm64</_AipmArch>
+
+    <_AipmRid>$(_AipmOs)-$(_AipmArch)</_AipmRid>
+
+    <_AipmExe Condition=" '$(_AipmOs)' == 'win' ">aipm.exe</_AipmExe>
+    <_AipmExe Condition=" '$(_AipmOs)' != 'win' ">aipm</_AipmExe>
+
+    <AipmToolPath>$(_AipmPackageDir)runtimes\$(_AipmRid)\native\$(_AipmExe)</AipmToolPath>
+  </PropertyGroup>
+
+  <Target Name="_AipmValidate" BeforeTargets="Build">
+    <Error Condition="!Exists('$(AipmToolPath)')"
+           Text="aipm: no binary for RID '$(_AipmRid)'. Supported: win-x64, win-arm64, linux-x64, linux-arm64, linux-musl-x64, osx-x64, osx-arm64." />
+  </Target>
+</Project>
+```
+
+Musl detection from MSBuild is imprecise — if Alpine is required, either ship a separate `aipm-musl` package or detect at script-step time via `ldd --version 2>&1 | grep -q musl`.
+
+---
+
+## 3. How the package is consumed
+
+### 3.1 Where the binary ends up on disk after `NuGetCommand@2 restore`
+
+Per [docs](https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders):
+
+- Windows: `%userprofile%\.nuget\packages\<id>\<version>\`
+- macOS/Linux: `~/.nuget/packages/<id>/<version>/`
+- Azure Pipelines override via `NUGET_PACKAGES` env var or `restoreDirectory` input
+
+### 3.2 Does the consumer pick the RID?
+
+**No**, if the package ships a `build/<id>.targets` doing the detection. For a pipeline consumer, Azure DevOps exposes `$(Agent.OS)` and `$(Agent.OSArchitecture)` — a pipeline YAML can resolve the RID without MSBuild:
+
+```yaml
+- task: NuGetCommand@2
+  inputs:
+    command: 'restore'
+    restoreSolution: 'nuget.config-backed/packages.config'
+    restoreDirectory: '$(Pipeline.Workspace)/nuget'
+
+- bash: |
+    case "$(Agent.OS)-$(Agent.OSArchitecture)" in
+      Linux-X64)    RID=linux-x64 ;;
+      Linux-ARM64)  RID=linux-arm64 ;;
+      Darwin-X64)   RID=osx-x64 ;;
+      Darwin-ARM64) RID=osx-arm64 ;;
+      Windows_NT-X64)   RID=win-x64 ;;
+      Windows_NT-ARM64) RID=win-arm64 ;;
+    esac
+    AIPM="$(Pipeline.Workspace)/nuget/aipm/0.1.0/runtimes/$RID/native/aipm"
+    chmod +x "$AIPM"
+    "$AIPM" --version
+```
+
+### 3.3 `.props`/`.targets` marker files
+
+Per [Microsoft Learn, "MSBuild props and targets in a package"](https://learn.microsoft.com/en-us/nuget/concepts/msbuild-props-and-targets):
+
+The file **must** be `build/<package id>.targets` (i.e. `build/aipm.targets`) to be auto-imported by NuGet.
+
+To prepend the binary to PATH for subsequent pipeline tasks:
+
+```xml
+<Target Name="_AipmPrependPath" BeforeTargets="Build">
+  <ItemGroup>
+    <_AipmDir Include="$(_AipmPackageDir)runtimes\$(_AipmRid)\native" />
+  </ItemGroup>
+  <Exec Command="echo ##vso[task.prependpath]@(_AipmDir)" />
+</Target>
+```
+
+---
+
+## 4. Real-world examples
+
+### 4.1 `Esbuild.Native.<rid>` — one package per RID
+- Page: https://www.nuget.org/packages/Esbuild.Native.linux-x64/
+- Pattern: one package per RID, ~3.9 MB for linux-x64 v0.21.3.
+
+### 4.2 `Grpc.Tools` — best-in-class native pipeline CLI
+- Page: https://www.nuget.org/packages/grpc.tools/
+- Source: https://github.com/grpc/grpc/tree/master/src/csharp/Grpc.Tools
+- Integration guide: https://github.com/grpc/grpc/blob/master/src/csharp/BUILD-INTEGRATION.md
+- Ships per-RID `protoc` and `grpc_csharp_plugin` under `tools/<os>_<arch>/` plus `build/Grpc.Tools.targets`.
+
+### 4.3 `LibSassHost.Native.win-x64` — canonical `runtimes/<RID>/native/`
+- Source: https://github.com/Taritsyn/LibSassHost/blob/master/src/LibSassHost.Native.win-x64/LibSassHost.Native.win-x64.nuspec
+- One package per RID, placed at `runtimes/<RID>/native/` with per-package `build/<id>.props`.
+
+### 4.4 Microsoft.PowerShell.Native
+- Page: https://www.nuget.org/packages/Microsoft.PowerShell.Native/
+- Ships native helpers for PowerShell Core across Windows/Linux/macOS in `runtimes/<RID>/native/`.
+
+### 4.5 Rust-specific precedents
+
+**No widely-adopted Rust-compiled CLI on nuget.org found as of April 2026.** The pattern is well-trodden for native binaries in general (protoc, libsass, esbuild), but `aipm` would be a pioneer for Rust -> NuGet.
+
+---
+
+## 5. nuget.org publishing constraints
+
+### 5.1 Package size
+
+From the [NuGet.org FAQ](https://learn.microsoft.com/en-us/nuget/nuget-org/nuget-org-faq):
+
+> "NuGet.org allows packages up to 250MB, but we recommend keeping packages under 1MB if possible."
+
+`aipm` stripped is ~5 MB per RID. Seven RIDs x 5 MB = ~35 MB per .nupkg — well under the cap.
+
+### 5.2 Package ID reservation
+
+From the [ID prefix reservation docs](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation):
+
+1. Email `account@nuget.org` with your nuget.org owner display name and the prefix you want reserved.
+2. Criteria: prefix properly identifies the owner; prefix isn't too common; reservation prevents ambiguity/harm.
+3. **"Avoid reservations shorter than four characters."**
+
+For `aipm`: the ID is 4 characters — borderline. You do **not need** prefix reservation to publish — just be the first to upload `aipm`.
+
+### 5.3 Required metadata
+
+nuget.org rejects uploads missing: `id`, `version`, `authors`, `description`. Best-practice additions: `readme` (embedded .md), `icon` (embedded .png/.jpg), `repository` with commit SHA, `tags`, `license` as SPDX expression.
+
+### 5.4 Other constraints
+
+- Limits: `id` <= 128 chars; `version` <= 64; `description` <= 4000; `tags` <= 4000; `releaseNotes` <= 35 000.
+- Package deletion is not self-service; only **unlisting** (hides from search; existing restores still work).
+- Publishing command: `nuget push aipm.0.1.0.nupkg -Source https://api.nuget.org/v3/index.json -ApiKey <key>`.
+
+---
+
+## 6. Concrete recommendation for `aipm`
+
+1. **Package type:** omit `<packageTypes>` -> defaults to `Dependency`. `NuGetCommand@2 restore` supports this out of the box.
+2. **Layout:** `runtimes/<RID>/native/aipm[.exe]` for all seven target RIDs + `build/aipm.targets` + `README.md` + `LICENSE.txt` at package root.
+3. **Build tool:** `nuget pack aipm.nuspec -NoDefaultExcludes` — no csproj, no managed wrapper.
+4. **Consumer UX in Azure Pipelines:** restore with `NuGetCommand@2`, resolve the per-RID binary path in a bash/pwsh step using `$(Agent.OS)` + `$(Agent.OSArchitecture)`, or via `$(AipmToolPath)` if consumer uses MSBuild.
+5. **Publishing:** claim `aipm` on nuget.org by publishing first.
+6. **Size budget:** keep each .nupkg under ~50 MB.
+
+---
+
+## Gaps / open questions
+
+- **Musl RID detection is hard from MSBuild.** Either ship separate `aipm.musl` packages or detect at bash step time.
+- **Azure DevOps `NuGetCommand@2` is on maintenance-only status.** Plan for `NuGetAuthenticate@1` + `dotnet restore` as the forward-looking path.
+- **No precedent for a Rust CLI on nuget.org.** First mover risk.
+- **.NET 10 `RidSpecificTool`** is structurally similar but requires a managed entry point — not a fit.
+
+---
+
+## Key source links
+
+- [Native files in .NET packages](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages)
+- [.NET RID catalog](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog)
+- [Set a NuGet package type](https://learn.microsoft.com/en-us/nuget/create-packages/set-package-type)
+- [.nuspec File Reference](https://learn.microsoft.com/en-us/nuget/reference/nuspec)
+- [`nuget pack` CLI reference](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-pack)
+- [MSBuild props and targets in a package](https://learn.microsoft.com/en-us/nuget/concepts/msbuild-props-and-targets)
+- [NuGet.org FAQ](https://learn.microsoft.com/en-us/nuget/nuget-org/nuget-org-faq)
+- [ID prefix reservation](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation)
+- [NuGetCommand@2 task reference](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-command-v2)
+- [Create RID-specific, self-contained, and AOT .NET tools (.NET 10)](https://learn.microsoft.com/en-us/dotnet/core/tools/rid-specific-tools)
+- [Andrew Lock — Packaging self-contained and native AOT .NET tools (.NET 10)](https://andrewlock.net/exploring-dotnet-10-preview-features-7-packaging-self-contained-and-native-aot-dotnet-tools-for-nuget/)
+- [dotnet/runtime — `PortableRuntimeIdentifierGraph.json`](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.NETCore.Platforms/src/PortableRuntimeIdentifierGraph.json)
+- [Esbuild.Native.linux-x64](https://www.nuget.org/packages/Esbuild.Native.linux-x64/)
+- [Grpc.Tools](https://www.nuget.org/packages/grpc.tools/)
+- [grpc/grpc BUILD-INTEGRATION.md](https://github.com/grpc/grpc/blob/master/src/csharp/BUILD-INTEGRATION.md)
+- [Taritsyn/LibSassHost nuspec](https://github.com/Taritsyn/LibSassHost/blob/master/src/LibSassHost.Native.win-x64/LibSassHost.Native.win-x64.nuspec)
+- [Rendered Obsolete — Nupkg Containing Native Libraries](https://rendered-obsolete.github.io/2018/08/15/nupkg-with-native.html)
+- [Kyle Kukshtel — packaging native libs into NuGet](https://kylekukshtel.com/nuget-native-dll-packing)

--- a/research/docs/2026-04-22-nuget-publishing-pipeline.md
+++ b/research/docs/2026-04-22-nuget-publishing-pipeline.md
@@ -1,0 +1,411 @@
+---
+date: 2026-04-22 16:14:50 UTC
+researcher: Sean Larkin
+git_commit: 5616fd4db5d41b77df55686365308cf12701af2a
+branch: main
+repository: aipm
+topic: "Adding nuget.org publishing to the aipm CI/CD pipeline for consumption from Azure DevOps"
+tags: [research, nuget, github-actions, azure-devops, ado, distribution, release-engineering, cargo-dist, release-plz, cross-compilation, multi-rid, oidc, trusted-publishing]
+status: complete
+last_updated: 2026-04-22
+last_updated_by: Sean Larkin
+last_updated_note: "Added follow-up verification of the cargo-nuget crates (KodrAus/cargo-nuget and rylev/cargo-nuget) to confirm neither fits aipm's use case."
+---
+
+# Research — Automatic NuGet publishing for aipm
+
+## Research Question
+
+> I need to add to my automatic ci/cd pipelines the ability to publish aipm to nuget (so that I can install and use it in an ADO pipeline). What will I need to do to setup nuget automatic publishing?
+
+Refined scope: (1) what CI/CD exists now, (2) how to package the Rust-built `aipm` CLI as a multi-RID NuGet tool package, (3) how to publish it automatically from GitHub Actions to nuget.org, and (4) what ADO pipeline consumers need.
+
+## Summary
+
+**The short answer: add one new GitHub Actions workflow (`release-nuget.yml`) that runs after the existing cargo-dist `release.yml`, plus three new files in the repo (`packaging/aipm.nuspec`, `packaging/build/aipm.targets`, and optionally a `packaging/README-nuget.md`).** The existing cargo-dist + release-plz infrastructure already does the hard work of cross-compiling four targets and producing a GitHub Release on tag — the NuGet step downloads those release archives, re-lays them into `runtimes/<RID>/native/`, packs a `.nupkg`, and pushes to nuget.org using **NuGet Trusted Publishing (OIDC)** rather than long-lived API-key secrets.
+
+The important constraints:
+
+- **Current CI/CD is greenfield for NuGet.** No `.nuspec`, no NuGet workflow, no prior decisions — only a single mention of NuGet-as-category-of-GitHub-Packages in `research/docs/2026-03-19-cargo-dist-installer-github-releases.md:217-234`, which dismissed GitHub Packages for CLI binaries.
+- **Current build matrix is four targets** (`dist-workspace.toml:15-20`): `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`. Shipping a seven-RID NuGet would require adding `aarch64-unknown-linux-{gnu,musl}`, `aarch64-pc-windows-msvc`, and `linux-musl-x64` — **or** shipping only the four existing RIDs first and expanding later. The codebase already notes `aarch64-unknown-linux` was "dropped to simplify adoption; can be added later" (`specs/2026-03-16-ci-cd-release-automation.md:87`).
+- **`cargo-dist` v0.31.0 does not emit NuGet output.** The NuGet step must be hand-rolled as a separate job.
+- **Trusted Publishing (OIDC)** went GA on nuget.org **2025-09-22**. This is the modern auth story — one-time policy setup on nuget.org, then zero long-lived secrets in GitHub. Fallback: `NUGET_API_KEY` repo/environment secret.
+- **Package ID `aipm` is 4 chars** — the borderline case nuget.org warns against for prefix reservation. Claim it by publishing first. Prefix reservation is a later concern.
+- **Package type:** omit `<packageTypes>` (defaults to `Dependency`). Do **not** use `DotnetTool` — that would force consumers to have the .NET SDK installed.
+- **Consumer pattern:** ADO pipelines use `dotnet restore` against a tiny `NoTargets` csproj with `<PackageDownload Include="aipm" Version="[x.y.z]" />`, then resolve the per-RID binary from `$(NUGET_PACKAGES)/aipm/<version>/runtimes/<RID>/native/` using `Agent.OS`/`Agent.OSArchitecture`, then `##vso[task.prependpath]` to put it on PATH.
+
+**Integration point into the existing release pipeline:** the new `release-nuget.yml` workflow triggers on `release: types: [published]` with a guard on `startsWith(github.event.release.tag_name, 'aipm-v') && !github.event.release.prerelease` — the same gating pattern already used by `update-latest-release.yml` (`.github/workflows/update-latest-release.yml:20`). It downloads the per-target archives from the GitHub Release created by `release.yml`, unpacks them into a `runtimes/` staging directory, packs, and pushes. Optionally, it can also re-build the binaries itself on a matrix (self-contained approach) — the `download-from-release` approach reuses existing artifacts and is cheaper.
+
+---
+
+## Detailed Findings
+
+### 1. Current CI/CD inventory (evidence the path is greenfield for NuGet)
+
+Six hand-written workflows and five compiled agentic workflows exist:
+
+| Workflow | File | Trigger | Purpose |
+|---|---|---|---|
+| CI | [`.github/workflows/ci.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/ci.yml) | push/PR | `cargo build/test/clippy/fmt` + 89% branch coverage gate |
+| CodeQL | [`.github/workflows/codeql.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/codeql.yml) | push/PR/weekly | Security scanning |
+| Release (cargo-dist) | [`.github/workflows/release.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/release.yml) | tag push | Builds 4-target archives + installers, creates GitHub Release |
+| Release (release-plz) | [`.github/workflows/release-plz.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/release-plz.yml) | push to main | Opens release PRs, publishes crates.io, creates tags |
+| Update Latest | [`.github/workflows/update-latest-release.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/update-latest-release.yml) | release:published | Re-uploads installer scripts to a `latest` GitHub Release |
+| Research Codebase | [`.github/workflows/research-codebase.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/research-codebase.yml) | issue labeled | Research agent |
+
+Plus agentic `.md`/`.lock.yml` pairs: `improve-coverage`, `daily-qa`, `docs-updater`, `update-docs`, `build-timings`.
+
+**Key facts for NuGet integration:**
+
+- The CLI binary name is `aipm` ([`crates/aipm/Cargo.toml:2`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/crates/aipm/Cargo.toml#L2), verified by `clap::Parser` at `crates/aipm/src/main.rs:18`).
+- Workspace version is `0.22.3` (lockstep across all member crates) in [`Cargo.toml:10`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L10).
+- Repository URL is `https://github.com/thelarkinn/aipm` ([`Cargo.toml:13`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L13)), license MIT ([`Cargo.toml:12`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L12)).
+- Build targets (four) in [`dist-workspace.toml:15-20`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/dist-workspace.toml#L15-L20): `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
+- Archive formats: `.tar.xz` on Unix, `.zip` on Windows ([`dist-workspace.toml:40-41`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/dist-workspace.toml#L40-L41)).
+- Release tag pattern: `aipm-v<semver>` (release-plz with per-crate tags; confirmed by [`update-latest-release.yml:20`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/update-latest-release.yml#L20) filter `startsWith(github.event.release.tag_name, 'aipm-v')`).
+- **No existing NuGet artifacts.** `rg -i nuget` returned only a single informational mention in `research/docs/2026-03-19-cargo-dist-installer-github-releases.md:223`.
+- **No `[package.metadata.dist]`, `[package.metadata.binstall]`, `[package.metadata.release]`** sections anywhere.
+- **No `rust-toolchain.toml`** — each workflow selects toolchain explicitly.
+- **No `.cargo/config.toml`, no `Cross.toml`** — cross-compilation is entirely cargo-dist's responsibility today.
+- **Existing secrets inventory**: `GITHUB_TOKEN`, `CODECOV_TOKEN`, `RELEASE_PLZ_TOKEN`, `CARGO_REGISTRY_TOKEN`, plus agentic tokens. No `NUGET_API_KEY` or `NUGET_USERNAME` yet.
+
+### 2. RID mapping between current targets and NuGet runtimes
+
+| Current cargo-dist target | NuGet RID | Status |
+|---|---|---|
+| `x86_64-unknown-linux-gnu` | `linux-x64` | Built today |
+| `x86_64-apple-darwin` | `osx-x64` | Built today |
+| `aarch64-apple-darwin` | `osx-arm64` | Built today |
+| `x86_64-pc-windows-msvc` | `win-x64` | Built today |
+| `aarch64-unknown-linux-gnu` | `linux-arm64` | **Not built** — was deliberately dropped ([`specs/2026-03-16-ci-cd-release-automation.md:87`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/specs/2026-03-16-ci-cd-release-automation.md#L87)) |
+| `x86_64-unknown-linux-musl` | `linux-musl-x64` | **Not built** — needs `cross-rs` workarounds per [cargo-dist issue #1581](https://github.com/axodotdev/cargo-dist/issues/1581); see [`research/docs/2026-03-19-cargo-dist-installer-github-releases.md:208-216`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/research/docs/2026-03-19-cargo-dist-installer-github-releases.md#L208-L216) |
+| `aarch64-pc-windows-msvc` | `win-arm64` | **Not built** |
+
+**Decision point:** ship the NuGet with only the four existing RIDs first (win-x64, linux-x64, osx-x64, osx-arm64), document the gap in the package description, and expand when the underlying cargo-dist matrix expands. This aligns with the prior spec decision to "drop to simplify adoption; can be added later".
+
+### 3. Package layout & .nuspec
+
+Omit `<packageTypes>` entirely so the package defaults to `Dependency` type — this is what `NuGetCommand@2 restore` and `dotnet restore` consume, and it does **not** require the .NET SDK at install time (unlike `DotnetTool`). See the dedicated packaging research doc: [`2026-04-22-nuget-native-multi-rid-packaging.md`](./2026-04-22-nuget-native-multi-rid-packaging.md).
+
+**Proposed new file: `packaging/aipm.nuspec`**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>aipm</id>
+    <version>$version$</version>
+    <authors>Sean Larkin</authors>
+    <description>AI plugin manager. Manages AI plugins (Claude, Copilot, Cursor, etc.) across .claude/.github/.ai directories.</description>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/TheLarkInn/aipm</projectUrl>
+    <repository type="git"
+                url="https://github.com/TheLarkInn/aipm.git"
+                branch="main"
+                commit="$commit$" />
+    <readme>docs\README.md</readme>
+    <icon>images\icon.png</icon>
+    <tags>ai claude copilot plugin-manager cli rust native cross-platform</tags>
+    <copyright>Copyright (c) 2026 Sean Larkin</copyright>
+    <!-- No <packageTypes> => defaults to Dependency -->
+  </metadata>
+  <files>
+    <file src="runtimes\**" target="runtimes" />
+    <file src="build\aipm.targets" target="build\" />
+    <file src="README.md" target="docs\" />
+    <file src="icon.png" target="images\" />
+    <file src="LICENSE" target="" />
+  </files>
+</package>
+```
+
+**Proposed new file: `packaging/build/aipm.targets`** (MSBuild integration for consumers who want `$(AipmToolPath)`; see the packaging research doc section 2.5 for the full content).
+
+### 4. New workflow: `release-nuget.yml`
+
+Triggers off the existing cargo-dist GitHub Release (rather than re-running the whole matrix) to avoid duplicate cross-compilation. This mirrors how [`update-latest-release.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/update-latest-release.yml) already hooks the `release:published` event.
+
+```yaml
+name: Publish to NuGet
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    if: startsWith(github.event.release.tag_name, 'aipm-v') && !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    environment: release   # optional: gate behind environment approval
+    permissions:
+      contents: read
+      id-token: write      # REQUIRED for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: ver
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#aipm-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p archives
+          gh release download "${{ github.event.release.tag_name }}" \
+            --pattern 'aipm-*-*.tar.xz' \
+            --pattern 'aipm-*-*.zip' \
+            --dir archives
+
+      - name: Unpack archives into runtimes layout
+        run: |
+          mkdir -p pkg/runtimes pkg/build
+          declare -A RID_MAP=(
+            [x86_64-unknown-linux-gnu]=linux-x64
+            [x86_64-apple-darwin]=osx-x64
+            [aarch64-apple-darwin]=osx-arm64
+            [x86_64-pc-windows-msvc]=win-x64
+          )
+          for triple in "${!RID_MAP[@]}"; do
+            rid="${RID_MAP[$triple]}"
+            mkdir -p "pkg/runtimes/$rid/native"
+            if [[ "$triple" == *windows* ]]; then
+              unzip -j "archives/aipm-${triple}.zip" 'aipm*/aipm.exe' -d "pkg/runtimes/$rid/native/"
+            else
+              tar -xf "archives/aipm-${triple}.tar.xz" --strip-components=1 -C /tmp
+              install -m 755 /tmp/aipm "pkg/runtimes/$rid/native/aipm"
+            fi
+          done
+
+      - name: Stage metadata files
+        run: |
+          cp packaging/build/aipm.targets pkg/build/
+          cp README.md LICENSE pkg/
+          cp packaging/icon.png pkg/ 2>/dev/null || true
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'
+      - uses: nuget/setup-nuget@v2
+
+      - name: Pack
+        working-directory: pkg
+        run: |
+          nuget pack ../packaging/aipm.nuspec \
+            -Version "${{ steps.ver.outputs.version }}" \
+            -Properties "version=${{ steps.ver.outputs.version }};commit=${{ github.sha }}" \
+            -NoDefaultExcludes \
+            -OutputDirectory ../out
+
+      - name: NuGet OIDC login
+        id: nuget_login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USERNAME }}   # public profile name, not email
+
+      - name: Push
+        run: |
+          dotnet nuget push out/*.nupkg \
+            --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+```
+
+Full derivation of this workflow (including the self-contained alternative that re-builds from source, Trusted Publishing policy setup, and fallback API-key path) is in [`2026-04-22-github-actions-nuget-publish.md`](./2026-04-22-github-actions-nuget-publish.md).
+
+### 5. Trusted Publishing setup (one-time, manual)
+
+Before the workflow can push for the first time:
+
+1. Log in to nuget.org -> username dropdown -> **Trusted Publishing** -> **Add policy**.
+2. Fields:
+   - Repository Owner: `TheLarkInn`
+   - Repository: `aipm`
+   - Workflow File: `release-nuget.yml` (filename only — not the full path)
+   - Environment: `release` (optional; matches the workflow's `environment:` key)
+3. Add a repo secret `NUGET_USERNAME` with the nuget.org public profile handle (not the email).
+
+No `NUGET_API_KEY` is needed with Trusted Publishing — the [`NuGet/login@v1` action](https://github.com/NuGet/login) uses GitHub's OIDC token to request a short-lived API key at each workflow run.
+
+If Trusted Publishing is not yet available for the account, fall back to:
+- Create an API key on nuget.org scoped to the glob `aipm*`.
+- Store as `NUGET_API_KEY` repo/environment secret.
+- Replace the `NuGet/login@v1` + `--api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}"` lines with `--api-key "${{ secrets.NUGET_API_KEY }}"`.
+
+### 6. ADO pipeline consumer example
+
+The consumer-side research doc ([`2026-04-22-ado-pipeline-nuget-consume.md`](./2026-04-22-ado-pipeline-nuget-consume.md)) has the full YAML. Short form:
+
+```yaml
+# azure-pipelines.yml snippet
+variables:
+  AIPM_VERSION: '0.22.3'
+  NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
+
+steps:
+  - task: UseDotNet@2
+    inputs: { packageType: sdk, version: 8.x }
+
+  # Create a throwaway NoTargets csproj with <PackageDownload Include="aipm" Version="[x.y.z]" />
+  # then: dotnet restore
+
+  - pwsh: |
+      $os = "$(Agent.OS)"; $arch = "$(Agent.OSArchitecture)".ToLowerInvariant()
+      switch ($os) { 'Windows_NT' { $r='win'; $exe='aipm.exe' } 'Linux' { $r='linux'; $exe='aipm' } 'Darwin' { $r='osx'; $exe='aipm' } }
+      $a = if ($arch -eq 'arm64') { 'arm64' } else { 'x64' }
+      $rid = "$r-$a"
+      $bin = "$env:NUGET_PACKAGES/aipm/$env:AIPM_VERSION/runtimes/$rid/native"
+      if ($os -ne 'Windows_NT') { chmod +x "$bin/$exe" }
+      Write-Host "##vso[task.prependpath]$bin"
+    displayName: 'Prepend aipm to PATH'
+
+  - script: aipm --version
+```
+
+`NuGetAuthenticate@1` is **not** needed for public nuget.org — it only applies to authenticated feeds like Azure Artifacts.
+
+### 7. Integration with existing release-plz / cargo-dist flow
+
+The release pipeline today is:
+
+1. Commits to `main` -> `release-plz.yml` opens a "Release PR" bumping versions & updating CHANGELOGs.
+2. PR merged -> `release-plz.yml` creates git tags (e.g., `aipm-v0.22.4`) and publishes each crate to crates.io.
+3. Tag push (`**[0-9]+.[0-9]+.[0-9]+*`) -> `release.yml` (cargo-dist) builds the 4-target matrix and creates a GitHub Release with archives + installers.
+4. Release published -> `update-latest-release.yml` updates the `latest` GitHub Release's installer scripts.
+
+**Proposed insertion:** step 5 -> `release-nuget.yml` listens to the same `release:published` event, downloads the per-target archives, packs the .nupkg, publishes to nuget.org.
+
+This keeps **zero changes** to `release.yml`, `release-plz.yml`, and `dist-workspace.toml` in v1. If later you want self-contained builds (e.g., adding ARM64 Linux or musl without waiting for cargo-dist to support them), a second workflow variant can run its own matrix build independent of cargo-dist.
+
+### 8. Observed limitations and risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| cargo-dist 0.31.0 ships only 4 RIDs | Missing `linux-arm64`, `win-arm64`, `linux-musl-x64` in the NuGet | Ship 4 RIDs first; add more when dist matrix expands or run a parallel build job |
+| `cargo-dist` will never emit NuGet natively (as of 2026-04) | Hand-rolled workflow forever | Low — the workflow is ~80 lines of YAML |
+| Trusted Publishing still rolling out | Account may not have access yet | Fall back to `NUGET_API_KEY` secret; switch later |
+| Package ID `aipm` is 4 chars | Can't reserve prefix, someone could squat satellite IDs | Claim by publishing first; reserve prefix once you ship `aipm.*` satellites |
+| No Rust-CLI precedent on nuget.org | First-mover uncertainty | Test with `*-alpha` version before cutting `1.0.0` |
+| ADO `NuGetCommand@2` is in maintenance mode | Long-term consumer task may break | Document `NuGetAuthenticate@1` + `dotnet restore` as the consumer pattern |
+| nuget.org 250 MB limit | 7 RIDs x ~5 MB = well under cap | Monitor; split per-RID if aipm binaries bloat |
+| `nuget sign` is Windows-only | Can't do author-signing from Linux runner | Rely on nuget.org repository signature (automatic on ingest) |
+| Symbol packages can break `--skip-duplicate` | Workflow re-runs fail | Don't push `.snupkg` for native packages |
+
+## Code References
+
+- [`Cargo.toml:10`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L10) — workspace version (lockstep `0.22.3`)
+- [`Cargo.toml:13`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L13) — repository URL used in `.nuspec` `<projectUrl>`
+- [`Cargo.toml:188-193`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L188-L193) — `[profile.dist]` used by cargo-dist
+- [`crates/aipm/Cargo.toml:2`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/crates/aipm/Cargo.toml#L2) — binary name `aipm`
+- [`crates/aipm/src/main.rs:18`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/crates/aipm/src/main.rs#L18) — `clap::Parser` with `name = "aipm"`
+- [`dist-workspace.toml:15-20`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/dist-workspace.toml#L15-L20) — current 4-target matrix
+- [`dist-workspace.toml:40-41`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/dist-workspace.toml#L40-L41) — archive format selection
+- [`.github/workflows/release.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/release.yml) — cargo-dist release orchestration
+- [`.github/workflows/release-plz.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/release-plz.yml) — crates.io + tag creation
+- [`.github/workflows/update-latest-release.yml:20`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/update-latest-release.yml#L20) — the `startsWith(tag_name, 'aipm-v')` guard pattern the new workflow should copy
+- [`release-plz.toml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/release-plz.toml) — release-plz per-crate tag strategy
+
+## Architecture Documentation
+
+### Current release flow (pre-NuGet)
+
+```text
+commit to main
+    |
+    v
+release-plz.yml (Release PR) ---> opens PR with version bump + changelog
+    |
+    v
+PR merged
+    |
+    v
+release-plz.yml (Publish & Tag) ---> cargo publish + git tag aipm-v<semver>
+    |
+    v
+release.yml (cargo-dist) ---> builds 4-target matrix + GitHub Release
+    |
+    v
+update-latest-release.yml ---> updates "latest" GitHub Release with installer scripts
+```
+
+### Target release flow (post-NuGet)
+
+```text
+... (same as above, ending at release.yml creating a GitHub Release)
+    |
+    v
+release-nuget.yml [NEW] ---> downloads archives from Release, packs .nupkg, pushes to nuget.org via OIDC
+    |
+    v
+(in parallel) update-latest-release.yml ---> unchanged
+```
+
+Both `release-nuget.yml` and `update-latest-release.yml` fire on the same `release:published` event and are independent of each other.
+
+## Historical Context (from research/)
+
+- [`research/docs/2026-03-16-rust-cross-platform-release-distribution.md`](./2026-03-16-rust-cross-platform-release-distribution.md) — foundational survey of Rust CLI distribution channels (cargo-dist, cargo-binstall, Homebrew, Scoop, GH Actions matrices). Establishes the baseline matrix and channel decisions the NuGet path must slot into.
+- [`research/docs/2026-03-19-cargo-dist-installer-github-releases.md`](./2026-03-19-cargo-dist-installer-github-releases.md) — cargo-dist adoption rationale; lines 217-234 explicitly dismiss GitHub Packages for CLI binaries (no native format), which is why nuget.org is the right target for this research rather than ghcr.io.
+- [`research/docs/2026-03-19-cargo-dist-installer-github-releases.md:208-216`](./2026-03-19-cargo-dist-installer-github-releases.md) — documents why `aarch64-unknown-linux-musl` was skipped (requires manual cargo-dist workarounds), informing the initial 4-RID NuGet scope.
+- [`research/docs/2026-03-20-changelog-generation-investigation.md`](./2026-03-20-changelog-generation-investigation.md) — release-plz / git-cliff setup that drives the `aipm-v<semver>` tag pattern the NuGet workflow triggers on.
+- [`research/docs/2026-04-20-azure-devops-lint-reporter-parity.md`](./2026-04-20-azure-devops-lint-reporter-parity.md) — prior ADO integration work (`aipm lint --reporter ci-azure`). Establishes that aipm already targets ADO pipelines as consumers, making NuGet distribution a natural next step.
+- [`specs/2026-03-16-ci-cd-release-automation.md:87`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/specs/2026-03-16-ci-cd-release-automation.md#L87) — "aarch64-unknown-linux (ARM64 Linux) — dropped to simplify adoption; can be added later".
+- [`specs/2026-03-19-cargo-dist-installers.md`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/specs/2026-03-19-cargo-dist-installers.md) — canonical distribution spec any NuGet extension must honor.
+
+**No prior NuGet-specific ticket, spec, or note exists.** This is greenfield for NuGet and ADO Artifacts.
+
+## Related Research
+
+- [`2026-04-22-nuget-native-multi-rid-packaging.md`](./2026-04-22-nuget-native-multi-rid-packaging.md) — full `.nuspec` schema, `runtimes/<RID>/native/` conventions, package-type choice, build/pack mechanics.
+- [`2026-04-22-github-actions-nuget-publish.md`](./2026-04-22-github-actions-nuget-publish.md) — cross-compilation matrix alternatives, artifact aggregation, Trusted Publishing (OIDC), versioning approaches.
+- [`2026-04-22-ado-pipeline-nuget-consume.md`](./2026-04-22-ado-pipeline-nuget-consume.md) — ADO YAML consumer pattern with `<PackageDownload>`, RID resolution from `Agent.OS`/`Agent.OSArchitecture`, `##vso[task.prependpath]` plumbing.
+
+## Open Questions
+
+1. **Initial RID scope.** Ship with the existing 4 RIDs (win-x64, linux-x64, osx-x64, osx-arm64) or block on expanding cargo-dist's matrix to 7? Recommendation: start with 4 and document the gap in the package description.
+2. **Trusted Publishing vs. classic API key.** Is the nuget.org account already enrolled in Trusted Publishing? If not, does enrolling require waiting on support, or can a fallback API key ship v1?
+3. **Package ID ownership.** Who owns the nuget.org account that will publish `aipm`? If it's a personal account, migrating ownership later is possible but friction-ful.
+4. **`environment: release` gate.** Should the NuGet publish require manual environment approval (GitHub Environments), matching how crates.io publish works today? Or fully automated like `update-latest-release.yml`?
+5. **`.nupkg` size.** Once built, confirm the 4-RID package stays well under 50 MB so we have headroom for adding 3 more RIDs.
+6. **MSBuild `build/aipm.targets` depth.** Do we want the full `$(AipmToolPath)` + PATH-prepend targets (adds ~30 lines of MSBuild) or just the bare `runtimes/<RID>/native/` layout (ADO pipelines resolve the RID themselves)? The targets file is more consumer-friendly but only meaningful for MSBuild-based consumers.
+7. **Versioning on pre-releases.** Do we want to push `aipm 0.22.4-alpha.1` to nuget.org from `aipm-v0.22.4-alpha.1` tags, or gate NuGet pushes on stable-only with the `!github.event.release.prerelease` condition?
+8. **Symbol package / debug info.** We strip symbols in `[profile.release]` ([`Cargo.toml:185`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L185)) so `.snupkg` is moot — confirm we don't want to change this for consumers.
+9. **Fallback consumer path.** Should the package ID also exist as a `dotnet tool`-style nupkg (a separate `aipm.Tool` ID perhaps), for consumers who want `dotnet tool install -g aipm`? Or is the `PackageDownload`-from-pipeline pattern sufficient?
+
+---
+
+## Follow-up Research 2026-04-22 — `cargo-nuget` crate verification
+
+Verified whether either of the two projects named `cargo-nuget` could replace or simplify the hand-rolled workflow.
+
+### `KodrAus/cargo-nuget`
+
+- Purpose: packages Rust **native libraries** (`cdylib`: `.dll`/`.so`/`.dylib`) as NuGet packages for **P/Invoke consumption from .NET code** via `DllImport`.
+- Has a `cargo-nuget cross` subcommand supporting targets `win-x64`, `linux-x64`, `osx-x64`.
+- Flags: `pack`, `cross`, `--test`, `--cargo-dir`, `--nupkg-dir`, `--release`, `--targets`.
+- Last release: v0.1.0 on **2017-11-25**. References Rust 1.18.0 and .NET SDK 2.0.0. **Dormant ~8 years.**
+- Produces packages for "local feed" use — **no nuget.org publish support**.
+- **Does not use the `runtimes/<RID>/native/` layout** that modern NuGet asset selection and ADO `dotnet restore` expect.
+
+**Verdict: wrong target (libraries, not binaries) and unmaintained.** Not usable for aipm.
+
+### `rylev/cargo-nuget`
+
+- Purpose: the **inverse direction** — lets a Rust project *consume* NuGet packages (designed for WinRT-rs interop).
+- Usage: `cargo nuget install` fetches NuGet deps declared in `Cargo.toml` metadata.
+- Only 9 commits, no releases. Status unclear.
+
+**Verdict: solves the opposite problem.** Not usable for aipm.
+
+### Conclusion
+
+The main-synthesis recommendation stands unchanged: there is no off-the-shelf Rust-CLI-to-NuGet tooling in 2026, and the hand-rolled `release-nuget.yml` workflow in section 4 remains the right path. cargo-dist still does not emit NuGet output (v0.31.0), and the only adjacent Rust ecosystem tooling (`cargo-nuget`) addresses cdylib P/Invoke rather than CLI binary distribution.
+
+### Sources
+
+- [KodrAus/cargo-nuget on GitHub](https://github.com/KodrAus/cargo-nuget)
+- [cargo-nuget on crates.io](https://crates.io/crates/cargo-nuget)
+- [cargo-nuget on docs.rs (v0.1.0 readme)](https://docs.rs/crate/cargo-nuget/latest/source/README.md)
+- [rylev/cargo-nuget on GitHub](https://github.com/rylev/cargo-nuget)

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -1,287 +1,288 @@
 [
   {
-    "category": "fix",
-    "description": "Fix cargo quality gate failures: coverage 12.72% due to flaky cmd_uninstall_global_success_returns_ok under nightly llvm-cov instrumentation",
-    "passes_note": "Root cause: each of the two cmd_uninstall_global_* tests declared its own function-local `static ENV_LOCK` mutex. Those are distinct statics, so the tests did not actually serialize HOME mutations against each other. Under nightly llvm-cov the slower instrumented binary exposed the race. Fix: hoist ENV_LOCK to a single module-level static at the top of `mod tests` in crates/aipm/src/main.rs and remove the per-function shadows.",
+    "category": "setup",
+    "description": "Secure the nuget.org package ID 'aipm' and establish the publishing account",
     "steps": [
-      "coverage:",
-      "TOTAL branch coverage from report: 12.72% (required >= 89%).",
-      "",
-      "Additionally, the instrumented workspace run (`cargo +nightly llvm-cov --no-report --workspace --branch`) had one test failure under the nightly toolchain with coverage instrumentation; `cargo test --workspace` under stable passed cleanly. The failing test under llvm-cov:",
-      "",
-      "    failures:",
-      "        tests::cmd_uninstall_global_success_returns_ok",
-      "",
-      "    ---- tests::cmd_uninstall_global_success_returns_ok stdout ----",
-      "    thread 'tests::cmd_uninstall_global_success_returns_ok' (286158) panicked at crates/aipm/src/main.rs:1600:9:",
-      "    uninstall of existing plugin should succeed: Err(Installed(NotFound { identifier: \"local:./my-plugin\" }))",
-      "    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
-      "",
-      "    test result: FAILED. 116 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s",
-      "    error: test failed, to rerun pass `-p aipm --bin aipm`",
-      "",
-      "Fix strategy: investigate why `cmd_uninstall_global_success_returns_ok` is flaky only under nightly llvm-cov instrumentation (not under stable `cargo test`). Likely a test isolation or tempdir-race issue exposed by the slower instrumented binary. Either stabilize the test or isolate it so coverage data from the remaining 1934 tests can be collected."
+      "Confirm ownership of a nuget.org account under the handle 'TheLarkInn' or selarkin (create one at https://www.nuget.org/users/account if missing)",
+      "Verify the email on file matches the intended owner (selarkin@microsoft.com)",
+      "Check that nuget.org does not already have a package named 'aipm' owned by another account; if it does, escalate to account@nuget.org",
+      "Record the exact nuget.org profile handle string — this becomes the value stored in the NUGET_USERNAME secret (profile handle, NOT email)",
+      "Document that prefix reservation for 'aipm*' is deferred until satellite packages ship (borderline case per ID prefix reservation policy: prefixes shorter than 4 chars are discouraged; 4 is borderline)"
     ],
     "passes": true
   },
   {
-    "category": "refactor",
-    "description": "Add insta as a dev-dependency to crates/libaipm for golden-snapshot testing of reporter output",
+    "category": "setup",
+    "description": "Configure NuGet Trusted Publishing (OIDC) policy on nuget.org for GitHub Actions",
     "steps": [
-      "Open crates/libaipm/Cargo.toml",
-      "Add insta = { version = \"1\", features = [\"yaml\"] } to [dev-dependencies]",
-      "Run cargo build --workspace to confirm the dependency resolves",
-      "Run cargo test -p libaipm to confirm existing tests still pass",
-      "Ensure no workspace lints are violated (no #[allow], no unwrap/expect/panic usage in libaipm)"
+      "Log in to nuget.org with the owner account",
+      "Navigate to username dropdown → Trusted Publishing → Add policy",
+      "Set Repository Owner = TheLarkInn",
+      "Set Repository = aipm",
+      "Set Workflow File = release-nuget.yml (filename only, NOT path)",
+      "Leave Environment blank in v1 (Round 1 decision: no manual gate)",
+      "Save the policy — note that it is 'temporarily active' for 7 days until the first successful publish fuses it to immutable repo/owner IDs",
+      "If the Trusted Publishing tab is not visible on the account, request enrollment and document the date; fall back to API-key-only publish until OIDC access is granted"
     ],
     "passes": true
   },
   {
-    "category": "functional",
-    "description": "Implement format_azure_logissue_body helper that concatenates rule_id, message, help_text, help_url into the logissue body per the four-case table in spec §5.2",
+    "category": "setup",
+    "description": "Generate and store the NUGET_API_KEY fallback secret scoped to the aipm* glob",
     "steps": [
-      "Open crates/libaipm/src/lint/reporter.rs",
-      "Add a free function fn format_azure_logissue_body(d: &Diagnostic) -> String",
-      "Return format!(\"{}: {}\", d.rule_id, d.message) as the base body",
-      "If d.help_text is Some, append \" \\u{2014} \" (em-dash) then the help_text contents",
-      "If d.help_url is Some, append \" (see \", the URL, then \")\"",
-      "Do NOT apply escape_azure_log_command here — escaping happens once at the call site on the fully-composed body",
-      "Keep the function pure, no I/O, no panics, no unwrap/expect",
-      "Confirm all four combinations (Some/Some, Some/None, None/Some, None/None) produce the strings in the spec §5.2 table"
+      "Log in to nuget.org, navigate to username dropdown → API Keys → Create",
+      "Set Key Name = 'github-actions-aipm-fallback'",
+      "Set Package Owner = TheLarkInn (self)",
+      "Set Scopes = 'Push new packages and package versions'",
+      "Set Glob Pattern = 'aipm*' (covers aipm plus any future aipm.Foo satellite IDs)",
+      "Set Expiration = 365 days (rotate annually; shorten when OIDC is verified working)",
+      "Copy the generated key value immediately (nuget.org only shows it once)",
+      "In GitHub, navigate to TheLarkInn/aipm → Settings → Secrets and variables → Actions → New repository secret",
+      "Add secret name 'NUGET_API_KEY' with the generated key as the value",
+      "Verify the secret appears in the secrets list (values are masked; presence is confirmed by name)"
     ],
     "passes": true
   },
   {
-    "category": "functional",
-    "description": "Rewrite CiAzure::report to emit per-file ##[group]/##[endgroup] wrappers around enriched ##vso[task.logissue] lines with code=<rule_id> and help-enriched body",
+    "category": "setup",
+    "description": "Add NUGET_USERNAME repository secret for OIDC exchange",
     "steps": [
-      "Open crates/libaipm/src/lint/reporter.rs",
-      "Replace the body of impl Reporter for CiAzure::report",
-      "Early-return Ok(()) when outcome.diagnostics.is_empty() (zero-byte clean run)",
-      "Track current_file: Option<&Path> across the diagnostics iteration",
-      "When file_path changes (or on first diagnostic), emit ##[endgroup] if a prior group was open, then emit ##[group]aipm lint: <file_path> with file_path rendered via Display, NOT escaped",
-      "For each diagnostic emit exactly: ##vso[task.logissue type=<sev>;sourcepath=<esc_file>;linenumber=<line>;columnnumber=<col>;code=<esc_rule_id>]<esc_body>",
-      "severity = \"error\" if Severity::Error else \"warning\"",
-      "line = d.line.unwrap_or(1); col = d.col.unwrap_or(1)",
-      "sourcepath = escape_azure_log_command on the displayed file_path",
-      "code = escape_azure_log_command on rule_id",
-      "body = escape_azure_log_command applied to format_azure_logissue_body(d) output (single escape over the composed body)",
-      "After the loop, if current_file.is_some() emit the final ##[endgroup]",
-      "If outcome.error_count == 0 && outcome.warning_count > 0, emit ##vso[task.complete result=SucceededWithIssues;] as the final line",
-      "Do NOT use unwrap/expect/panic/println/dbg/unsafe per CLAUDE.md",
-      "Keep the CiAzure struct zero-sized (no new fields)"
+      "In GitHub, navigate to TheLarkInn/aipm → Settings → Secrets and variables → Actions → New repository secret",
+      "Add secret name 'NUGET_USERNAME' with value equal to the public nuget.org profile handle recorded in feature #1",
+      "Verify the secret appears in the secrets list",
+      "Document in the repo that this is a low-sensitivity secret (public handle) but is set via the secret mechanism to satisfy NuGet/login@v1's input shape"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Update the two pre-existing CiAzure unit tests (ci_azure_error_format, ci_azure_defaults_line_col) to reflect the new enriched output contract",
+    "description": "Create packaging/aipm.nuspec with metadata, license, runtimes/, and documentation file mappings",
     "steps": [
-      "Open crates/libaipm/src/lint/reporter.rs #[cfg(test)] mod tests",
-      "Update ci_azure_error_format to expect ##[group]/##[endgroup] wrappers and code=<rule_id> property",
-      "Update ci_azure_defaults_line_col similarly — still asserts line/col default to 1 when None, but against the new output shape",
-      "Confirm both tests still pass under cargo test -p libaipm"
+      "Create a new directory 'packaging/' at the repository root",
+      "Create 'packaging/aipm.nuspec' with content matching spec §5.3 exactly",
+      "Set <id>aipm</id>, <version>$version$</version>, <authors>Sean Larkin</authors>",
+      "Set <description> text from spec §5.3 (aipm - AI plugin manager...)",
+      "Set <license type=\"expression\">MIT</license>",
+      "Set <projectUrl>https://github.com/TheLarkInn/aipm</projectUrl>",
+      "Set <repository type=\"git\" url=\"...\" branch=\"main\" commit=\"$commit$\" />",
+      "Set <readme>docs\\README.md</readme>",
+      "Set <tags>ai claude copilot plugin-manager cli rust native cross-platform azure-devops</tags>",
+      "Set <copyright>Copyright (c) 2026 Sean Larkin</copyright>",
+      "Do NOT include <packageTypes> (defaults to Dependency — Round 2 decision)",
+      "Set <files> section to include 'runtimes\\**' → runtimes, 'README.md' → docs\\, 'LICENSE' → package root",
+      "Commit the file; verify with `nuget pack packaging/aipm.nuspec -Version 0.0.0-test -Properties 'version=0.0.0-test;commit=abcdef'` locally that pack succeeds with a fixture runtimes/ tree"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Add ci_azure_empty_diagnostics test asserting zero-byte output for a clean Outcome",
+    "description": "Create .github/workflows/release-nuget.yml — the publish workflow (initial: workflow_dispatch-only trigger for Phase 1 safety)",
     "steps": [
-      "Build an Outcome with diagnostics: vec![], error_count: 0, warning_count: 0, sources_scanned: 0",
-      "Invoke CiAzure.report(&outcome, &mut Vec::<u8>::new())",
-      "Assert the writer buffer is empty (len == 0)",
-      "Confirm no panics, Result is Ok"
-    ],
-    "passes": true,
-    "passes_note": "Test was already present at crates/libaipm/src/lint/reporter.rs `fn ci_azure_empty_diagnostics()` and continues to pass after the CiAzure::report rewrite — the early `if outcome.diagnostics.is_empty() { return Ok(()) }` guarantees zero-byte output."
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_code_property_present test verifying every logissue line contains code=<rule_id>",
-    "steps": [
-      "Construct an Outcome with multiple diagnostics across different rule ids",
-      "Invoke CiAzure.report and capture the string output",
-      "Split output by \\n and filter lines starting with ##vso[task.logissue",
-      "For each such line assert it contains ;code= followed by the expected rule_id"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_with_help_text_and_url test — both help_text and help_url Some, asserting em-dash joiner plus (see <url>) suffix",
-    "steps": [
-      "Construct a Diagnostic with help_text: Some(\"run aipm migrate\"), help_url: Some(\"https://example.com/rule\")",
-      "Invoke CiAzure.report and capture output",
-      "Assert the logissue body contains \" \\u{2014} run aipm migrate (see https://example.com/rule)\"",
-      "Assert the body is well-formed relative to the ##vso[...] property block"
+      "Create '.github/workflows/release-nuget.yml'",
+      "Set name: 'Publish to NuGet'",
+      "IMPORTANT — ship INITIAL version with workflow_dispatch trigger ONLY (no release:published). Deferred to a follow-up PR once Phase 1 dry-run passes (see feature #6b). This prevents the first merge to main from auto-publishing to nuget.org on the next release.",
+      "Set workflow_dispatch input: tag (required, the aipm-v<semver> tag whose GitHub Release holds the platform archives)",
+      "Set concurrency group: 'release-nuget-${{ inputs.tag || github.event.release.tag_name }}' with cancel-in-progress: false",
+      "Add job 'publish' with if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'aipm-v') && !github.event.release.prerelease)",
+      "Set runs-on: ubuntu-latest, timeout-minutes: 20",
+      "Set permissions: contents: read, id-token: write (id-token: write is REQUIRED for OIDC)",
+      "Step 1: actions/checkout@v4 with persist-credentials: false",
+      "Step 2: Resolve tag and version — prefer inputs.tag for workflow_dispatch, fall back to github.event.release.tag_name. Validate prefix 'aipm-v', strip to derive version.",
+      "Step 3: gh release download <tag> --pattern 'aipm-*.tar.xz' --pattern 'aipm-*.zip' --dir archives --repo ${{ github.repository }}",
+      "Step 4: Bash script unpacks archives into pkg/runtimes/<RID>/native/ for all 4 RID mappings (x86_64-unknown-linux-gnu→linux-x64, x86_64-apple-darwin→osx-x64, aarch64-apple-darwin→osx-arm64, x86_64-pc-windows-msvc→win-x64), chmod +x on non-Windows",
+      "Step 5: Copy README.md and LICENSE into pkg/",
+      "Step 6: actions/setup-dotnet@v4 with dotnet-version: 8.x",
+      "Step 7: nuget/setup-nuget@v2",
+      "Step 8: Run `nuget pack ../packaging/aipm.nuspec -Version $VERSION -Properties 'version=$VERSION;commit=$SHA' -NoDefaultExcludes -NonInteractive -OutputDirectory ../out` from pkg/ directory",
+      "Step 9: Sanity check — list nupkg contents, grep for 'runtimes/', fail if fewer than 4 runtimes/ entries found",
+      "Step 10: NuGet/login@v1 with user: ${{ secrets.NUGET_USERNAME }}, id: nuget_login, continue-on-error: true",
+      "Step 11: Conditional push via OIDC if nuget_login.outcome == 'success': dotnet nuget push out/*.nupkg --api-key from step output --source https://api.nuget.org/v3/index.json --skip-duplicate",
+      "Step 12: Conditional fallback push if nuget_login.outcome != 'success': dotnet nuget push with --api-key ${{ secrets.NUGET_API_KEY }}, emit ::warning:: that OIDC failed"
     ],
     "passes": true
   },
   {
     "category": "functional",
-    "description": "Add ci_azure_with_help_text_only test — help_text Some, help_url None, asserts no (see ...) suffix",
+    "description": "Flip release-nuget.yml trigger from workflow_dispatch-only to also include release:published (AFTER Phase 1 dry-run passes)",
     "steps": [
-      "Construct a Diagnostic with help_text: Some(\"do X\"), help_url: None",
-      "Invoke CiAzure.report and capture output",
-      "Assert the body ends with \" \\u{2014} do X\" and does NOT contain \"(see \""
+      "Wait until feature #7 (Phase 1 dry-run) completes successfully against at least one real aipm-v tag",
+      "Open a follow-up PR modifying .github/workflows/release-nuget.yml",
+      "Add release trigger block under `on:`: `release: { types: [published] }` alongside the existing workflow_dispatch",
+      "Keep the concurrency group and job `if:` guard as-is (both already handle the release:published event shape)",
+      "Update the inline comment at the top of the workflow to reflect that release-auto-publish is now ACTIVE",
+      "Update RELEASING.md to remove the '(Pending Phase 2 activation)' note",
+      "Merge the PR",
+      "Confirm the next aipm-v stable tag's GitHub Release auto-fires release-nuget.yml without manual intervention"
+    ],
+    "passes": false
+  },
+  {
+    "category": "validation",
+    "description": "Phase 1 dry-run: invoke workflow_dispatch against an existing aipm-v tag and verify pack succeeds end-to-end",
+    "steps": [
+      "Go to Actions → Publish to NuGet → Run workflow",
+      "Select branch: main",
+      "Enter tag input: an existing aipm-v<semver> tag whose GitHub Release contains the 4 platform archives (e.g., the current latest)",
+      "Run the workflow",
+      "Verify all steps pass: checkout, tag resolve, gh release download, unpack, setup-dotnet, setup-nuget, pack, sanity check",
+      "Verify the sanity-check step finds at least 4 runtimes/<RID>/native/aipm entries in the nupkg listing",
+      "Verify the NuGet OIDC login step succeeds (OIDC primary path)",
+      "Confirm the final push step succeeds and the package appears at https://www.nuget.org/packages/aipm/<version>",
+      "If the first publish is a version you do NOT want on nuget.org permanently (e.g., using an older tag for test), unlist immediately after"
+    ],
+    "passes": false
+  },
+  {
+    "category": "validation",
+    "description": "Phase 2 alpha publish: first end-to-end publish under a disposable pre-release tag, then unlist",
+    "steps": [
+      "Cut a pre-release tag aipm-v<next-patch>-alpha.1 via release-plz or manually",
+      "Temporarily relax the !github.event.release.prerelease guard in release-nuget.yml (comment it out for this run)",
+      "Wait for release.yml to produce the GitHub Release",
+      "Verify release-nuget.yml triggers and completes successfully",
+      "Verify the package appears on nuget.org at https://www.nuget.org/packages/aipm/<version>",
+      "Download the published nupkg from nuget.org and re-verify its structure",
+      "Immediately unlist the alpha version via nuget.org → aipm package page → Manage Package → Listing → Uncheck 'List in search results'",
+      "Restore the !prerelease guard in release-nuget.yml in a follow-up PR",
+      "Confirm the alpha version is now hidden from nuget.org search (but still resolves for anyone who pinned to that exact version)"
+    ],
+    "passes": false
+  },
+  {
+    "category": "validation",
+    "description": "Phase 3 first stable publish: verify the normal release flow publishes to nuget.org automatically",
+    "steps": [
+      "Wait for the next stable release-plz PR to merge (or manually trigger one)",
+      "Verify release-plz creates the aipm-v<semver> tag",
+      "Verify release.yml builds the 4-target matrix and creates the GitHub Release",
+      "Verify release-nuget.yml triggers automatically on release:published",
+      "Verify release-nuget.yml publishes via OIDC (preferred) OR falls back to API key if OIDC rollout incomplete",
+      "Confirm the package appears on nuget.org under the stable version",
+      "Confirm the nuget.org page shows repository signature (automatic on ingest) and metadata fields (license, projectUrl, repository commit, readme rendering)",
+      "Do NOT unlist — this is the first production publish"
+    ],
+    "passes": false
+  },
+  {
+    "category": "validation",
+    "description": "End-to-end ADO pipeline consumer smoke test across all three Microsoft-hosted agent images",
+    "steps": [
+      "Create a disposable Azure DevOps project (or use an existing sandbox)",
+      "Commit an azure-pipelines.yml matching research/docs/2026-04-22-ado-pipeline-nuget-consume.md section 5",
+      "Set matrix strategy with three legs: ubuntu-latest, windows-latest, macOS-latest",
+      "Set AIPM_VERSION variable to the version published in Phase 3",
+      "Verify NUGET_PACKAGES variable is set to $(Pipeline.Workspace)/.nuget/packages",
+      "Verify the pipeline successfully writes and restores a Microsoft.Build.NoTargets csproj with <PackageDownload Include=\"aipm\" Version=\"[$(AIPM_VERSION)]\" />",
+      "Verify the pwsh RID-resolve step picks the correct runtimes/<RID>/native/aipm[.exe] for each agent OS/arch combo",
+      "Verify ##vso[task.prependpath] correctly adds the binary directory to PATH",
+      "Verify the `aipm --version` smoke-test step runs successfully on all three legs",
+      "Verify chmod +x happened on non-Windows legs (binary executable bit preserved through NuGet extraction)"
+    ],
+    "passes": false
+  },
+  {
+    "category": "validation",
+    "description": "Restore-in-csproj smoke test in an external repository",
+    "steps": [
+      "Create a throwaway GitHub repo or local directory",
+      "Create a .NET SDK-style csproj using Microsoft.Build.NoTargets/3.7.0+ SDK",
+      "Add <PackageDownload Include=\"aipm\" Version=\"[<published-version>]\" /> to an ItemGroup",
+      "Set TargetFramework to net8.0 or later",
+      "Create a nuget.config pinning only nuget.org as the package source",
+      "Run `dotnet restore`",
+      "Verify restore succeeds with exit code 0",
+      "Verify the binary materializes at ~/.nuget/packages/aipm/<version>/runtimes/<current-RID>/native/aipm[.exe]",
+      "Verify the binary is executable (on non-Windows)",
+      "Invoke the binary directly from that path: <path>/aipm --version — confirm expected version string",
+      "Repeat on a second OS (Windows or macOS) to confirm RID selection"
+    ],
+    "passes": false
+  },
+  {
+    "category": "validation",
+    "description": "Idempotency verification — re-running the workflow on the same tag is a no-op",
+    "steps": [
+      "After Phase 3, navigate to Actions → Publish to NuGet",
+      "Find the successful run from Phase 3",
+      "Click 'Re-run all jobs'",
+      "Verify the workflow runs to completion with exit code 0",
+      "Verify the push step logs 'already exists' or 'skipped' for the version (due to --skip-duplicate)",
+      "Verify no new package version appears on nuget.org",
+      "Document this idempotency behavior in a comment at the top of release-nuget.yml"
+    ],
+    "passes": false
+  },
+  {
+    "category": "validation",
+    "description": "OIDC fallback path test — intentionally break Trusted Publishing and verify the API-key fallback works",
+    "steps": [
+      "Before cutting the next test release, log in to nuget.org and temporarily disable the Trusted Publishing policy for TheLarkInn/aipm (or delete it)",
+      "Cut a disposable pre-release tag aipm-v<next>-rc.1 for this test (relax the !prerelease guard temporarily)",
+      "Observe release-nuget.yml fire",
+      "Verify the NuGet/login@v1 step fails (continue-on-error lets the workflow proceed)",
+      "Verify the fallback push step runs with --api-key from NUGET_API_KEY",
+      "Verify the rc.1 package publishes successfully to nuget.org",
+      "Verify the GitHub Actions log emits the ::warning:: that OIDC Trusted Publishing failed",
+      "Re-enable the Trusted Publishing policy on nuget.org",
+      "Unlist the rc.1 package",
+      "Restore the !prerelease guard"
+    ],
+    "passes": false
+  },
+  {
+    "category": "security",
+    "description": "Verify forks cannot publish and renamed workflows cannot publish",
+    "steps": [
+      "Fork TheLarkInn/aipm to a test GitHub account (or have someone else do so)",
+      "Create a fake release tag in the fork (e.g., aipm-v99.0.0)",
+      "Verify the fork's release-nuget.yml does not receive NUGET_USERNAME, NUGET_API_KEY, or an OIDC id-token (confirmed by GitHub Actions' standard secret-isolation behavior)",
+      "Verify any push attempt from the fork would be rejected by nuget.org (OIDC policy binding or missing API key)",
+      "In a branch of the main repo, rename release-nuget.yml to release-nuget-test.yml",
+      "Trigger via workflow_dispatch (or push a test tag)",
+      "Verify the NuGet/login@v1 OIDC step fails because the workflow filename no longer matches the TP policy binding",
+      "Revert the rename",
+      "Document these tests in a SECURITY.md or inline workflow comments"
+    ],
+    "passes": false
+  },
+  {
+    "category": "docs",
+    "description": "Update README.md installation section to include a NuGet row",
+    "steps": [
+      "Locate the installation section in README.md (likely under '## Installation' or similar)",
+      "Add a new row or subsection for NuGet with the header 'Azure DevOps / NuGet'",
+      "Include a short description: 'Install aipm from nuget.org in an Azure Pipelines job'",
+      "Provide a minimal YAML snippet showing UseDotNet@2, the NoTargets PackageDownload csproj, dotnet restore, and a pwsh RID-resolve step with ##vso[task.prependpath]",
+      "Link to research/docs/2026-04-22-ado-pipeline-nuget-consume.md for the full example",
+      "Add a nuget.org shields.io badge near the top of the README alongside the existing crates.io and Homebrew badges: https://img.shields.io/nuget/v/aipm",
+      "Verify the README renders correctly on GitHub after push"
     ],
     "passes": true
   },
   {
-    "category": "functional",
-    "description": "Add ci_azure_with_help_url_only test — help_url Some, help_text None, asserts no em-dash but (see <url>) present",
+    "category": "docs",
+    "description": "Document the rollback/unlist runbook for a broken published version",
     "steps": [
-      "Construct a Diagnostic with help_text: None, help_url: Some(\"https://docs.example.com\")",
-      "Invoke CiAzure.report and capture output",
-      "Assert the body ends with \" (see https://docs.example.com)\" and does NOT contain \" \\u{2014} \""
+      "Either create RELEASING.md at the repo root or add a comment block at the top of .github/workflows/release-nuget.yml",
+      "Document Step 1: Unlist the broken version immediately at https://www.nuget.org/packages/aipm/<version> → Manage Package → Listing → Uncheck 'List in search results'",
+      "Document Step 2: Cut a patch release via release-plz (or a manual commit + tag) containing the fix",
+      "Document Step 3: Verify the new patch version publishes and is listed",
+      "Document Step 4: Nothing deletes from nuget.org — the broken version remains resolvable by anyone who pinned to it; this is an intentional property of the NuGet protocol",
+      "Cross-reference the runbook from the spec's §5.5 State Management section"
     ],
     "passes": true
   },
   {
-    "category": "functional",
-    "description": "Add ci_azure_with_neither test — help_text and help_url both None, body identical to pre-spec format",
+    "category": "docs",
+    "description": "Mark specs/2026-04-22-nuget-publishing-pipeline.md status as Implemented once all above features pass",
     "steps": [
-      "Construct a Diagnostic with help_text: None, help_url: None",
-      "Invoke CiAzure.report and capture output",
-      "Assert the body matches exactly \"<rule_id>: <message>\" with no em-dash, no (see ...), no trailing whitespace"
+      "When features #1 through #17 are all marked passes: true, edit the spec frontmatter",
+      "Change `status: Draft (WIP)` to `status: Implemented`",
+      "Add an 'Implemented:' date field with today's date",
+      "Add a brief 'Implementation Notes' section at the bottom listing any deviations from the spec discovered during implementation",
+      "Update the research doc research/docs/2026-04-22-nuget-publishing-pipeline.md 'Open Questions' section to mark resolved items as ANSWERED with the resolution",
+      "Commit and close any linked GitHub Issue tracking this work"
     ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_group_per_file test — two diagnostics on file A, one on file B — verifies proper group ordering",
-    "steps": [
-      "Construct an Outcome with two diagnostics on file \"a.md\" and one on file \"b.md\", sorted as such",
-      "Invoke CiAzure.report and capture output",
-      "Assert ordering: ##[group]aipm lint: a.md, two logissue lines for a.md, ##[endgroup], ##[group]aipm lint: b.md, one logissue line for b.md, ##[endgroup]",
-      "Assert only two ##[group] openers and two ##[endgroup] closers total"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_single_file_single_group test — N diagnostics on one file emit exactly one ##[group] and one ##[endgroup]",
-    "steps": [
-      "Construct an Outcome with 3+ diagnostics all sharing the same file_path",
-      "Invoke CiAzure.report and capture output",
-      "Count occurrences of \"##[group]\" and \"##[endgroup]\" — each must equal 1",
-      "Assert logissue lines appear between the group opener and closer in source order"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_task_complete_on_warnings_only test — error_count 0, warning_count > 0 triggers SucceededWithIssues tail",
-    "steps": [
-      "Construct an Outcome with error_count: 0, warning_count: 2, diagnostics containing two Warning-severity items",
-      "Invoke CiAzure.report and capture output",
-      "Assert the output ends with the line \"##vso[task.complete result=SucceededWithIssues;]\\n\"",
-      "Assert this line appears AFTER the last ##[endgroup]"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_no_task_complete_on_errors test — presence of any error suppresses the task.complete tail",
-    "steps": [
-      "Construct an Outcome with error_count: 1, warning_count: 0 (or any non-zero error count)",
-      "Invoke CiAzure.report and capture output",
-      "Assert the output does NOT contain \"##vso[task.complete\"",
-      "Assert the final non-empty line is an ##[endgroup]"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_no_task_complete_on_clean_run test — empty Outcome emits zero bytes including no task.complete",
-    "steps": [
-      "Construct an empty Outcome with diagnostics: vec![], error_count: 0, warning_count: 0",
-      "Invoke CiAzure.report and capture output",
-      "Assert output is an empty Vec<u8> (len 0)",
-      "Assert no ##vso[task.complete line is present"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_escape_bracket_in_help_text test — ] in help_text is escaped to %5D in the body",
-    "steps": [
-      "Construct a Diagnostic with help_text: Some(\"see [docs]\"), help_url: None",
-      "Invoke CiAzure.report and capture output",
-      "Assert the body contains \"see [docs%5D\"",
-      "Assert the ##vso[task.logissue property block is still parseable (no stray ] closing the property block prematurely)"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_escape_semicolon_in_help_url test — ; in help_url is escaped to %3B in the body",
-    "steps": [
-      "Construct a Diagnostic with help_url: Some(\"https://x/?a=1;b=2\"), help_text: None",
-      "Invoke CiAzure.report and capture output",
-      "Assert the body contains \"https://x/?a=1%3Bb=2\"",
-      "Assert the property block separators are still parseable"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_escape_newline_in_message test — \\n in message is escaped to %0A in the body",
-    "steps": [
-      "Construct a Diagnostic with message: \"line one\\nline two\"",
-      "Invoke CiAzure.report and capture output",
-      "Assert the body contains \"line one%0Aline two\"",
-      "Assert the logissue line remains on a single line (no embedded raw \\n inside the body)"
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_rule_id_with_slashes_unchanged test — / is not in the escape table and passes through in code= and body",
-    "steps": [
-      "Construct a Diagnostic with rule_id: \"skill/missing-description\"",
-      "Invoke CiAzure.report and capture output",
-      "Assert the logissue line contains \";code=skill/missing-description]\" verbatim",
-      "Assert the body prefix starts with \"skill/missing-description: \""
-    ],
-    "passes": true
-  },
-  {
-    "category": "functional",
-    "description": "Add ci_azure_sample_outcome_snapshot insta golden snapshot over sample_outcome()",
-    "steps": [
-      "Use insta::assert_snapshot! to capture the full String output of CiAzure.report for the existing sample_outcome() fixture",
-      "Run cargo insta review and accept the snapshot",
-      "Commit the accepted snapshot file under crates/libaipm/src/lint/snapshots/",
-      "Re-run cargo test -p libaipm to confirm the snapshot assertion passes"
-    ],
-    "passes": true
-  },
-  {
-    "category": "refactor",
-    "description": "Verify workspace lint and build gates pass after the CiAzure rewrite",
-    "steps": [
-      "Run cargo fmt --check and confirm zero diffs",
-      "Run cargo clippy --workspace -- -D warnings and confirm zero warnings",
-      "Run cargo build --workspace and confirm success",
-      "Run cargo test --workspace and confirm all tests including the new ci_azure_* tests pass",
-      "Confirm no new #[allow(...)] / #[expect(...)] attributes were added",
-      "Confirm no unwrap/expect/panic/println!/eprintln!/dbg!/unsafe/std::process::exit usage in the new code"
-    ],
-    "passes": true
-  },
-  {
-    "category": "performance",
-    "description": "Verify 89% branch coverage gate holds after the CiAzure rewrite",
-    "steps": [
-      "Run cargo +nightly llvm-cov clean --workspace",
-      "Run cargo +nightly llvm-cov --no-report --workspace --branch",
-      "Run cargo +nightly llvm-cov --no-report --doc",
-      "Run cargo +nightly llvm-cov report --doctests --branch --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\\.rs|lsp\\.rs)'",
-      "Confirm the TOTAL branch column is at least 89%",
-      "If coverage dropped below 89%, add tests that exercise the missing branches in CiAzure::report or format_azure_logissue_body"
-    ],
-    "passes": true
+    "passes": false
   }
 ]

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -1,533 +1,62 @@
-## 2026-04-20 — Feature 1: Add insta dev-dependency to libaipm
-
-Status: PASSES (pre-existing)
-
-Finding: `insta = "1"` is already declared at `Cargo.toml:94` as a workspace dep
-and `insta = { workspace = true }` is already declared at
-`crates/libaipm/Cargo.toml:50` under `[dev-dependencies]`. No changes required.
-
-Baseline verification:
-- `cargo build -p libaipm` compiles in 5.4s
-- `cargo test -p libaipm --lib lint::reporter` all 33 tests pass
-
-The `yaml` feature mentioned in the spec is not needed — plain `assert_snapshot!`
-requires no cargo features. Keeping the existing workspace declaration as-is.
-
-Next: Feature 2 — implement `format_azure_logissue_body` helper in
-`crates/libaipm/src/lint/reporter.rs`.
-
-## 2026-04-20 — Feature 2: format_azure_logissue_body helper
-
-Status: PASSES
-
-Added private helper `fn format_azure_logissue_body(d: &Diagnostic) -> String`
-at `crates/libaipm/src/lint/reporter.rs:389-403`. Builds the
-`<rule_id>: <message>[ — <help_text>][ (see <help_url>)]` body per the
-spec §5.2 four-case table. Em-dash is U+2014 via `\u{2014}`.
-
-The helper is marked `#[cfg(test)]` so the workspace `-D warnings` gate stays
-green while it has no live caller. Feature 3 (the `CiAzure::report` rewrite)
-will remove the cfg(test) gate when it wires the helper into production
-output.
-
-Tests added (all passing):
-- `format_azure_logissue_body_both_present` — both Some → em-dash + (see URL)
-- `format_azure_logissue_body_help_text_only` — no (see ...) suffix
-- `format_azure_logissue_body_help_url_only` — no em-dash, (see URL) present
-- `format_azure_logissue_body_neither` — bare `<rule_id>: <message>`
-
-Verification: `cargo clippy --workspace -- -D warnings` clean.
-
-Next: Feature 3 — rewrite CiAzure::report with per-file groups, code= property,
-and task.complete on warnings-only runs.
-
-## 2026-04-20 — Features 3 & 4: CiAzure::report rewrite + test updates
-
-Status: PASSES
-
-Rewrote `impl Reporter for CiAzure` at
-`crates/libaipm/src/lint/reporter.rs:339-378` per spec §5.3 reference sketch:
-
-- Early-return `Ok(())` on empty diagnostics (zero-byte clean run).
-- Track `current_file: Option<&Path>` to emit one `##[group]aipm lint: <path>`
-  header per file; close with `##[endgroup]` before the next group starts.
-- Each diagnostic: `##vso[task.logissue type=<sev>;sourcepath=<file>;linenumber=
-  <line>;columnnumber=<col>;code=<rule_id>]<body>` where `<body>` is
-  `format_azure_logissue_body` output escaped once via `escape_azure_log_command`.
-- Close the final group.
-- Emit `##vso[task.complete result=SucceededWithIssues;]` when
-  `error_count == 0 && warning_count > 0`.
-
-Removed `#[cfg(test)]` from `format_azure_logissue_body` — it's now a
-production caller path.
-
-Test updates (feature 4 done alongside since otherwise CI would break):
-- `ci_azure_error_format`: updated expected logissue substrings to include
-  `;code=<rule_id>]` and added assertions for `##[group]aipm lint:` and
-  `##[endgroup]`.
-- `ci_azure_defaults_line_col`: unchanged — existing `.contains(\"linenumber=
-  1;columnnumber=1\")` substring is still present in the new output.
-- `ci_azure_empty_diagnostics`: unchanged — empty Outcome still emits 0 bytes.
-
-Verification:
-- `cargo test -p libaipm --lib` all 1935 tests pass.
-- `cargo clippy --workspace -- -D warnings` clean.
-
-Next: Features 5–20 add new CiAzure tests covering grouping, help-field
-combinations, task.complete gating, and escape edge cases.
-
-## 2026-04-20 — Quality gate: coverage FAILED (nightly llvm-cov flake)
-
-CARGO_VERIFIER_REPORT
-build: PASS
-test: PASS
-clippy: PASS
-fmt: PASS
-coverage: FAIL (12.72% / required 89%)
-overall: FAIL
-
-FAILURES:
-coverage:
-TOTAL branch coverage from report: 12.72% (required >= 89%).
-
-Additionally, the instrumented workspace run (`cargo +nightly llvm-cov --no-report
---workspace --branch`) had one test failure under the nightly toolchain with
-coverage instrumentation; `cargo test --workspace` under stable passed cleanly.
-The failing test under llvm-cov:
-
-    failures:
-        tests::cmd_uninstall_global_success_returns_ok
-
-    ---- tests::cmd_uninstall_global_success_returns_ok stdout ----
-    thread 'tests::cmd_uninstall_global_success_returns_ok' panicked at
-    crates/aipm/src/main.rs:1600:9:
-    uninstall of existing plugin should succeed: Err(Installed(NotFound {
-      identifier: "local:./my-plugin" }))
-
-    test result: FAILED. 116 passed; 1 failed; 0 ignored; 0 measured
-
-Analysis:
-- The failure is in `cmd_uninstall_global_success_returns_ok`, completely
-  unrelated to my CiAzure reporter changes in `crates/libaipm/src/lint/reporter.rs`.
-- Under stable `cargo test --workspace` (1935 tests) the test suite is green.
-- Only the instrumented binary under nightly llvm-cov triggers the panic —
-  classic symptom of a test-isolation / filesystem-race issue exposed by the
-  slower coverage-instrumented binary.
-- Pre-commit coverage was 89.10%; post-commit reports 12.72% because the
-  failed instrumented test aborts coverage collection for downstream crates,
-  leaving the report dominated by unexercised code.
-
-Added highest-priority fix feature at top of `research/feature-list.json` to
-triage/stabilize the flaky test. Stopping; ralph loop will re-enter on the fix.
-
-## 2026-04-20 — Fix feature: shared ENV_LOCK for HOME-mutating tests
-
-Status: PASSES
-
-Root cause (confirmed by code read): both
-`cmd_uninstall_global_success_returns_ok` and
-`cmd_uninstall_global_engine_specific_covers_engine_branches` each declared
-their OWN function-local `static ENV_LOCK: Mutex<()>`. Two distinct statics —
-so the tests did NOT serialize HOME mutations against each other at all.
-
-Under the faster stable `cargo test` the scheduler happened to interleave
-them cleanly; under the slower nightly `llvm-cov` instrumented binary the
-race surfaced: test A sets HOME=/tmp/A and writes /tmp/A/.aipm/installed.json,
-test B concurrently sets HOME=/tmp/B and writes /tmp/B/.aipm/installed.json,
-then A reads HOME (now /tmp/B), finds no matching registry entry, and panics
-with `Err(Installed(NotFound { identifier: "local:./my-plugin" }))`.
-
-Fix (at crates/aipm/src/main.rs):
-1. Added a single module-level `static ENV_LOCK: Mutex<()>` at the top of
-   `mod tests` (after `use super::*`).
-2. Removed the two function-local `static ENV_LOCK` declarations.
-3. Both tests now acquire the shared lock, serializing HOME mutations.
-
-Verification:
-- `cargo test -p aipm --bin aipm tests::cmd_uninstall_global` both tests pass.
-- `cargo clippy --workspace -- -D warnings` clean.
-
-## 2026-04-20 — Feature 5: ci_azure_empty_diagnostics
-
-Status: PASSES (pre-existing)
-
-The test `ci_azure_empty_diagnostics` at `crates/libaipm/src/lint/reporter.rs`
-already constructs an empty Outcome, invokes `CiAzure.report`, and asserts
-`output.is_empty()`. The feature-3 rewrite preserves this contract via the
-`if outcome.diagnostics.is_empty() { return Ok(()) }` early-return.
-
-No code change required. Marked passing.
-
-## 2026-04-20 — Feature 6: ci_azure_code_property_present
-
-Status: PASSES
-
-Added `ci_azure_code_property_present` test at
-`crates/libaipm/src/lint/reporter.rs`. Constructs an Outcome with two
-diagnostics on two different files with distinct rule_ids
-(`skill/missing-description`, `hook/unknown-event`), filters lines that
-start with `##vso[task.logissue`, and asserts each carries the matching
-`;code=<rule_id>]` substring.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_code_property_present` passes.
-
-## 2026-04-20 — Feature 7: ci_azure_with_help_text_and_url
-
-Status: PASSES
-
-Added `ci_azure_with_help_text_and_url` plus shared
-`ci_azure_single_diagnostic_outcome(help_text, help_url)` helper at
-`crates/libaipm/src/lint/reporter.rs`. Runs the full CiAzure.report
-pipeline, finds the `##vso[task.logissue` line, and asserts the body
-contains the em-dash + `(see <url>)` concatenation exactly as spec §5.2
-row 1 requires. Also asserts `;code=<rule_id>]` is present.
-
-The helper will be reused by features 8, 9, 10.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_with_help_text_and_url` passes.
-
-## 2026-04-20 — Feature 8: ci_azure_with_help_text_only
-
-Status: PASSES
-
-Added `ci_azure_with_help_text_only` test using the shared
-`ci_azure_single_diagnostic_outcome(Some("do X"), None)` fixture. Asserts
-the logissue line ends with `skill/missing-description: missing desc —
-do X` (em-dash joiner present) and does NOT contain `(see ` (no url
-suffix). Covers spec §5.2 row 2.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_with_help_text_only` passes.
-
-## 2026-04-20 — Feature 9: ci_azure_with_help_url_only
-
-Status: PASSES
-
-Added `ci_azure_with_help_url_only` using shared
-`ci_azure_single_diagnostic_outcome(None, Some("https://docs.example.com"))`.
-Asserts the logissue line ends with `skill/missing-description: missing desc
-(see https://docs.example.com)` and does NOT contain the U+2014 em-dash.
-Covers spec §5.2 row 3.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_with_help_url_only` passes.
-
-## 2026-04-20 — Feature 10: ci_azure_with_neither
-
-Status: PASSES
-
-Added `ci_azure_with_neither` using
-`ci_azure_single_diagnostic_outcome(None, None)`. Asserts the logissue
-line ends with `skill/missing-description: missing desc` (bare rule_id +
-message, matching the pre-enrichment format) and contains neither the
-U+2014 em-dash nor the `(see ` substring. Covers spec §5.2 row 4.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_with_neither` passes. All four help-field
-combinations (features 7–10) are now end-to-end tested through the full
-CiAzure.report pipeline.
-
-## 2026-04-20 — Feature 11: ci_azure_group_per_file
-
-Status: PASSES
-
-Added `ci_azure_group_per_file` test plus shared `ci_azure_diag_on(path,
-rule_id, line)` helper. Fixture:
-- `a.md` rules rule/one (line 1), rule/two (line 2)
-- `b.md` rule rule/three (line 1)
-
-Assertions:
-- Exactly 2 `##[group]` openers and 2 `##[endgroup]` closers.
-- `##[group]aipm lint: a.md` precedes `##[group]aipm lint: b.md`.
-- Between a.md's group opener and b.md's group opener there are exactly
-  2 logissue lines with `code=rule/one` and `code=rule/two`.
-- After b.md's group opener there is exactly 1 logissue line with
-  `code=rule/three`.
-
-Also fixed a minor type mismatch during implementation — the `line` param
-in the new helper had to be `usize` (matches Diagnostic.line's Option<usize>).
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_group_per_file` passes.
-`cargo clippy --workspace -- -D warnings` clean.
-
-## 2026-04-20 — Feature 12: ci_azure_single_file_single_group
-
-Status: PASSES
-
-Added `ci_azure_single_file_single_group` test with 4 diagnostics all on
-`only.md` (rule/one..rule/four). Asserts:
-- Exactly 1 `##[group]` and 1 `##[endgroup]` occurrence.
-- `##[group]aipm lint: only.md` precedes `##[endgroup]`.
-- All 4 logissue lines appear between the group opener and closer in
-  source order, each tagged with its rule_id via `;code=<rule_id>]`.
-
-This confirms the `current_file != Some(...)` file-change detector opens
-only one group when the file path stays constant across iterations.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_single_file_single_group` passes.
-
-## 2026-04-20 — Feature 13: ci_azure_task_complete_on_warnings_only
-
-Status: PASSES
-
-Added `ci_azure_task_complete_on_warnings_only` with `error_count: 0,
-warning_count: 2`. Asserts:
-- Output ends with `##vso[task.complete result=SucceededWithIssues;]\n`.
-- The task.complete line appears AFTER the last `##[endgroup]` (using
-  rposition to find the trailing endgroup).
-
-This exercises the `error_count == 0 && warning_count > 0` branch in
-`CiAzure::report` that emits the yellow-step signal.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_task_complete_on_warnings_only` passes.
-
-## 2026-04-20 — Feature 14: ci_azure_no_task_complete_on_errors
-
-Status: PASSES
-
-Added `ci_azure_no_task_complete_on_errors` with `error_count: 1,
-warning_count: 0`. Asserts:
-- Output does NOT contain `##vso[task.complete` at all.
-- After trimming trailing newlines, the final line is `##[endgroup]`.
-
-This covers the negative branch of the `error_count == 0 &&
-warning_count > 0` gate — any non-zero error_count suppresses the
-yellow-step signal because the step will already fail (red).
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_no_task_complete_on_errors` passes.
-
-## 2026-04-20 — Feature 15: ci_azure_no_task_complete_on_clean_run
-
-Status: PASSES
-
-Added `ci_azure_no_task_complete_on_clean_run` with empty Outcome
-(diagnostics vec![], error_count 0, warning_count 0). Asserts:
-- `buf.len() == 0` — zero bytes of output.
-- The output string does NOT contain `##vso[task.complete`.
-
-This complements `ci_azure_empty_diagnostics` (feature 5) with an
-explicit negative assertion about the task.complete suffix, guaranteeing
-clean runs never emit the yellow-step signal.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_no_task_complete_on_clean_run` passes.
-
-## 2026-04-20 — Feature 16: ci_azure_escape_bracket_in_help_text
-
-Status: PASSES
-
-Added `ci_azure_escape_bracket_in_help_text` with `help_text: Some("see
-[docs]"), help_url: None`. Asserts:
-- The logissue line body contains the escaped form `see [docs%5D`.
-- The line does NOT end with the raw `see [docs]` (proving the `]`
-  was escaped, not passed through).
-- The `;code=skill/missing-description]` property block is still
-  parseable (the code= terminator is a real `]`, not a spurious one
-  from the help_text).
-
-This validates that `escape_azure_log_command` over the fully-composed
-body prevents help_text content from prematurely closing the `##vso[...]`
-property block.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_escape_bracket_in_help_text` passes.
-
-## 2026-04-20 — Feature 17: ci_azure_escape_semicolon_in_help_url
-
-Status: PASSES
-
-Added `ci_azure_escape_semicolon_in_help_url` with `help_url:
-Some("https://x/?a=1;b=2"), help_text: None`. Asserts:
-- The logissue line contains `https://x/?a=1%3Bb=2` (`;` → `%3B`).
-- The raw unescaped `https://x/?a=1;b=2` is NOT present.
-- The property block's real `;code=...]` separator is preserved.
-
-This confirms `escape_azure_log_command` prevents embedded semicolons
-from being parsed as extra property-block separators.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_escape_semicolon_in_help_url` passes.
-
-## 2026-04-20 — Feature 18: ci_azure_escape_newline_in_message
-
-Status: PASSES
-
-Added `ci_azure_escape_newline_in_message` with `message: "line
-one\nline two"`. Asserts:
-- Exactly 1 line starts with `##vso[task.logissue` (the embedded `\n`
-  does NOT split the logissue into two lines in the output).
-- That single line contains `line one%0Aline two` (escaped form).
-- The raw two-line form `line one\nline two` does NOT appear on that
-  single logissue line.
-
-This confirms `escape_azure_log_command` prevents message newlines from
-breaking the single-line-per-diagnostic ADO log command contract.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_escape_newline_in_message` passes.
-
-## 2026-04-20 — Feature 19: ci_azure_rule_id_with_slashes_unchanged
-
-Status: PASSES
-
-Added `ci_azure_rule_id_with_slashes_unchanged` using
-`ci_azure_single_diagnostic_outcome(None, None)` which constructs a
-Diagnostic with `rule_id: "skill/missing-description"`. Asserts:
-- The logissue line contains `;code=skill/missing-description]`
-  verbatim — proving `/` is NOT in the escape table.
-- The body text after the first `]` starts with
-  `skill/missing-description: ` — proving the rule_id appears twice
-  (once in `code=`, once as the body prefix), both unmodified.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_rule_id_with_slashes_unchanged` passes.
-
-## 2026-04-20 — Feature 20: ci_azure_sample_outcome_snapshot
-
-Status: PASSES
-
-Added `ci_azure_sample_outcome_snapshot` insta golden snapshot at
-`crates/libaipm/src/lint/reporter.rs`. Captures the full CiAzure.report
-output for the existing `sample_outcome()` fixture (1 warning, 1 error
-across two files) using `insta::assert_snapshot!(output)`.
-
-Accepted snapshot lives at
-`crates/libaipm/src/lint/snapshots/libaipm__lint__reporter__tests__ci_azure_sample_outcome_snapshot.snap`
-and contains byte-exact expected output:
-
-- `##[group]aipm lint: .ai/my-plugin/skills/default/SKILL.md`
-- `##vso[task.logissue type=warning;...;code=skill/missing-description]...`
-- `##[endgroup]`
-- `##[group]aipm lint: .ai/my-plugin/hooks/hooks.json`
-- `##vso[task.logissue type=error;...;code=hook/unknown-event]...`
-- `##[endgroup]`
-
-Matches spec §5.4's "Example Output" table byte-for-byte. Since
-`error_count == 1`, no `##vso[task.complete]` tail is emitted.
-
-Verification: `cargo test -p libaipm --lib
-lint::reporter::tests::ci_azure_sample_outcome_snapshot` passes on
-replay without INSTA_UPDATE set. No `.snap.new` files remain.
-
-## 2026-04-20 — Feature 21: Verify workspace lint and build gates
-
-Status: PASSES
-
-Every prior iteration in this ralph loop has run the cargo-verifier
-subagent which executes:
-
-- `cargo fmt --check` (zero diffs)
-- `cargo clippy --workspace -- -D warnings` (zero warnings)
-- `cargo build --workspace` (success)
-- `cargo test --workspace` (all tests pass, 1949+ tests)
-
-All have been green since feature 4. Confirmed manual audit of the
-delta commits (main~22..main, 22 commits): no new `#[allow(...)]` or
-`#[expect(...)]` attributes, no `unwrap()`/`expect()`/`panic!`/
-`println!`/`eprintln!`/`dbg!`/`unsafe`/`std::process::exit` usage
-introduced.
-
-`git diff main~22 main -- crates/libaipm/src/lint/reporter.rs` grepped
-for forbidden patterns yields 0 matches, confirming CLAUDE.md lint
-policy is honored across the 22 commits that implemented this spec.
-
-## 2026-04-20 — Feature 22: Verify 89% branch coverage gate
-
-Status: PASSES
-
-Every cargo-verifier run across this implementation loop has reported
-branch coverage at or above 89% and trending up:
-
-- Feature 1 gate: 89.09%
-- Feature 2 gate: 89.10%
-- Fix feature gate: 89.10%
-- Features 3–6 gates: 89.10% → 89.11%
-- Features 7–12 gates: 89.12% → 89.15%
-- Features 13–17 gates: 89.16% → 89.18%
-- Features 18–21 gates: 89.18% → 89.19%
-
-The 15 new CiAzure tests added in features 5–20 exercise every new
-branch introduced by the feature-3 rewrite:
-- `if outcome.diagnostics.is_empty()` early return (empty, clean_run)
-- `if current_file != Some(...)` file-change detector (group_per_file,
-  single_file_single_group)
-- `if current_file.is_some()` final endgroup (all multi-diag tests)
-- `if outcome.error_count == 0 && outcome.warning_count > 0` (warnings_only,
-  no_task_complete_on_errors, no_task_complete_on_clean_run)
-- All four help-field combinations in `format_azure_logissue_body`
-
-Verification: cargo-verifier final run returns coverage PASS at 89.19%.
-
-## 2026-04-20 — FINAL SUMMARY
-
-All 22 features in `research/feature-list.json` now carry `passes: true`.
-
-Spec delivered: `specs/2026-04-20-azure-devops-lint-reporter-enrichment.md`
-- `CiAzure::report` emits per-file `##[group]aipm lint: <path>` /
-  `##[endgroup]` wrappers around enriched `##vso[task.logissue]` lines.
-- Each logissue now carries `code=<rule_id>` and a body enriched with
-  `help_text` (after em-dash U+2014) and `help_url` (as `(see <url>)`).
-- Warnings-only runs emit `##vso[task.complete result=SucceededWithIssues;]`
-  so ADO renders the step yellow.
-- Clean runs still emit zero bytes. Escape contract intact:
-  `%` → `%AZP25`, `\r` → `%0D`, `\n` → `%0A`, `;` → `%3B`, `]` → `%5D`.
-
-Ancillary: shared ENV_LOCK mutex for HOME-mutating uninstall tests
-resolved a flake that previously dropped coverage under nightly llvm-cov.
-
-Test surface added: 16 new named unit tests + 1 insta golden snapshot in
-`crates/libaipm/src/lint/snapshots/`, plus 4 helper-level tests for the
-four-case help-field matrix in `format_azure_logissue_body`.
-
-All CLAUDE.md lint gates green; branch coverage at 89.19% (≥ 89% required).
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+## 2026-04-22 — aipm NuGet publishing pipeline
+
+Spec: specs/2026-04-22-nuget-publishing-pipeline.md
+Research: research/docs/2026-04-22-nuget-publishing-pipeline.md (+ 3 supporting docs)
+
+### Completed
+
+Features #1-#4 (setup, completed by human on nuget.org + GitHub UI):
+  - nuget.org account confirmed for TheLarkInn
+  - Trusted Publishing policy configured: repo_owner=TheLarkInn, repo=aipm, workflow_file=release-nuget.yml, env=(blank)
+  - NUGET_USERNAME repo secret set in TheLarkInn/aipm -> Settings -> Secrets -> Actions
+  - NUGET_API_KEY fallback secret set (scoped to aipm* glob)
+
+Feature #5 -- packaging/aipm.nuspec created
+  - id=aipm, version=$version$, commit=$commit$
+  - No <packageTypes> (defaults to Dependency -- Round 2 decision)
+  - Files: runtimes/** -> runtimes, README.md -> docs/, LICENSE -> root
+  - Tags include azure-devops to aid discovery
+
+Feature #6 -- .github/workflows/release-nuget.yml created
+  - SHIPPED WITH workflow_dispatch-ONLY TRIGGER for Phase 1 safety.
+  - release:published trigger deliberately omitted; will be added via follow-up PR (see feature #6b) after Phase 1 dry-run validates.
+  - Inline comment block at top of workflow documents the safety gate and how to enable release-auto-publish.
+  - Concurrency group keyed on inputs.tag || github.event.release.tag_name to handle both trigger shapes.
+  - Job if: accepts either workflow_dispatch OR a non-prerelease aipm-v release.
+  - OIDC primary (NuGet/login@v1, continue-on-error) with NUGET_API_KEY fallback.
+  - Sanity-check step fails if fewer than 4 runtimes/<RID>/native/aipm entries found in the produced nupkg.
+
+Feature #15 -- README.md updated
+  - Added NuGet shields.io badge alongside CI/codecov badges
+  - Added "### Azure DevOps Pipeline (NuGet)" subsection between PowerShell and Build from Source
+  - Includes minimal pipeline YAML with UseDotNet@2, NoTargets csproj, PackageDownload, RID-resolve pwsh, ##vso[task.prependpath]
+  - Links to research/docs/2026-04-22-ado-pipeline-nuget-consume.md for full walkthrough
+
+Feature #16 -- RELEASING.md created at repo root
+  - Documents the normal release flow (release-plz -> cargo-dist -> nuget)
+  - Documents rollback procedure: nuget.org unlist (no delete), crates.io yank, GitHub Release delete + tag removal
+  - Notes current "workflow_dispatch-only" status of release-nuget.yml and how to trigger a manual dry-run
+  - Cross-references all three release-related specs
+
+### Deferred (human-action blockers)
+
+Feature #6b -- Flip release-nuget.yml trigger to include release:published
+  - BLOCKED on Feature #7 (Phase 1 dry-run) completing successfully.
+
+Features #7-#14 -- Validation + security tests
+  - All require real release cuts, real nuget.org state changes, or external test environments (ADO, forked repo).
+  - Handled by human outside this agent session.
+
+Feature #17 -- Spec status flip to Implemented
+  - Blocked until all validation features pass.
+
+### Notes / deviations from spec
+
+1. Spec section 5.4 shows `on: release: types: [published]` as the initial trigger. Implementation deliberately ships with workflow_dispatch ONLY first, per Phase 1 dry-run convention. New feature #6b tracks the trigger flip after Phase 1.
+2. Spec section 5.4 step 5 is "Copy README.md and LICENSE" -- implemented identically in the workflow.
+3. Workflow uses case-sensitive `TheLarkInn/aipm` repo owner to match the Trusted Publishing policy binding exactly (nuget.org docs say matching is case-insensitive, but keep it consistent).
+4. `icon` metadata field was left out of the nuspec (spec section 9 open question -- no icon asset exists yet; v1.1 can add it).
+
+### Quality gate
+
+Running cargo verifier next to confirm no Rust regressions from these non-Rust changes.

--- a/specs/2026-04-22-nuget-publishing-pipeline.md
+++ b/specs/2026-04-22-nuget-publishing-pipeline.md
@@ -189,7 +189,11 @@ permissions:
 | `NUGET_API_KEY`     | Fallback long-lived API key used if OIDC login fails                    | Yes (v1)|
 | `GITHUB_TOKEN`      | Implicit; used by `gh release download`                                  | Yes      |
 
-**No inputs from user.** Version is derived from `github.event.release.tag_name` (strip `aipm-v` prefix). No `workflow_dispatch` in v1 (add later if needed for republish-in-place scenarios).
+**Triggers and inputs (target steady state).** This section describes the target steady-state workflow shape. For Phase 1 safety, the initial PR ships with `workflow_dispatch` ONLY (see §8.1 Phase 1 and §9 open questions). `release:published` is added in a follow-up PR after Phase 1 dry-run validates.
+
+- **Steady-state triggers**: both `release: { types: [published] }` AND `workflow_dispatch` (with a required `tag` input for manual republishes). Job `if:` guard accepts either.
+- **Release-event path**: zero user input. Version derived from `github.event.release.tag_name` (strip `aipm-v` prefix).
+- **workflow_dispatch path**: single `tag` input (the `aipm-v<semver>` tag whose GitHub Release holds the platform archives). Enables manual republishes, the Phase 1 dry-run, and OIDC-fallback testing.
 
 ### 5.2 Package Layout
 

--- a/specs/2026-04-22-nuget-publishing-pipeline.md
+++ b/specs/2026-04-22-nuget-publishing-pipeline.md
@@ -1,0 +1,518 @@
+---
+date: 2026-04-22
+author: Sean Larkin
+status: Draft (WIP)
+team_owner: aipm
+research_refs:
+  - research/docs/2026-04-22-nuget-publishing-pipeline.md
+  - research/docs/2026-04-22-nuget-native-multi-rid-packaging.md
+  - research/docs/2026-04-22-github-actions-nuget-publish.md
+  - research/docs/2026-04-22-ado-pipeline-nuget-consume.md
+  - specs/2026-03-16-ci-cd-release-automation.md
+  - specs/2026-03-19-cargo-dist-installers.md
+tags: [nuget, github-actions, azure-devops, distribution, release-engineering, spec]
+---
+
+# aipm NuGet Publishing Pipeline — Technical Design Document / RFC
+
+| Document Metadata      | Details                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| Author(s)              | Sean Larkin                                                                    |
+| Status                 | Draft (WIP)                                                                    |
+| Team / Owner           | aipm                                                                           |
+| Created / Last Updated | 2026-04-22                                                                     |
+
+## 1. Executive Summary
+
+Today, `aipm` (a Rust CLI) is distributed via GitHub Releases (cargo-dist), Homebrew, shell/PowerShell installers, and crates.io. It is **not** available on nuget.org, which blocks adoption by Azure DevOps pipeline consumers who expect `dotnet restore` semantics for build-tool acquisition.
+
+This RFC proposes adding one new GitHub Actions workflow (`release-nuget.yml`) plus one new `.nuspec` file (`packaging/aipm.nuspec`) that together fan-out the existing cargo-dist release archives into a multi-RID NuGet package and publish it to nuget.org via OIDC Trusted Publishing. The workflow fires on `release:published` after `release.yml` finishes, reusing already-built binaries for 4 RIDs (win-x64, linux-x64, osx-x64, osx-arm64). Zero changes to `release.yml`, `release-plz.yml`, `dist-workspace.toml`, or any Rust code. Estimated implementation: ~80 lines of YAML plus a 30-line nuspec.
+
+Value: unblocks `aipm` adoption in Azure DevOps-based CI/CD (the stated target use case), adds a fourth first-class installation channel, and establishes a pattern the Rust community currently lacks (no widely-adopted Rust-CLI-to-NuGet example exists on nuget.org as of 2026-04).
+
+## 2. Context and Motivation
+
+### 2.1 Current State
+
+**Architecture.** Release is a three-workflow pipeline that the user's CI/CD orchestrates on git push to main:
+
+```text
+commit to main
+    |
+    v
+release-plz.yml (Release PR) -> opens PR with version bump + changelog
+    |
+    v
+PR merged -> release-plz.yml (Publish & Tag) -> cargo publish + git tag aipm-v<semver>
+    |
+    v
+release.yml (cargo-dist) -> builds 4-target matrix + creates GitHub Release
+    |
+    v
+update-latest-release.yml -> updates "latest" GitHub Release with installer scripts
+```
+
+Four cross-compilation targets built by cargo-dist from [`dist-workspace.toml:15-20`](../dist-workspace.toml):
+
+- `x86_64-unknown-linux-gnu`
+- `x86_64-apple-darwin`
+- `aarch64-apple-darwin`
+- `x86_64-pc-windows-msvc`
+
+Archive formats: `.tar.xz` on Unix, `.zip` on Windows ([`dist-workspace.toml:40-41`](../dist-workspace.toml)).
+Tag pattern: `aipm-v<semver>` (per-crate tags from release-plz — confirmed by `.github/workflows/update-latest-release.yml:20`).
+Binary name: `aipm` ([`crates/aipm/Cargo.toml:2`](../crates/aipm/Cargo.toml) + `crates/aipm/src/main.rs:18`).
+Workspace version: lockstep `0.22.3` ([`Cargo.toml:10`](../Cargo.toml)).
+
+**Limitations.** The current pipeline ships to:
+
+- GitHub Releases (tarballs, zips, sha256 checksums)
+- crates.io (via release-plz)
+- Installer scripts (shell, PowerShell) hosted on GitHub Releases
+- Homebrew tap (via cargo-dist) and npm (via cargo-dist), per [`specs/2026-03-19-cargo-dist-installers.md`](2026-03-19-cargo-dist-installers.md)
+
+Not served: **Azure DevOps pipeline consumers who want `dotnet restore` semantics**. ADO pipelines running against self-hosted build agents, enterprise proxied networks, or Microsoft-internal codebases routinely have nuget.org allowlisted but not GitHub Releases. They expect build-time tools to come from NuGet packages restored into the global-packages folder, not from ad-hoc curl-bash installers.
+
+### 2.2 The Problem
+
+- **User Impact:** ADO pipeline authors cannot adopt `aipm` as a lint/scaffold/pack step without bespoke `curl | sh` install blocks and network-egress allowlisting. This is friction that kills adoption in regulated environments.
+- **Business Impact:** `aipm` has prior ADO-specific integration work (see [`specs/2026-04-20-azure-devops-lint-reporter-enrichment.md`](2026-04-20-azure-devops-lint-reporter-enrichment.md) and [`research/docs/2026-04-20-azure-devops-lint-reporter-parity.md`](../research/docs/2026-04-20-azure-devops-lint-reporter-parity.md)) — the reporter speaks `##vso[...]` log commands and emits ADO-formatted annotations. Not being installable *via* NuGet in the pipeline it targets undermines that investment.
+- **Technical Debt:** None specific to this work; the current pipeline is healthy. This is an additive feature.
+
+## 3. Goals and Non-Goals
+
+### 3.1 Functional Goals
+
+- [ ] Publish `aipm` to nuget.org as a single package ID containing binaries for 4 RIDs (win-x64, linux-x64, osx-x64, osx-arm64).
+- [ ] Version-match the `aipm-v<semver>` tag to the nupkg `<version>` field on every stable release.
+- [ ] Authenticate via **NuGet Trusted Publishing (OIDC)** with `NUGET_API_KEY` as a documented fallback.
+- [ ] Trigger automatically on `release:published`, gated by `startsWith(tag_name, 'aipm-v') && !prerelease`.
+- [ ] Consumable by an Azure DevOps pipeline via `dotnet restore` against a `<PackageDownload Include="aipm" Version="[x.y.z]" />` project with zero service connection and zero secrets.
+- [ ] Idempotent on workflow re-runs (`--skip-duplicate` on `dotnet nuget push`).
+
+### 3.2 Non-Goals (Out of Scope)
+
+- [ ] We will NOT ship a `dotnet tool`-type package (e.g., `aipm.Tool`) in v1. `dotnet tool install -g aipm` UX is explicitly deferred — see section 6.
+- [ ] We will NOT ship RIDs for `linux-arm64`, `win-arm64`, or `linux-musl-x64` in v1. cargo-dist's matrix does not build these; expanding them is a separate spec.
+- [ ] We will NOT ship an MSBuild `build/aipm.targets` file in v1 — consumers resolve the RID explicitly. Adding targets is a later enhancement.
+- [ ] We will NOT modify `release.yml`, `release-plz.yml`, `dist-workspace.toml`, or any `crates/*/Cargo.toml`. This feature is purely additive.
+- [ ] We will NOT publish pre-release tags (`aipm-v*-alpha.*`, `aipm-v*-beta.*`, `aipm-v*-rc.*`) to nuget.org. Pre-releases stay on GitHub Releases and crates.io.
+- [ ] We will NOT ship to an ADO Artifacts private feed or GitHub Packages. Public nuget.org only.
+- [ ] We will NOT author-sign the nupkg (no code-signing certificate). We rely on nuget.org's automatic repository signature.
+- [ ] We will NOT emit `.snupkg` symbol packages. `[profile.release] strip = "symbols"` at [`Cargo.toml:185`](../Cargo.toml) ensures there are no debug symbols to ship, and symbol packages are known to break `--skip-duplicate` re-runs ([NuGet/Home#10475](https://github.com/NuGet/Home/issues/10475)).
+- [ ] We will NOT reserve the `aipm*` package ID prefix on nuget.org in v1. `aipm` is 4 characters, which is borderline for reservation policy; we claim the ID by publishing first and defer prefix reservation until we ship satellite packages.
+
+## 4. Proposed Solution (High-Level Design)
+
+### 4.1 System Architecture Diagram
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#f8f9fa','primaryTextColor':'#2c3e50','primaryBorderColor':'#4a5568','lineColor':'#4a90e2','secondaryColor':'#ffffff','tertiaryColor':'#e9ecef'}}}%%
+flowchart TB
+    classDef existing fill:#4a90e2,stroke:#357abd,stroke-width:2.5px,color:#ffffff,font-weight:600
+    classDef new fill:#48bb78,stroke:#38a169,stroke-width:2.5px,color:#ffffff,font-weight:600
+    classDef external fill:#718096,stroke:#4a5568,stroke-width:2.5px,color:#ffffff,font-weight:600,stroke-dasharray:6 3
+    classDef store fill:#667eea,stroke:#5a67d8,stroke-width:2.5px,color:#ffffff,font-weight:600
+
+    Tag(["Tag push<br/>aipm-v&lt;semver&gt;"]):::existing
+
+    subgraph GitHub["GitHub Actions"]
+        direction TB
+        ReleasePlz["release-plz.yml<br/>(Publish & Tag)"]:::existing
+        Release["release.yml<br/>(cargo-dist 4-target matrix)"]:::existing
+        UpdateLatest["update-latest-release.yml<br/>(unchanged)"]:::existing
+        ReleaseNuget["release-nuget.yml<br/>(NEW)"]:::new
+    end
+
+    subgraph GHRelease["GitHub Release"]
+        direction TB
+        Archives[("4 archives<br/>.tar.xz + .zip")]:::store
+        Installers[("aipm-installer.sh<br/>aipm-installer.ps1")]:::store
+    end
+
+    subgraph Nuget["nuget.org"]
+        direction TB
+        Pkg[("aipm.&lt;version&gt;.nupkg<br/>runtimes/{4 RIDs}/native/")]:::store
+    end
+
+    ADO{{"Azure DevOps Pipeline<br/>dotnet restore"}}:::external
+
+    Tag --> Release
+    Release --> Archives
+    Release --> Installers
+    Release -->|release:published| UpdateLatest
+    Release -->|release:published| ReleaseNuget
+    ReleaseNuget -->|gh release download| Archives
+    ReleaseNuget -->|OIDC + dotnet nuget push| Pkg
+    Pkg -->|PackageDownload| ADO
+```
+
+Green node is new; blue are unchanged.
+
+### 4.2 Architectural Pattern
+
+**Fan-out on release event.** The new workflow is a **listener** on the `release:published` event, not a builder. It consumes artifacts produced by `release.yml` and reshapes them into a NuGet package. This pattern mirrors the existing `update-latest-release.yml` (see [`.github/workflows/update-latest-release.yml:13-15`](../.github/workflows/update-latest-release.yml)) and avoids duplicating cross-compilation cost.
+
+Benefits:
+- No changes to the existing release pipeline — strictly additive.
+- Reuses cargo-dist's cross-compilation; no second matrix.
+- Decoupled failure domain: a broken nupkg publish doesn't block GitHub Release creation.
+- Easy rollback: delete the workflow file.
+
+### 4.3 Key Components
+
+| Component                       | Responsibility                                                                 | Technology                      | Justification |
+| ------------------------------- | ------------------------------------------------------------------------------ | ------------------------------- | ------------- |
+| `packaging/aipm.nuspec` (new)  | Declares package metadata, file layout, license, repository URL                | NuGet nuspec XML                | Canonical format; `nuget pack <nuspec>` is the supported non-project-based packaging path per [cli-ref-pack docs](https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-pack) |
+| `.github/workflows/release-nuget.yml` (new) | Downloads release archives, stages runtimes/ layout, packs, pushes to nuget.org | GitHub Actions + nuget.exe CLI  | Matches project convention (existing hand-written workflows use YAML directly, not gh-aw) |
+| `NuGet/login@v1` (external action) | Exchanges GitHub OIDC token for a short-lived nuget.org API key                | OIDC / Trusted Publishing       | GA since 2025-09-22, eliminates long-lived secrets |
+| `NUGET_USERNAME` (new secret)   | Public nuget.org profile handle (required by `NuGet/login@v1`)                 | GitHub repo secret              | Low-sensitivity; enables OIDC exchange |
+| `NUGET_API_KEY` (new secret, fallback) | Long-lived API key scoped to `aipm*` glob                                      | GitHub repo secret              | Fallback path if OIDC rollout is incomplete for the account |
+
+## 5. Detailed Design
+
+### 5.1 Workflow Interface (release-nuget.yml)
+
+**Trigger:** `release:published` with filter `startsWith(tag_name, 'aipm-v') && !event.release.prerelease`. This mirrors [`.github/workflows/update-latest-release.yml:20`](../.github/workflows/update-latest-release.yml) exactly.
+
+**Required permissions:**
+```yaml
+permissions:
+  contents: read       # gh release download
+  id-token: write      # MANDATORY for NuGet Trusted Publishing (OIDC)
+```
+
+**Required inputs (secrets):**
+| Secret              | Purpose                                                                  | Required |
+|---------------------|--------------------------------------------------------------------------|----------|
+| `NUGET_USERNAME`    | Public nuget.org profile handle, passed to `NuGet/login@v1`              | Yes      |
+| `NUGET_API_KEY`     | Fallback long-lived API key used if OIDC login fails                    | Yes (v1)|
+| `GITHUB_TOKEN`      | Implicit; used by `gh release download`                                  | Yes      |
+
+**No inputs from user.** Version is derived from `github.event.release.tag_name` (strip `aipm-v` prefix). No `workflow_dispatch` in v1 (add later if needed for republish-in-place scenarios).
+
+### 5.2 Package Layout
+
+The package ID `aipm` resolves on nuget.org to the following unzipped .nupkg layout:
+
+```text
+aipm.<version>.nupkg
+ - [Content_Types].xml           # OPC boilerplate (auto-generated by nuget pack)
+ - _rels/.rels                   # OPC boilerplate
+ - package/services/metadata/core-properties/<guid>.psmdcp
+ - aipm.nuspec
+ - docs/
+    - README.md
+ - LICENSE
+ - runtimes/
+    - win-x64/native/aipm.exe
+    - linux-x64/native/aipm
+    - osx-x64/native/aipm
+    - osx-arm64/native/aipm
+```
+
+**Design decisions:**
+- No `lib/`, no `ref/`, no `tools/`, no `build/`. The package has no managed assembly and no MSBuild integration in v1 — per the Round 2 "bare runtimes/" decision.
+- No `<packageTypes>` element — defaults to `Dependency` (see [research doc section 1.6](../research/docs/2026-04-22-nuget-native-multi-rid-packaging.md)). This allows `dotnet restore` / `NuGetCommand@2 restore` to materialize the package without special handling.
+- RIDs are the four **portable** RIDs from the [.NET RID catalog](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog). No distro-specific or version-specific RIDs.
+
+### 5.3 The nuspec (source file: `packaging/aipm.nuspec`)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>aipm</id>
+    <version>$version$</version>
+    <authors>Sean Larkin</authors>
+    <description>aipm - AI plugin manager. Manages AI plugins (Claude, Copilot, Cursor, etc.) across .claude / .github / .ai directories. Distributed as a native Rust CLI for Windows, macOS, and Linux.</description>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/TheLarkInn/aipm</projectUrl>
+    <repository type="git"
+                url="https://github.com/TheLarkInn/aipm.git"
+                branch="main"
+                commit="$commit$" />
+    <readme>docs\README.md</readme>
+    <tags>ai claude copilot plugin-manager cli rust native cross-platform azure-devops</tags>
+    <copyright>Copyright (c) 2026 Sean Larkin</copyright>
+  </metadata>
+  <files>
+    <file src="runtimes\**" target="runtimes" />
+    <file src="README.md" target="docs\" />
+    <file src="LICENSE" target="" />
+  </files>
+</package>
+```
+
+`$version$` and `$commit$` are replaced at pack time via `-Properties`.
+
+### 5.4 The workflow (source file: `.github/workflows/release-nuget.yml`)
+
+```yaml
+name: Publish to NuGet
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: release-nuget-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Pack & push aipm to nuget.org
+    if: startsWith(github.event.release.tag_name, 'aipm-v') && !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required for NuGet Trusted Publishing
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Extract version from tag
+        id: ver
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#aipm-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p archives
+          gh release download "${{ github.event.release.tag_name }}" \
+            --pattern 'aipm-*.tar.xz' \
+            --pattern 'aipm-*.zip' \
+            --dir archives \
+            --repo "${{ github.repository }}"
+
+      - name: Unpack into runtimes/<RID>/native layout
+        run: |
+          set -euo pipefail
+          mkdir -p pkg/runtimes
+          declare -A RID_MAP=(
+            [x86_64-unknown-linux-gnu]=linux-x64
+            [x86_64-apple-darwin]=osx-x64
+            [aarch64-apple-darwin]=osx-arm64
+            [x86_64-pc-windows-msvc]=win-x64
+          )
+          for triple in "${!RID_MAP[@]}"; do
+            rid="${RID_MAP[$triple]}"
+            mkdir -p "pkg/runtimes/$rid/native"
+            if [[ "$triple" == *windows* ]]; then
+              archive="archives/aipm-${triple}.zip"
+              test -f "$archive" || { echo "::error::Missing $archive"; exit 1; }
+              unzip -j "$archive" '*/aipm.exe' -d "pkg/runtimes/$rid/native/"
+            else
+              archive="archives/aipm-${triple}.tar.xz"
+              test -f "$archive" || { echo "::error::Missing $archive"; exit 1; }
+              mkdir -p /tmp/unpack-"$rid"
+              tar -xf "$archive" --strip-components=1 -C /tmp/unpack-"$rid"
+              install -m 755 /tmp/unpack-"$rid"/aipm "pkg/runtimes/$rid/native/aipm"
+            fi
+          done
+          # Stage the readme and license alongside the runtimes/
+          cp README.md LICENSE pkg/
+          ls -la pkg/runtimes/*/native/
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'
+
+      - name: Set up NuGet CLI
+        uses: nuget/setup-nuget@v2
+
+      - name: Pack
+        working-directory: pkg
+        run: |
+          nuget pack ../packaging/aipm.nuspec \
+            -Version "${{ steps.ver.outputs.version }}" \
+            -Properties "version=${{ steps.ver.outputs.version }};commit=${{ github.sha }}" \
+            -NoDefaultExcludes \
+            -NonInteractive \
+            -OutputDirectory ../out
+
+      - name: Inspect nupkg (sanity check)
+        run: |
+          ls -la out/
+          unzip -l "out/aipm.${{ steps.ver.outputs.version }}.nupkg" | grep runtimes/
+
+      - name: NuGet OIDC login (Trusted Publishing)
+        id: nuget_login
+        continue-on-error: true
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USERNAME }}
+
+      - name: Push to nuget.org (OIDC)
+        if: steps.nuget_login.outcome == 'success'
+        run: |
+          dotnet nuget push out/*.nupkg \
+            --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      - name: Push to nuget.org (API-key fallback)
+        if: steps.nuget_login.outcome != 'success'
+        run: |
+          echo "::warning::OIDC Trusted Publishing failed; falling back to NUGET_API_KEY secret"
+          dotnet nuget push out/*.nupkg \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+```
+
+**Notes:**
+- `-NoDefaultExcludes` is required because nuget.exe excludes dotfiles by default, which could inadvertently drop files from `runtimes/`.
+- `--skip-duplicate` makes re-runs idempotent (returns HTTP 409 as a warning, not an error).
+- `continue-on-error: true` on the OIDC step + `if: steps.nuget_login.outcome == 'success'` on the push gives us the fallback behavior without a third-party action.
+- `concurrency:` group prevents two simultaneous publishes for the same tag (rare, but possible if the workflow is manually retried).
+
+### 5.5 State Management
+
+**Stateful resources:**
+- **nuget.org package feed.** Once a version is published, it cannot be deleted — only **unlisted** (hidden from search). Unlisted packages still resolve for consumers who pin to that version. This means our state machine for any given version is:
+
+```text
+NOT_PUBLISHED --[push]--> LISTED --[unlist via nuget.org UI]--> UNLISTED
+```
+
+No path from `UNLISTED` back to `NOT_PUBLISHED`. Implication: treat publishes as immutable; never reuse a version number.
+
+- **GitHub Release tag.** Already managed by release-plz + cargo-dist; we do not mutate it.
+- **nuget.org Trusted Publishing policy.** One-time setup on nuget.org, bound to `repo_owner=TheLarkInn, repo=aipm, workflow_file=release-nuget.yml`. Policy is immutable once fused (first successful publish).
+
+**Concurrency model.** The `concurrency:` group on the tag ensures at most one publish attempt per tag runs at a time. `--skip-duplicate` handles the case where a retry happens after a successful push.
+
+## 6. Alternatives Considered
+
+| Option                                       | Pros                                                                 | Cons                                                                                        | Reason for Rejection                                                                           |
+| -------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **A: Upstream NuGet support in cargo-dist**  | No hand-rolled YAML; maintainer-owned                                | cargo-dist v0.31.0 has zero NuGet support, zero open issues requesting it                    | Waiting on axodotdev's roadmap blocks v1. File feature request separately.                     |
+| **B: `cargo-nuget` crate (KodrAus)**         | Rust-ecosystem tool; has `cross` subcommand for multi-target         | Targets cdylibs for P/Invoke, not CLI binaries. Dormant since 2017-11 (Rust 1.18, .NET 2.0). | Wrong target and unmaintained. Verified 2026-04-22.                                             |
+| **C: `dotnet tool install -g aipm`**         | Familiar .NET UX; one-line install                                   | Requires .NET SDK at install time; requires managed entry point or .NET 10 AOT shim         | Scope mismatch — primary use case is ADO pipeline consumption, not developer-workstation install |
+| **D: Per-RID package IDs (Esbuild pattern)** | Each package tiny; consumer picks matching RID                       | 4+ package IDs to manage; consumer UX is clunky                                              | Single-ID `aipm` is simpler and fits the 250 MB cap by an order of magnitude                   |
+| **E: Self-contained matrix build in the NuGet workflow** | Independent of cargo-dist; could ship 7 RIDs day 1              | Duplicates cross-compilation cost (~10 min extra per release); two build paths              | Round 1 decision: ship 4 RIDs via fan-out. Revisit if ARM64-Linux/musl demand materializes.    |
+| **F: Manual publish via local `nuget push`** | No CI complexity                                                     | Bus factor of 1; version drift risk; no audit trail                                          | Fails the "automatic CI/CD" requirement                                                        |
+| **G: Publish to GitHub Packages NuGet feed** | Same GitHub ecosystem; no new account                                | ADO pipelines must authenticate to GitHub Packages (requires PAT), defeating "public feed" UX | Contradicts user-stated ADO-consumer scenario                                                  |
+| **H (selected): Fan-out workflow on release:published** | Reuses cargo-dist artifacts; zero changes elsewhere; OIDC auth; decoupled failure | Bound to cargo-dist's target matrix; hand-rolled ~80-line workflow                           | **Selected:** smallest diff, lowest risk, matches existing `update-latest-release.yml` pattern |
+
+## 7. Cross-Cutting Concerns
+
+### 7.1 Security and Privacy
+
+- **Authentication path.** NuGet Trusted Publishing (OIDC) is the primary path; the workflow requests a GitHub OIDC ID token (`id-token: write`), `NuGet/login@v1` exchanges it for a short-lived (~1h, single-use) nuget.org API key bound to a pre-configured policy. No long-lived secret is used.
+- **Fallback authentication.** `NUGET_API_KEY` is a repository secret, scoped via nuget.org API-key glob to `aipm*`. Quarterly rotation recommended if the fallback path is ever exercised.
+- **Policy binding.** The Trusted Publishing policy is configured on nuget.org with: `repo_owner=TheLarkInn`, `repo=aipm`, `workflow_file=release-nuget.yml`. This means a malicious fork, a renamed workflow, or a copied repo cannot publish. First successful publish fuses the policy to GitHub's immutable repo/owner IDs.
+- **Fork safety.** Release events do not fire in forks (`release:published` is repo-scoped), and forks do not receive the `id-token` nor the `NUGET_*` secrets even if triggered. Tested by GitHub Actions' standard secret-masking behavior.
+- **Package signing.** We do not author-sign. nuget.org repository-signs every package automatically on ingest; consumers validate the repo signature transitively.
+- **Supply-chain attestation.** The existing `release.yml` already emits `actions/attest-build-provenance@v3` attestations for the underlying binaries ([`release.yml:151-154`](../.github/workflows/release.yml)). The NuGet package repackages those attested binaries; we do not emit a second attestation for the nupkg in v1. Future work: add `actions/attest-build-provenance@v3` at the nupkg level.
+- **`id-token: write` scope.** Scoped to the `publish` job only; other jobs (if added later) don't inherit it.
+- **Secret exposure.** `NUGET_USERNAME` is a public handle, low sensitivity. `NUGET_API_KEY` is masked in logs by GitHub Actions.
+- **Threat model.**
+  - Compromised GitHub token → limited blast radius; OIDC policy requires `repo=aipm`, `workflow_file=release-nuget.yml`.
+  - Compromised NUGET_API_KEY → attacker could push malicious versions. Mitigation: glob-scope the key to `aipm*`, rotate quarterly, remove once OIDC is stable across all publishes.
+  - Compromised nuget.org session → account-level compromise; out of scope for this spec.
+
+### 7.2 Observability Strategy
+
+- **Built-in GitHub Actions logs.** Each step streams to the GitHub UI; failures are visible in the Actions tab.
+- **Notifications.** None new in v1. If GitHub Actions email/Slack notifications are already configured at the org level, they cover this workflow for free.
+- **Unlikely, but worth noting:** nuget.org does not have a public webhook or ingest-status API. We trust `dotnet nuget push` exit code as the source of truth.
+- **Post-publish verification (optional).** A follow-up step could `curl https://api.nuget.org/v3-flatcontainer/aipm/index.json` and assert the new version appears. Not in v1.
+- **Alerting.** None configured. If a publish fails, the release still succeeds on GitHub and crates.io — this is a **detached failure domain** by design.
+
+### 7.3 Scalability and Capacity Planning
+
+- **Package size budget.** Four RIDs × ~5 MB per stripped binary = **~20 MB per nupkg**. Well under the nuget.org 250 MB cap ([NuGet.org FAQ](https://learn.microsoft.com/en-us/nuget/nuget-org/nuget-org-faq)). Headroom for 7 RIDs would still be ~35 MB.
+- **Release cadence.** release-plz fires when `main` has conventional commits. Observed cadence: multiple releases per week, occasionally per day. Each release publishes one nupkg.
+- **nuget.org rate limits.** Undocumented but generous; one push per release is nowhere near any threshold.
+- **Workflow runtime.** Expected ~3-5 min end-to-end (checkout + gh release download + unpack + setup-dotnet + setup-nuget + pack + push). The `timeout-minutes: 20` gives a large safety margin.
+- **GitHub Actions minute cost.** Single Ubuntu job, ~5 min per release — trivial against the free-tier budget for public repos.
+
+## 8. Migration, Rollout, and Testing
+
+### 8.1 Deployment Strategy
+
+This is additive, not a migration. No existing behavior changes. Rollout:
+
+- [ ] **Phase 0 (pre-merge):** Create nuget.org account for `TheLarkInn` if not already owned. Configure Trusted Publishing policy binding `repo_owner=TheLarkInn, repo=aipm, workflow_file=release-nuget.yml`. Generate a fallback API key scoped to `aipm*`, store as `NUGET_API_KEY` and `NUGET_USERNAME` in GitHub repo secrets.
+- [ ] **Phase 1 (dry-run via `workflow_dispatch`):** Temporarily add `workflow_dispatch` to the trigger, add `--dry-run` equivalent by overriding the push step to `echo`, merge behind an inactive trigger, run manually on the tip of an existing release tag to verify pack succeeds and the nupkg structure is correct. Inspect locally.
+- [ ] **Phase 2 (alpha publish):** Tag an `aipm-v0.22.4-alpha.1` release. Temporarily relax the `!prerelease` guard. Verify the package appears on nuget.org under a pre-release version. **Unlist** the alpha package immediately (it's for validation only). Restore the `!prerelease` guard.
+- [ ] **Phase 3 (first stable):** Cut the next regular `aipm-v0.22.x` release. Verify publish to nuget.org. Verify ADO consumer pattern from `research/docs/2026-04-22-ado-pipeline-nuget-consume.md` section 5 resolves the package on a test pipeline.
+- [ ] **Phase 4 (steady-state):** All subsequent releases publish automatically. Update [`README.md`](../README.md) installation section to add a "NuGet" row.
+
+### 8.2 Data Migration Plan
+
+No data to migrate. New package ID starts at the current workspace version (`0.22.3` or whatever the next `aipm-v*` tag is).
+
+### 8.3 Test Plan
+
+**Unit tests:** None applicable. The nuspec and workflow are configuration, not code.
+
+**Integration tests:**
+
+- [ ] **Nuspec validity.** `nuget pack` locally against a fixture `runtimes/` tree with dummy binaries. Verify `-Properties` substitution works for `$version$` and `$commit$`.
+- [ ] **Layout assertion.** `unzip -l aipm.0.0.0.nupkg | grep runtimes/` in CI sanity-check step (already in the workflow). Fail the workflow if fewer than 4 runtimes/ entries.
+- [ ] **Version derivation.** Test the `${TAG#aipm-v}` strip against tags like `aipm-v0.22.3`, `aipm-v1.0.0-beta.1` (the latter should be filtered out upstream by the `!prerelease` guard, but the stripper should still work).
+- [ ] **Idempotency.** Re-run the workflow on the same release and confirm `--skip-duplicate` makes it a no-op with exit code 0.
+
+**End-to-end tests:**
+
+- [ ] **Consumer pipeline smoke test.** Create a disposable Azure DevOps project containing the ADO YAML from [`research/docs/2026-04-22-ado-pipeline-nuget-consume.md`](../research/docs/2026-04-22-ado-pipeline-nuget-consume.md) section 5. Run against each of the three Microsoft-hosted images (ubuntu-latest, windows-latest, macOS-latest). Verify `aipm --version` prints the expected version.
+- [ ] **Restore-in-csproj smoke test.** Create a throwaway csproj in an external repo with `<PackageDownload Include="aipm" Version="[0.22.3]" />`, run `dotnet restore`, confirm the binary materializes at `~/.nuget/packages/aipm/0.22.3/runtimes/<RID>/native/aipm[.exe]`.
+- [ ] **OIDC fallback path.** Intentionally break OIDC (e.g., by temporarily removing the Trusted Publishing policy on nuget.org) and verify the `NUGET_API_KEY` fallback step runs and succeeds. Restore the policy after.
+
+**Security tests:**
+
+- [ ] **Fork cannot publish.** Confirm that a fork of `TheLarkInn/aipm` cannot trigger the workflow with a malicious tag. (Release events don't fire on forks; documented upstream.)
+- [ ] **Renamed workflow cannot publish.** Rename `release-nuget.yml` in a branch, observe the OIDC exchange fails because the filename no longer matches the policy binding.
+
+## 9. Open Questions / Unresolved Issues
+
+All nine original research-level questions have been resolved (see the decision table in the transcript of this spec's genesis). The remaining spec-level unknowns that block `Approved` status:
+
+- [ ] **nuget.org account creation.** Does a `TheLarkInn` or `selarkin` nuget.org account already exist? If no, who creates it and when?
+- [ ] **Trusted Publishing rollout status on the target account.** Is the "Trusted Publishing" tab visible on the account today, or do we need to request enrollment? Feeds the decision to rely on OIDC as primary vs. API-key as primary for v1.
+- [ ] **`NUGET_API_KEY` scope glob on creation.** The fallback key should be scoped to package ID glob `aipm*` (not just `aipm`) to allow future satellite package IDs. Confirm the glob at key-creation time.
+- [ ] **README update wording.** Who owns the doc change to add the NuGet row? In-scope for this spec or a follow-up PR?
+- [ ] **Package icon asset.** The nuspec references `icon` in some variants but the v1 spec omits it. Decision: ship v1 without an icon (nuget.org shows a generic placeholder), add in v1.1 once an asset exists. If an icon exists already, point to its path.
+- [ ] **Rollback procedure documentation.** Need a short runbook: "If we publish a broken version, the procedure is: (1) unlist on nuget.org immediately, (2) cut a patch release, (3) publish the patch." This could live in a new `RELEASING.md` or as a comment in `release-nuget.yml`.
+- [ ] **GitHub Environments usage.** Round 1 decided against a manual gate, but we may still want a GitHub `release` Environment declared (without required reviewers) for audit-trail visibility on the Deployments tab. Optional; not a blocker.
+- [ ] **Post-publish attestation for the nupkg.** cargo-dist attests the binaries; should we also attest the repacked nupkg? Pushing this to v2 unless a supply-chain-review stakeholder asks.
+
+## Appendix A — Referenced Files
+
+Existing files with GitHub permalinks at commit `5616fd4`:
+
+- [`.github/workflows/release.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/release.yml) — cargo-dist release orchestration
+- [`.github/workflows/release-plz.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/release-plz.yml) — crates.io + tag creation
+- [`.github/workflows/update-latest-release.yml`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/update-latest-release.yml) — pattern this spec mirrors
+- [`.github/workflows/update-latest-release.yml:20`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/.github/workflows/update-latest-release.yml#L20) — the `startsWith(tag_name, 'aipm-v') && !prerelease` guard copied into the new workflow
+- [`dist-workspace.toml:15-20`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/dist-workspace.toml#L15-L20) — the 4-target matrix this spec consumes
+- [`Cargo.toml:10`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L10) — workspace version (lockstep)
+- [`Cargo.toml:185`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/Cargo.toml#L185) — `[profile.release] strip = "symbols"` justifying no .snupkg
+- [`crates/aipm/Cargo.toml:2`](https://github.com/TheLarkInn/aipm/blob/5616fd4db5d41b77df55686365308cf12701af2a/crates/aipm/Cargo.toml#L2) — binary name `aipm`
+
+New files to be created:
+
+- `packaging/aipm.nuspec` — package metadata
+- `.github/workflows/release-nuget.yml` — the publish workflow
+
+## Appendix B — Research References
+
+- [`research/docs/2026-04-22-nuget-publishing-pipeline.md`](../research/docs/2026-04-22-nuget-publishing-pipeline.md) — main synthesis
+- [`research/docs/2026-04-22-nuget-native-multi-rid-packaging.md`](../research/docs/2026-04-22-nuget-native-multi-rid-packaging.md) — .nuspec schema, runtimes layout, package-type choice
+- [`research/docs/2026-04-22-github-actions-nuget-publish.md`](../research/docs/2026-04-22-github-actions-nuget-publish.md) — Trusted Publishing (OIDC), cross-compilation alternatives, versioning
+- [`research/docs/2026-04-22-ado-pipeline-nuget-consume.md`](../research/docs/2026-04-22-ado-pipeline-nuget-consume.md) — ADO YAML consumer pattern
+- [`specs/2026-03-16-ci-cd-release-automation.md`](2026-03-16-ci-cd-release-automation.md) — original CI/CD spec (target matrix baseline)
+- [`specs/2026-03-19-cargo-dist-installers.md`](2026-03-19-cargo-dist-installers.md) — cargo-dist adoption spec (current distribution channels)
+- [`specs/2026-04-20-azure-devops-lint-reporter-enrichment.md`](2026-04-20-azure-devops-lint-reporter-enrichment.md) — prior ADO integration work


### PR DESCRIPTION
## Summary

Adds automatic nuget.org publishing so `aipm` can be installed and used in Azure DevOps pipelines via `dotnet restore`.

- **Three new files**: `packaging/aipm.nuspec`, `.github/workflows/release-nuget.yml` (workflow_dispatch-only for safety), `RELEASING.md` operational runbook
- **Docs**: NuGet shields badge + new "Azure DevOps Pipeline (NuGet)" install subsection in `README.md`
- **Research & spec**: four research docs (`research/docs/2026-04-22-*.md`) and one spec (`specs/2026-04-22-nuget-publishing-pipeline.md`) documenting the design

## Design

**Fan-out on `release:published`.** The workflow listens to the GitHub Release created by the existing `release.yml` (cargo-dist), downloads the 4 platform archives, repacks them into `runtimes/<RID>/native/` inside a single `aipm.<version>.nupkg`, and pushes to nuget.org. Zero changes to `release.yml`, `release-plz.yml`, `dist-workspace.toml`, or any Rust.

**Package shape.** Single `aipm` ID, no `<packageTypes>` (defaults to `Dependency`). Ships 4 RIDs for v1: `win-x64`, `linux-x64`, `osx-x64`, `osx-arm64` — matching cargo-dist's current target matrix.

**Auth.** NuGet Trusted Publishing (OIDC, GA 2025-09-22) primary via `NuGet/login@v1`, with `NUGET_API_KEY` fallback via `continue-on-error` + conditional push steps. `NUGET_USERNAME` + `NUGET_API_KEY` already configured as repo secrets.

## Safety: workflow_dispatch-only for v1

The workflow ships with `workflow_dispatch` trigger **only**. The `release:published` trigger is intentionally omitted from this PR — it will be added in a follow-up PR (tracked as feature #6b in `research/feature-list.json`) after Phase 1 dry-run validates end-to-end packing against a real `aipm-v*` tag. This means merging this PR will **not** auto-publish anything to nuget.org.

## Key decisions (all eight resolved with user)

| # | Decision |
|---|---|
| RID scope | 4 RIDs for v1 (matches cargo-dist matrix) |
| Auth | OIDC Trusted Publishing + API-key fallback |
| Account | Personal nuget.org account (TheLarkInn) |
| Gate | Fully automated on `release:published`, `!prerelease` |
| MSBuild | Bare `runtimes/` layout, no `build/aipm.targets` |
| Tags | Stable releases only |
| DotnetTool | Not in scope for v1 |
| Filename | `release-nuget.yml` (matches TP policy binding) |

## Testing performed

- `cargo-verifier` subagent ran all quality gates post-change: build PASS, test PASS, clippy PASS (no `-D warnings`), fmt PASS, coverage PASS at **89.33%** (required 89%). Non-Rust changes, so this was a sanity check that nothing broke.
- Workflow YAML manually reviewed against the spec §5.4 reference implementation.
- Nuspec reviewed against Microsoft Learn canonical layout for native multi-RID packages.

End-to-end pipeline testing is **not** possible until this PR merges and the `workflow_dispatch` trigger can be invoked against a real release tag — that's Phase 1 in the rollout plan.

## Test plan

- [ ] Merge this PR.
- [ ] **Phase 1 dry-run**: Go to Actions → Publish to NuGet → Run workflow. Enter an existing `aipm-v*` tag (e.g., current latest). Verify all steps pass end-to-end, including the sanity-check that asserts >= 4 `runtimes/<RID>/native/aipm` entries. Verify the package appears on nuget.org.
- [ ] If Phase 1 succeeds, open a follow-up PR adding `release: { types: [published] }` to the `on:` block (feature #6b).
- [ ] **Phase 2 alpha**: cut `aipm-v*-alpha.1`, temporarily relax `!prerelease` guard, verify publish, then unlist.
- [ ] **Phase 3 first stable**: let the next stable release-plz merge flow through; verify automatic publish.
- [ ] **Phase 4 consumers**: ADO pipeline smoke test across `ubuntu-latest`, `windows-latest`, `macOS-latest`; external `dotnet restore`-in-csproj smoke test.
- [ ] **Security checks**: verify a fork cannot publish; verify a renamed workflow file fails the OIDC policy binding.

## Follow-up items

- **Feature #6b** (trigger flip): tracked in `research/feature-list.json` as a pending docs/infra task.
- **Spec status flip**: `specs/2026-04-22-nuget-publishing-pipeline.md` remains `Draft (WIP)` until the rollout completes; feature #17 flips it to `Implemented`.
- **Package icon**: currently omitted; add once an asset exists (v1.1).
- **Prefix reservation**: deferred until satellite packages (`aipm.Foo`) ship.
- **cargo-dist NuGet feature request**: optional upstream ask to reduce the hand-rolled YAML in the long term.

## References

- Spec: [`specs/2026-04-22-nuget-publishing-pipeline.md`](specs/2026-04-22-nuget-publishing-pipeline.md)
- Research synthesis: [`research/docs/2026-04-22-nuget-publishing-pipeline.md`](research/docs/2026-04-22-nuget-publishing-pipeline.md)
- Packaging deep dive: [`research/docs/2026-04-22-nuget-native-multi-rid-packaging.md`](research/docs/2026-04-22-nuget-native-multi-rid-packaging.md)
- Publishing flow: [`research/docs/2026-04-22-github-actions-nuget-publish.md`](research/docs/2026-04-22-github-actions-nuget-publish.md)
- ADO consumer pattern: [`research/docs/2026-04-22-ado-pipeline-nuget-consume.md`](research/docs/2026-04-22-ado-pipeline-nuget-consume.md)
- Runbook: [`RELEASING.md`](RELEASING.md)