### PR TITLE
fix(nuget): set -BasePath . so pack resolves runtimes/ in pkg/

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -138,9 +138,14 @@ jobs:
         working-directory: pkg
         run: |
           set -euo pipefail
+          # -BasePath . tells nuget.exe to resolve <file src="..."> entries
+          # against CWD (pkg/) instead of the directory containing the nuspec
+          # (packaging/). Without this, nuget looks for packaging/runtimes/*
+          # and fails with "Could not find a part of the path".
           nuget pack ../packaging/aipm.nuspec \
             -Version "${{ steps.ver.outputs.version }}" \
             -Properties "version=${{ steps.ver.outputs.version }};commit=${{ github.sha }}" \
+            -BasePath . \
             -NoDefaultExcludes \
             -NonInteractive \
             -OutputDirectory ../out


### PR DESCRIPTION
## Summary

Third hot-fix for the NuGet publish workflow. [Run 24904392109](https://github.com/TheLarkInn/aipm/actions/runs/24904392109/job/72929896266) cleared the Windows-zip fix (#654) and the mono install (#655), then failed at Pack with:

```
Attempting to build package from 'aipm.nuspec'.
Could not find a part of the path '/home/runner/work/aipm/aipm/packaging/runtimes'.
##[error]Process completed with exit code 1.
```

## Root cause

`nuget.exe pack` resolves `<file src="...">` entries **relative to the nuspec's directory** (`packaging/`), not the shell CWD. My `cd pkg` + `../packaging/aipm.nuspec` trick assumed CWD would be the source base — it isn't. The nuspec's `<file src="runtimes\**" ... />` was being looked up at `packaging/runtimes/`, which doesn't exist.

## Fix

Add `-BasePath .` to the `nuget pack` invocation:

```diff
       - name: Pack
         working-directory: pkg
         run: |
           set -euo pipefail
           nuget pack ../packaging/aipm.nuspec \
             -Version "${{ steps.ver.outputs.version }}" \
             -Properties "version=${{ steps.ver.outputs.version }};commit=${{ github.sha }}" \
+            -BasePath . \
             -NoDefaultExcludes \
             -NonInteractive \
             -OutputDirectory ../out
```

With `working-directory: pkg`, CWD is `pkg/`, so `-BasePath .` points at the directory where the earlier unpack step staged:
- `pkg/runtimes/<RID>/native/aipm[.exe]` (all 4 RIDs)
- `pkg/README.md`
- `pkg/LICENSE`

## Impact

Run 24904392109 failed at Pack (step 7), **before push**. `aipm 0.22.3` is still unpublished. After this merges, re-running with `tag: aipm-v0.22.3` should complete end-to-end — we've now passed:

- ✅ Tag resolve
- ✅ Release download
- ✅ Windows zip unpack (#654)
- ✅ Unix tarball unpack
- ✅ File staging
- ✅ setup-dotnet
- ✅ setup-nuget
- ✅ mono install (#655)
- 🔜 Pack — needs this PR

And pending after:

- 🔜 Sanity check (4-RID entry assertion)
- 🔜 NuGet OIDC login (Trusted Publishing)
- 🔜 Push

## Test plan

- [ ] Merge this PR
- [ ] Actions → Publish to NuGet → Run workflow → `tag: aipm-v0.22.3`
- [ ] Verify Pack step produces `out/aipm.0.22.3.nupkg`
- [ ] Verify sanity check logs 4 `runtimes/<RID>/native/aipm[.exe]` entries
- [ ] Verify OIDC login succeeds (Trusted Publishing → short-lived API key)
- [ ] Verify `dotnet nuget push` succeeds
- [ ] Verify `https://www.nuget.org/packages/aipm/0.22.3` displays the package