### PR TITLE
fix(nuget): handle flat Windows zip layout from cargo-dist

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -99,7 +99,10 @@ jobs:
             if [[ "$triple" == *windows* ]]; then
               archive="archives/aipm-${triple}.zip"
               test -f "$archive" || { echo "::error::Missing $archive"; exit 1; }
-              unzip -j "$archive" '*/aipm.exe' -d "pkg/runtimes/$rid/native/"
+              # cargo-dist's Windows zip is FLAT (aipm.exe at archive root), while
+              # Unix tarballs use a subdirectory. Pattern '*aipm.exe' matches both
+              # flat and nested layouts so we're robust against future changes.
+              unzip -j "$archive" '*aipm.exe' -d "pkg/runtimes/$rid/native/"
             else
               archive="archives/aipm-${triple}.tar.xz"
               test -f "$archive" || { echo "::error::Missing $archive"; exit 1; }


### PR DESCRIPTION
## Summary

One-line fix for the bug that crashed the first Phase 1 dry-run ([run 24903987161](https://github.com/TheLarkInn/aipm/actions/runs/24903987161/job/72928548482)).

cargo-dist's archive layouts are **asymmetric**:

| Archive | Layout | Binary location |
|---|---|---|
| `aipm-*.tar.xz` (Unix) | `aipm-<triple>/` subdirectory | `aipm-<triple>/aipm` |
| `aipm-*.zip` (Windows) | **Flat — no subdirectory** | `aipm.exe` at root |

The workflow's original pattern `'*/aipm.exe'` required a leading directory component, which matched the Unix layout but failed on the flat Windows zip with:

```
Archive:  archives/aipm-x86_64-pc-windows-msvc.zip
caution: filename not matched:  */aipm.exe
##[error]Process completed with exit code 11.
```

Switching to `'*aipm.exe'` (no leading slash) matches both flat and nested layouts, so we're robust against any future cargo-dist change.

## Impact

- The failed run stopped at the **unpack step**, before pack or push. **No partial package was sent to nuget.org** — `aipm 0.22.3` is still unpublished.
- After this merges, re-running the workflow with `tag = aipm-v0.22.3` should succeed end-to-end.

## Testing

- Verified locally: downloaded `aipm-x86_64-pc-windows-msvc.zip` from the v0.22.3 release, confirmed flat layout via `unzip -l`, ran both `'aipm.exe'` and `'*aipm.exe'` patterns successfully.
- Unix tarball extraction path unchanged and previously confirmed working in the same failed run (the Windows branch of the loop was the sole failure).

## Test plan

- [ ] Merge this PR
- [ ] Re-run the workflow: Actions → Publish to NuGet → Run workflow → `tag: aipm-v0.22.3`
- [ ] Verify all steps complete green through to the `dotnet nuget push` step
- [ ] Verify `https://www.nuget.org/packages/aipm/0.22.3` shows the package