### PR TITLE
fix(nuget): normalize nuspec paths for mono compatibility

### DIFF
--- a/packaging/aipm.nuspec
+++ b/packaging/aipm.nuspec
@@ -11,13 +11,16 @@
                 url="https://github.com/TheLarkInn/aipm.git"
                 branch="main"
                 commit="$commit$" />
-    <readme>docs\README.md</readme>
+    <readme>docs/README.md</readme>
     <tags>ai claude copilot plugin-manager cli rust native cross-platform azure-devops</tags>
     <copyright>Copyright (c) 2026 Sean Larkin</copyright>
   </metadata>
   <files>
-    <file src="runtimes\**" target="runtimes" />
-    <file src="README.md" target="docs\" />
-    <file src="LICENSE" target="" />
+    <!-- Forward slashes + explicit target filenames (no empty target="",
+         no trailing separator) avoid mono nuget.exe's "String cannot be
+         empty. Parameter name: entryName" failure when building the ZIP. -->
+    <file src="runtimes/**" target="runtimes/" />
+    <file src="README.md" target="docs/README.md" />
+    <file src="LICENSE" target="LICENSE" />
   </files>
 </package>


### PR DESCRIPTION
## Summary

Fourth hot-fix. [Run 24904613922](https://github.com/TheLarkInn/aipm/actions/runs/24904613922/job/72930676598) cleared the BasePath fix (#657) but Pack failed with:

```
Attempting to build package from 'aipm.nuspec'.
String cannot be empty.
Parameter name: entryName
```

## Root cause

`entryName` is the parameter to `ZipArchive.CreateEntry`. nuget.exe was trying to add zip entries with empty or malformed names because of three nuspec quirks Windows-native nuget.exe tolerates but mono's port does not:

| Nuspec | Issue |
|---|---|
| `<file src="LICENSE" target="" />` | Empty `target=""` → empty entry name → `ArgumentException` |
| `<file src="README.md" target="docs\" />` | Trailing backslash with no filename → mono interprets literally and the readme metadata pointer misses |
| `<readme>docs\README.md</readme>` | Backslash paths are historically Windows-only; mono resolves inconsistently |

## Fix

Normalize to forward slashes + explicit target filenames:

```diff
-    <readme>docs\README.md</readme>
+    <readme>docs/README.md</readme>
...
-    <file src="runtimes\**" target="runtimes" />
-    <file src="README.md" target="docs\" />
-    <file src="LICENSE" target="" />
+    <file src="runtimes/**" target="runtimes/" />
+    <file src="README.md" target="docs/README.md" />
+    <file src="LICENSE" target="LICENSE" />
```

No empty targets. No trailing-separator ambiguity. Every file path is a full explicit filename or a directory-glob with trailing `/`.

## Impact

Run 24904613922 died at Pack **before `dotnet nuget push`**. `aipm 0.22.3` is still unpublished. After this merges, the retry should clear Pack and move on to sanity-check → OIDC login → push.

## Larger observation

This is the fourth fix in a row against the same workflow. Each has been a real bug only a real run could surface, but we've accumulated enough friction with the `nuget.exe` + `mono` + nuspec-quirks chain that it's starting to look like a smell.

**Follow-up worth filing after Phase 1 completes**: migrate the Pack step from `nuget pack` to `dotnet pack` with a stub `packaging/aipm-pack.csproj`. That drops `nuget/setup-nuget@v2`, the mono install, and most of the nuspec-on-mono fragility. The nuspec itself survives unchanged; only the invocation changes.

## Workflow progress

| Step | Status |
|---|---|
| Tag resolve | ✅ |
| Release download | ✅ |
| Unpack (Windows zip) | ✅ fixed in #654 |
| Unpack (Unix tarball) | ✅ |
| File staging | ✅ |
| setup-dotnet, setup-nuget | ✅ |
| Install mono | ✅ fixed in #655 |
| Pack — BasePath | ✅ fixed in #657 |
| **Pack — nuspec paths** | 🔜 fixed in **this PR** |
| Sanity check (4-RID) | ⏳ not reached |
| NuGet OIDC login | ⏳ not reached |
| Push | ⏳ not reached |

## Test plan

- [ ] Merge
- [ ] Actions → Publish to NuGet → Run workflow → `tag: aipm-v0.22.3`
- [ ] Verify Pack produces `out/aipm.0.22.3.nupkg` without `entryName` errors
- [ ] Verify sanity-check asserts 4 RID entries
- [ ] Verify OIDC login + push succeed
- [ ] Verify `https://www.nuget.org/packages/aipm/0.22.3` displays the package