### PR TITLE
chore: release v0.22.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1146,7 +1146,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.22.3"
+version = "0.22.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.22.3" }
+libaipm = { path = "crates/libaipm", version = "0.22.4" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.4] - 2026-04-24
+
+### Features
+- Automatic nuget.org publishing pipeline ([#651](https://github.com/TheLarkInn/aipm/pull/651)) (134d94a)
+
+### Miscellaneous
+- Release v0.22.3 ([#607](https://github.com/TheLarkInn/aipm/pull/607)) (78d3d4b)
+
+### Testing
+- Cover apply_rule_diagnostics branches in lint/mod.rs (d6624b0)
+- Cover load_lint_config 'allow' string override branch (473dcc8)
+- Cover ci-github and ci-azure reporter branches in cmd_lint (6b6a883)
+- Cover cmd_lint error path and string severity config override (fa0ae63)
+- Cover lint_file_diagnostics Err branch (855ea47)
+
 ## [0.22.3] - 2026-04-20
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.4] - 2026-04-24
+
+### Features
+- Automatic nuget.org publishing pipeline ([#651](https://github.com/TheLarkInn/aipm/pull/651)) (134d94a)
+
+### Miscellaneous
+- Release v0.22.3 ([#607](https://github.com/TheLarkInn/aipm/pull/607)) (78d3d4b)
+
+### Testing
+- Cover CiAzure warning_count==0 branch in reporter (a22aa73)
+- Cover download() with success, version-not-found, and checksum-mismatch tests (349c419)
+- Cover adaptor.apply() false branch (c7e6632)
+- Cover apply_rule_diagnostics branches in lint/mod.rs (d6624b0)
+- Cover is_external and matches! guard branches (67911a8)
+- Cover Rule trait methods and migrate edge-case paths (1e8b226)
+- Cover ColorChoice::Always path through Human::report() (802e642)
+- Cover uncovered feature-activation branches (1c12ffc)
+- Cover write_cleanup_plan skip-shared-config in recursive report (94851ea)
+- Cover cache_policy and cache_ttl_secs update branches (0c1d984)
+- Cover detectors.is_empty() fallback branch in migrate_single_source (7291b8a)
+- Add coverage for emitter write-failure and edge-case branches (0b28c4c)
+- Cover DiscoveredSource::claude_dir() backward-compat alias (a131d20)
+- Cover cmd_lint error path and string severity config override (fa0ae63)
+- Cover unrecognized-file skip branch in discover_features (0933f87)
+- Cover format_errors branches in Error::Multiple display (0a66bb5)
+
 ## [0.22.3] - 2026-04-20
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.22.3 -> 0.22.4 (✓ API compatible changes)
* `aipm`: 0.22.3 -> 0.22.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.22.4] - 2026-04-24

### Features
- Automatic nuget.org publishing pipeline ([#651](https://github.com/TheLarkInn/aipm/pull/651)) (134d94a)

### Miscellaneous
- Release v0.22.3 ([#607](https://github.com/TheLarkInn/aipm/pull/607)) (78d3d4b)

### Testing
- Cover CiAzure warning_count==0 branch in reporter (a22aa73)
- Cover download() with success, version-not-found, and checksum-mismatch tests (349c419)
- Cover adaptor.apply() false branch (c7e6632)
- Cover apply_rule_diagnostics branches in lint/mod.rs (d6624b0)
- Cover is_external and matches! guard branches (67911a8)
- Cover Rule trait methods and migrate edge-case paths (1e8b226)
- Cover ColorChoice::Always path through Human::report() (802e642)
- Cover uncovered feature-activation branches (1c12ffc)
- Cover write_cleanup_plan skip-shared-config in recursive report (94851ea)
- Cover cache_policy and cache_ttl_secs update branches (0c1d984)
- Cover detectors.is_empty() fallback branch in migrate_single_source (7291b8a)
- Add coverage for emitter write-failure and edge-case branches (0b28c4c)
- Cover DiscoveredSource::claude_dir() backward-compat alias (a131d20)
- Cover cmd_lint error path and string severity config override (fa0ae63)
- Cover unrecognized-file skip branch in discover_features (0933f87)
- Cover format_errors branches in Error::Multiple display (0a66bb5)
</blockquote>

## `aipm`

<blockquote>

## [0.22.4] - 2026-04-24

### Features
- Automatic nuget.org publishing pipeline ([#651](https://github.com/TheLarkInn/aipm/pull/651)) (134d94a)

### Miscellaneous
- Release v0.22.3 ([#607](https://github.com/TheLarkInn/aipm/pull/607)) (78d3d4b)

### Testing
- Cover apply_rule_diagnostics branches in lint/mod.rs (d6624b0)
- Cover load_lint_config 'allow' string override branch (473dcc8)
- Cover ci-github and ci-azure reporter branches in cmd_lint (6b6a883)
- Cover cmd_lint error path and string severity config override (fa0ae63)
- Cover lint_file_diagnostics Err branch (855ea47)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).