### PR TITLE
fix(docs): use bundled Microsoft.NET.Sdk for ADO consumer snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,21 +44,39 @@ steps:
     inputs: { packageType: sdk, version: 8.x }
 
   - pwsh: |
-      New-Item -ItemType Directory -Force -Path "$(Agent.TempDirectory)/aipm-fetch" | Out-Null
+      $dir = "$(Agent.TempDirectory)/aipm-fetch"
+      New-Item -ItemType Directory -Force -Path $dir | Out-Null
+      # Microsoft.NET.Sdk is bundled with the .NET SDK installed by UseDotNet@2,
+      # so the project file parses without an extra NuGet fetch for the SDK itself.
       @'
-      <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+      <Project Sdk="Microsoft.NET.Sdk">
         <PropertyGroup>
           <TargetFramework>net8.0</TargetFramework>
+          <NoBuild>true</NoBuild>
+          <IncludeBuildOutput>false</IncludeBuildOutput>
+          <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
           <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
         </PropertyGroup>
         <ItemGroup>
           <PackageDownload Include="aipm" Version="[$(env:AIPM_VERSION)]" />
         </ItemGroup>
       </Project>
-      '@ | Set-Content "$(Agent.TempDirectory)/aipm-fetch/fetch.csproj"
+      '@ | Set-Content "$dir/fetch.csproj"
+      # Pin nuget.org as the only source so the agent's default config (which
+      # may include offline / internal feeds) cannot reroute the restore.
+      @'
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <clear />
+          <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        </packageSources>
+      </configuration>
+      '@ | Set-Content "$dir/nuget.config"
     displayName: 'Generate aipm download-only project'
 
   - script: dotnet restore "$(Agent.TempDirectory)/aipm-fetch/fetch.csproj"
+    displayName: 'Restore aipm from nuget.org'
 
   - pwsh: |
       switch ("$(Agent.OS)") { 'Windows_NT'{$o='win';$x='aipm.exe'} 'Linux'{$o='linux';$x='aipm'} 'Darwin'{$o='osx';$x='aipm'} }

--- a/research/docs/2026-04-22-ado-pipeline-nuget-consume.md
+++ b/research/docs/2026-04-22-ado-pipeline-nuget-consume.md
@@ -43,24 +43,28 @@ This is exactly aipm's use case. Key properties:
 - Dependencies are **not** resolved (plus for a leaf tool).
 - Packages extracted into NuGet global-packages folder.
 
-Canonical download-only wrapper csproj:
+Recommended download-only wrapper csproj (uses the bundled `Microsoft.NET.Sdk` so MSBuild can parse the project without an extra NuGet fetch for the SDK itself):
 
 ```xml
-<Project Sdk="Microsoft.Build.NoTargets/1.0.80">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <NoBuild>true</NoBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageDownload Include="Aipm" Version="[1.0.0]" />
+    <PackageDownload Include="aipm" Version="[1.0.0]" />
   </ItemGroup>
 </Project>
 ```
 
 `PackageDownload` **cannot** live in `Directory.Packages.props` — it must be in a regular csproj's `<ItemGroup>`. `packages.config` is legacy (non-SDK projects) and does not belong in any new pipeline.
 
-**`GlobalPackageReference`** (from `Directory.Packages.props`) is an alternative, but requires at least one `PackageReference`-style project in the repo. For a pipeline that only needs the CLI, the `NoTargets` + `PackageDownload` wrapper is cleaner.
+The official Microsoft Learn docs show `Microsoft.Build.NoTargets/1.0.80` as the SDK in their PackageDownload example. That works on agents with full nuget.org egress, but adds a hard failure mode on agents where the `Microsoft.Build.NoTargets` SDK package cannot be downloaded — MSBuild can't even parse the project before restore starts. `Microsoft.NET.Sdk` ships bundled with the .NET SDK and avoids that failure mode entirely while producing identical restore behavior.
+
+**`GlobalPackageReference`** (from `Directory.Packages.props`) is an alternative, but requires at least one `PackageReference`-style project in the repo. For a pipeline that only needs the CLI, the `Microsoft.NET.Sdk` + `PackageDownload` wrapper is cleaner.
 
 **Does `NuGetAuthenticate@1` help for public nuget.org?**
 
@@ -166,15 +170,23 @@ steps:
       version: 8.x
 
   - pwsh: |
+      # Microsoft.NET.Sdk is bundled with the .NET SDK installed by UseDotNet@2,
+      # so the project file parses without any extra NuGet fetch for the SDK
+      # itself. (Microsoft.Build.NoTargets would also work but adds a hard
+      # dependency on nuget.org reachability before restore can even start;
+      # if your agent has restricted egress, that fails before aipm is ever
+      # downloaded.)
       $proj = @'
-      <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+      <Project Sdk="Microsoft.NET.Sdk">
         <PropertyGroup>
           <TargetFramework>net8.0</TargetFramework>
