### PR TITLE
chore: release v0.22.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1146,7 +1146,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.22.4"
+version = "0.22.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.22.4" }
+libaipm = { path = "crates/libaipm", version = "0.22.5" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.5] - 2026-04-30
+
+### Documentation
+- Add Azure DevOps NuGet installation guide ([#664](https://github.com/TheLarkInn/aipm/pull/664)) (80fe35c)
+- Bump example AIPM_VERSION to 0.22.4 ([#704](https://github.com/TheLarkInn/aipm/pull/704)) (12d758c)
+
 ## [0.22.4] - 2026-04-24
 
 ### Features

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.22.5] - 2026-04-30
+
+### Documentation
+- Add Azure DevOps NuGet installation guide ([#664](https://github.com/TheLarkInn/aipm/pull/664)) (80fe35c)
+- Bump example AIPM_VERSION to 0.22.4 ([#704](https://github.com/TheLarkInn/aipm/pull/704)) (12d758c)
+
 ## [0.22.4] - 2026-04-24
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.22.4 -> 0.22.5 (✓ API compatible changes)
* `aipm`: 0.22.4 -> 0.22.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.22.5] - 2026-04-30

### Documentation
- Add Azure DevOps NuGet installation guide ([#664](https://github.com/TheLarkInn/aipm/pull/664)) (80fe35c)
- Bump example AIPM_VERSION to 0.22.4 ([#704](https://github.com/TheLarkInn/aipm/pull/704)) (12d758c)
</blockquote>

## `aipm`

<blockquote>

## [0.22.5] - 2026-04-30

### Documentation
- Add Azure DevOps NuGet installation guide ([#664](https://github.com/TheLarkInn/aipm/pull/664)) (80fe35c)
- Bump example AIPM_VERSION to 0.22.4 ([#704](https://github.com/TheLarkInn/aipm/pull/704)) (12d758c)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).