### PR TITLE
chore: release v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.22.5"
+version = "0.23.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1146,7 +1146,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.22.5"
+version = "0.23.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.22.5"
+version = "0.23.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.22.5" }
+libaipm = { path = "crates/libaipm", version = "0.23.0" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.23.0] - 2026-05-01
+
+### Documentation
+- Add NuGet installation guide and update CHANGELOG for v0.22.4 ([#702](https://github.com/TheLarkInn/aipm/pull/702)) (fbb0eca)
+
+### Testing
+- Cover cmd_lint text/color branches and fix lockfile assertion short-circuits (8a9d094)
+
 ## [0.22.5] - 2026-04-30
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.23.0] - 2026-05-01
+
+### Documentation
+- Add NuGet installation guide and update CHANGELOG for v0.22.4 ([#702](https://github.com/TheLarkInn/aipm/pull/702)) (fbb0eca)
+
+### Testing
+- Cover fetch_index error path when cache .git is invalid (0e641f1)
+- Cover cmd_lint text/color branches and fix lockfile assertion short-circuits (8a9d094)
+- Cover default Fs trait method implementations (91f68de)
+
 ## [0.22.5] - 2026-04-30
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.22.5 -> 0.23.0 (⚠ API breaking changes)
* `aipm`: 0.22.5 -> 0.23.0

### ⚠ `libaipm` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DiscoveredFeature.engine in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/discovery/types.rs:81
  field DiscoveredFeature.layout in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/discovery/types.rs:83
  field DiscoveredFeature.source_root in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/discovery/types.rs:85
  field DiscoveredFeature.feature_dir in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/discovery/types.rs:89
  field DiscoveredFeature.path in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/discovery/types.rs:92
  field Outcome.scan_counts in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/lint/mod.rs:224
  field Outcome.scanned_dirs in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/lint/mod.rs:226
  field Outcome.scan_counts in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/migrate/mod.rs:222
  field Outcome.scanned_dirs in /tmp/.tmpbsBLim/aipm/crates/libaipm/src/migrate/mod.rs:225

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function libaipm::discovery::discover_features, previously in file /tmp/.tmpotgH0Q/libaipm/src/discovery.rs:299

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct libaipm::discovery::SourceContext, previously in file /tmp/.tmpotgH0Q/libaipm/src/discovery.rs:30

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field file_path of struct DiscoveredFeature, previously in file /tmp/.tmpotgH0Q/libaipm/src/discovery.rs:41
  field source_context of struct DiscoveredFeature, previously in file /tmp/.tmpotgH0Q/libaipm/src/discovery.rs:46
  field relative_path of struct DiscoveredFeature, previously in file /tmp/.tmpotgH0Q/libaipm/src/discovery.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.23.0] - 2026-05-01

### Documentation
- Add NuGet installation guide and update CHANGELOG for v0.22.4 ([#702](https://github.com/TheLarkInn/aipm/pull/702)) (fbb0eca)

### Testing
- Cover fetch_index error path when cache .git is invalid (0e641f1)
- Cover cmd_lint text/color branches and fix lockfile assertion short-circuits (8a9d094)
- Cover default Fs trait method implementations (91f68de)
</blockquote>

## `aipm`

<blockquote>

## [0.23.0] - 2026-05-01

### Documentation
- Add NuGet installation guide and update CHANGELOG for v0.22.4 ([#702](https://github.com/TheLarkInn/aipm/pull/702)) (fbb0eca)

### Testing
- Cover cmd_lint text/color branches and fix lockfile assertion short-circuits (8a9d094)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).