### PR TITLE
fix(nuget): install mono for nuget.exe on Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -123,6 +123,17 @@ jobs:
       - name: Set up NuGet CLI
         uses: nuget/setup-nuget@v2
 
+      - name: Install mono (nuget.exe runtime on Linux)
+        # ubuntu-latest (24.04) no longer ships mono pre-installed, but
+        # nuget.exe is a .NET Framework binary that requires it. Installing
+        # mono-devel (~200 MB, ~20 s) covers the System.Net.Http assemblies
+        # nuget pack / push need. Forward-looking alternative: migrate to
+        # `dotnet pack` + stub csproj once .NET 10's -p:NuspecFile stabilizes.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends mono-devel
+          mono --version | head -1
+
       - name: Pack
         working-directory: pkg
         run: |


### PR DESCRIPTION
## Summary

Second hot-fix for the NuGet publish workflow. First Phase 1 dry-run ([run 24904173472](https://github.com/TheLarkInn/aipm/actions/runs/24904173472/job/72929159585)) cleared the Windows-zip unpack (#654 fix worked) but failed at the **Pack** step:

```
/opt/hostedtoolcache/nuget.exe/7.3.1/x64/nuget: 2: mono: not found
##[error]Process completed with exit code 127.
```

## Root cause

`nuget.exe` is a .NET Framework binary that requires `mono` to run on Linux. `nuget/setup-nuget@v2` downloads the binary but doesn't install a runtime. Previously this worked only because `ubuntu-22.04` hosted runners shipped mono pre-installed — `ubuntu-latest` is now Ubuntu 24.04 which does not.

Microsoft's own docs flag this as the reason the Azure DevOps `NuGetCommand@2` task is in maintenance mode: the whole nuget.exe-on-Linux ecosystem is aging out.

## Fix

Add an apt-get step to install `mono-devel` before the Pack step:

```yaml
- name: Install mono (nuget.exe runtime on Linux)
  run: |
    sudo apt-get update
    sudo apt-get install -y --no-install-recommends mono-devel
    mono --version | head -1
```

- `mono-devel` (~200 MB) covers the System.Net.Http assemblies nuget.exe uses.
- `--no-install-recommends` keeps the surface minimal.
- `mono --version` at the end surfaces the installed version in the log for debugging.
- Total added runtime: ~20 s per publish run.

## Impact

Run 24904173472 failed at Pack (step 6), **before push**, so `aipm 0.22.3` is still unpublished. After this merges, re-running the workflow with `tag = aipm-v0.22.3` should complete end-to-end.

## Longer-term migration note

The comment in the workflow flags the forward-looking alternative: switch to `dotnet pack` with a stub csproj (or .NET 10's direct `-p:NuspecFile` support when stable) so we can drop the nuget.exe + mono chain entirely. Out of scope for this hot-fix.

## Test plan

- [ ] Merge this PR
- [ ] Actions → Publish to NuGet → Run workflow → `tag: aipm-v0.22.3`
- [ ] Verify mono install step succeeds (~20 s, prints mono version)
- [ ] Verify Pack step succeeds and produces `out/aipm.0.22.3.nupkg`
- [ ] Verify sanity-check asserts 4 RID entries
- [ ] Verify OIDC login + push succeed
- [ ] Verify `https://www.nuget.org/packages/aipm/0.22.3` shows the package