### PR TITLE
chore: release v0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1146,7 +1146,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.23.0" }
+libaipm = { path = "crates/libaipm", version = "0.23.1" }
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.23.1] - 2026-05-04
+
 ## [0.23.0] - 2026-05-01
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.23.1] - 2026-05-04
+
+### Testing
+- Cover enumerate_sources early-return for nonexistent source dir (366c10d)
+- Cover dedup_agent_artifacts and is_dot_agent_md branches (7fd5e29)
+- Cover counts() empty-set branch and fix guard branch (72cab6f)
+
 ## [0.23.0] - 2026-05-01
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm`: 0.23.0 -> 0.23.1 (✓ API compatible changes)
* `aipm`: 0.23.0 -> 0.23.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm`

<blockquote>

## [0.23.1] - 2026-05-04

### Testing
- Cover enumerate_sources early-return for nonexistent source dir (366c10d)
- Cover dedup_agent_artifacts and is_dot_agent_md branches (7fd5e29)
- Cover counts() empty-set branch and fix guard branch (72cab6f)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).