-          <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+          <NoBuild>true</NoBuild>
+          <IncludeBuildOutput>false</IncludeBuildOutput>
           <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+          <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
         </PropertyGroup>
         <ItemGroup>
-          <PackageDownload Include="Aipm" Version="[$(env:AIPM_VERSION)]" />
+          <PackageDownload Include="aipm" Version="[$(env:AIPM_VERSION)]" />
         </ItemGroup>
       </Project>
       '@
@@ -230,8 +242,9 @@ steps:
 ```
 
 **Notes:**
-- `Microsoft.Build.NoTargets` is a well-known MSBuild SDK on nuget.org, designed for "project that doesn't build anything, just orchestrates NuGet".
+- `Microsoft.NET.Sdk` is the canonical SDK that ships bundled with every `.NET SDK` install, so the wrapper project file parses without an extra NuGet fetch for the SDK itself. `Microsoft.Build.NoTargets` is a popular alternative, but it must be downloaded from nuget.org before MSBuild can even parse the project — that adds a failure mode if the agent has restricted nuget.org egress (`Could not resolve SDK 'Microsoft.Build.NoTargets/x.y.z'`). With `Microsoft.NET.Sdk` + `<NoBuild>true</NoBuild>` + `<IncludeBuildOutput>false</IncludeBuildOutput>` the restore behavior is identical.
 - Version brackets `[1.0.0]` are **mandatory** for `<PackageDownload>`; floating versions not supported.
+- An explicit `nuget.config` next to the wrapper csproj pins `nuget.org` as the only source. Without `<clear />`, the agent's machine-wide config (which may include Visual Studio offline packages, ADO Artifacts feeds, or corporate mirrors) can route the restore to the wrong place or fail to find `Microsoft.NET.Sdk`-resolved packages.
 - RID resolution is the only platform-aware step.
 - `chmod +x` on non-Windows is defensive.
 


### PR DESCRIPTION
## Summary

A user hit this consuming aipm from an Azure DevOps pipeline that copied the README snippet:

\`\`\`
error MSB4236: The SDK 'Microsoft.Build.NoTargets/3.7.0' specified could not be found.
warning : Unable to load the service index for source https://api.nuget.org/v3/index.json.
\`\`\`

## Root cause

\`Microsoft.Build.NoTargets\` is a **third-party MSBuild SDK** that has to be downloaded from nuget.org **before** MSBuild can even parse the project file. On agents with restricted egress, transient nuget.org issues, or polluted machine-wide nuget.config (Visual Studio offline packages, ADO Artifacts feeds, corporate mirrors), the SDK resolution fails before \`dotnet restore\` ever gets a chance to download \`aipm\` itself.

## Fix

Two changes:

1. **Switch the wrapper project from \`Microsoft.Build.NoTargets/3.7.0\` to \`Microsoft.NET.Sdk\`.** The latter ships bundled with every .NET SDK install — it's already on disk after \`UseDotNet@2\` runs. Adding \`<NoBuild>true</NoBuild>\` + \`<IncludeBuildOutput>false</IncludeBuildOutput>\` keeps restore behavior identical to NoTargets.

2. **Add an explicit \`nuget.config\` next to the csproj.** Pins \`nuget.org\` as the only source via \`<clear />\`, so the agent's machine-wide config (which can include VS offline packages, internal feeds, or corporate mirrors) can't reroute the restore.

## Diff at a glance

\`\`\`diff
-      <Project Sdk=\"Microsoft.Build.NoTargets/3.7.0\">
+      <Project Sdk=\"Microsoft.NET.Sdk\">
         <PropertyGroup>
           <TargetFramework>net8.0</TargetFramework>
+          <NoBuild>true</NoBuild>
+          <IncludeBuildOutput>false</IncludeBuildOutput>
+          <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
           <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
         </PropertyGroup>
\`\`\`

Plus the new \`nuget.config\` block written by the same pwsh step.

## Impact

- **\`aipm 0.22.3\` on nuget.org is unchanged.** This is purely a consumer-side documentation fix.
- **Existing copies of the README snippet in user pipelines will need to be updated.** Anyone who already vendored the old snippet will hit the same NoTargets resolution failure until they pull the corrected version.
- The research doc (\`research/docs/2026-04-22-ado-pipeline-nuget-consume.md\`) is updated in lockstep so the README link to it stays consistent.

## Test plan

- [ ] Merge this PR
- [ ] Affected user updates their ADO pipeline YAML with the new snippet from README
- [ ] Re-run the ADO pipeline and verify \`dotnet restore\` succeeds against \`Microsoft.NET.Sdk\`
- [ ] Verify the existing RID-resolve / prependpath / smoke-test steps continue to work identically

## Follow-up note

Once a few users have validated this consumer pattern works against their ADO instances, feature #10 (3-OS smoke test) and feature #11 (csproj restore smoke test) in \`research/feature-list.json\` can be marked passes:true.