### PR TITLE
chore: release v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1541,7 +1541,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "libaipm-engine-spec"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "bitflags 2.11.0",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.23.1"
+version = "0.24.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,8 +22,8 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.23.1" }
-libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.23.1" }
+libaipm = { path = "crates/libaipm", version = "0.24.0" }
+libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.24.0" }
 
 # Engine API schema source-of-truth (build-time codegen + runtime tables)
 phf = "0.13"

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.24.0] - 2026-05-05
+
+### Features
+- Engine API schema source-of-truth (libaipm-engine-spec crate) ([#771](https://github.com/TheLarkInn/aipm/pull/771)) (14a7f4f)
+
 ## [0.23.1] - 2026-05-04
 
 ## [0.23.0] - 2026-05-01

--- a/crates/libaipm-engine-spec/CHANGELOG.md
+++ b/crates/libaipm-engine-spec/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+## [0.24.0] - 2026-05-05
+
+### Bug Fixes
+- Correct GitHub latest release download URL format in README installers ([#171](https://github.com/TheLarkInn/aipm/pull/171)) (99b7ec5)
+
+### Documentation
+- Add CI and Codecov badges to README ([#48](https://github.com/TheLarkInn/aipm/pull/48)) (df75b44)
+- Rewrite README with full API docs, roadmap, and apm comparison ([#105](https://github.com/TheLarkInn/aipm/pull/105)) (1aa3cac)
+- Document install/update/uninstall/link/unlink/list/lint commands and new libaipm modules ([#244](https://github.com/TheLarkInn/aipm/pull/244)) (fa03dcf)
+- Add lint configuration guide and workspace.lints README example ([#263](https://github.com/TheLarkInn/aipm/pull/263)) (28b77d6)
+- Add `aipm lint` and `aipm migrate` how-to guides ([#266](https://github.com/TheLarkInn/aipm/pull/266)) (d750692)
+- Add missing guides, docs index, and fix lint path matching docs ([#268](https://github.com/TheLarkInn/aipm/pull/268)) (e55a9fb)
+- Cross-link lint.md with configuring-lint.md and README ([#272](https://github.com/TheLarkInn/aipm/pull/272)) (5ddc7c9)
+- Fix marketplace spec format and document mp: alias ([#279](https://github.com/TheLarkInn/aipm/pull/279)) (da9ec77)
+- Add verbosity & logging guide and complete global flags reference ([#300](https://github.com/TheLarkInn/aipm/pull/300)) (a949eb3)
+- Document `aipm lsp` command in README ([#403](https://github.com/TheLarkInn/aipm/pull/403)) (5714aa1)
+- Add VS Code extension guide and aipm lsp command reference ([#411](https://github.com/TheLarkInn/aipm/pull/411)) (8dfd32f)
+- Add VS Code extension setup guide and fix project structure ([#412](https://github.com/TheLarkInn/aipm/pull/412)) (9582f5a)
+- Add editor schema support section to README ([#419](https://github.com/TheLarkInn/aipm/pull/419)) (d333739)
+- Add missing install guide links to `aipm install` See also section ([#422](https://github.com/TheLarkInn/aipm/pull/422)) (faa0849)
+- Fix Claude Code LSP artifact listing in README and add v0.19.7 changelog ([#425](https://github.com/TheLarkInn/aipm/pull/425)) (b81ea0d)
+- Add instruction file patterns to VS Code LSP document selector ([#466](https://github.com/TheLarkInn/aipm/pull/466)) (8497d8d)
+- Add `instructions/oversized` example to workspace lints in README ([#492](https://github.com/TheLarkInn/aipm/pull/492)) (46c94fb)
+- Update README to reflect 18-rule lint coverage and `instructions/oversized` example ([#487](https://github.com/TheLarkInn/aipm/pull/487)) (3c88808)
+- Add uninstall guide cross-reference to README `aipm uninstall` section ([#500](https://github.com/TheLarkInn/aipm/pull/500)) (0acf52a)
+- Add `generate` and `wizard` modules to libaipm reference table ([#503](https://github.com/TheLarkInn/aipm/pull/503)) (2de0d46)
+- Add `aipm init` workspace initialization guide ([#505](https://github.com/TheLarkInn/aipm/pull/505)) (3d38565)
+- Add `aipm make plugin` command documentation ([#513](https://github.com/TheLarkInn/aipm/pull/513)) (7813296)
+- Add `aipm update` guide and lockfile semantics reference ([#508](https://github.com/TheLarkInn/aipm/pull/508)) (2b94a6c)
+- Add `make` to README command table and missing `See also` links ([#516](https://github.com/TheLarkInn/aipm/pull/516)) (8506b00)
+- Fix init paths, registry caveat, aipm-pack note, and roadmap status markers ([#517](https://github.com/TheLarkInn/aipm/pull/517)) (49a36db)
+- Add `--engine both` example to README `aipm make plugin` section ([#546](https://github.com/TheLarkInn/aipm/pull/546)) (c4c394e)
+- Fix incorrect marketplace directory path in README `aipm init` section ([#567](https://github.com/TheLarkInn/aipm/pull/567)) (22c161f)
+- Add Azure DevOps NuGet installation guide ([#664](https://github.com/TheLarkInn/aipm/pull/664)) (80fe35c)
+- Bump example AIPM_VERSION to 0.22.4 ([#704](https://github.com/TheLarkInn/aipm/pull/704)) (12d758c)
+- Add NuGet installation guide and update CHANGELOG for v0.22.4 ([#702](https://github.com/TheLarkInn/aipm/pull/702)) (fbb0eca)
+
+### Features
+- Merge aipm-pack into aipm ([#417](https://github.com/TheLarkInn/aipm/pull/417)) ([#522](https://github.com/TheLarkInn/aipm/pull/522)) (eab803d)
+- Automatic nuget.org publishing pipeline ([#651](https://github.com/TheLarkInn/aipm/pull/651)) (134d94a)
+- Engine API schema source-of-truth (libaipm-engine-spec crate) ([#771](https://github.com/TheLarkInn/aipm/pull/771)) (14a7f4f)

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.24.0] - 2026-05-05
+
+### Features
+- Engine API schema source-of-truth (libaipm-engine-spec crate) ([#771](https://github.com/TheLarkInn/aipm/pull/771)) (14a7f4f)
+
 ## [0.23.1] - 2026-05-04
 
 ### Testing


### PR DESCRIPTION



## 🤖 New release

* `libaipm-engine-spec`: 0.23.1 -> 0.24.0
* `libaipm`: 0.23.1 -> 0.24.0 (⚠ API breaking changes)
* `aipm`: 0.23.1 -> 0.24.0

### ⚠ `libaipm` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PluginManifestOpts.engines in /tmp/.tmp0M5VHk/aipm/crates/libaipm/src/manifest/builder.rs:23
  field DiscoveredFeature.source in /tmp/.tmp0M5VHk/aipm/crates/libaipm/src/discovery/types.rs:96
  field DiscoveredFeature.source in /tmp/.tmp0M5VHk/aipm/crates/libaipm/src/discovery/types.rs:96

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum libaipm::make::engine_features::Feature, previously in file /tmp/.tmpwjHmDS/libaipm/src/make/engine_features.rs:8
  enum libaipm::make::Feature, previously in file /tmp/.tmpwjHmDS/libaipm/src/make/engine_features.rs:8
  enum libaipm::discovery::types::Engine, previously in file /tmp/.tmpwjHmDS/libaipm/src/discovery/types.rs:39
  enum libaipm::discovery::Engine, previously in file /tmp/.tmpwjHmDS/libaipm/src/discovery/types.rs:39
  enum libaipm::engine::Engine, previously in file /tmp/.tmpwjHmDS/libaipm/src/engine.rs:14

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function libaipm::lint::rules::known_events::suggest_canonical, previously in file /tmp/.tmpwjHmDS/libaipm/src/lint/rules/known_events.rs:94
  function libaipm::lint::rules::known_events::is_valid_for_any_tool, previously in file /tmp/.tmpwjHmDS/libaipm/src/lint/rules/known_events.rs:87
  function libaipm::lint::rules::known_events::is_valid_event, previously in file /tmp/.tmpwjHmDS/libaipm/src/lint/rules/known_events.rs:75

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod libaipm::lint::rules::known_events, previously in file /tmp/.tmpwjHmDS/libaipm/src/lint/rules/known_events.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  COPILOT_LEGACY_MAP in file /tmp/.tmpwjHmDS/libaipm/src/lint/rules/known_events.rs:58
  CLAUDE_EVENTS in file /tmp/.tmpwjHmDS/libaipm/src/lint/rules/known_events.rs:10
  COPILOT_EVENTS in file /tmp/.tmpwjHmDS/libaipm/src/lint/rules/known_events.rs:41
  INSTRUCTION_FILENAMES in file /tmp/.tmpwjHmDS/libaipm/src/discovery/instruction.rs:29

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field engine of struct DiscoveredFeature, previously in file /tmp/.tmpwjHmDS/libaipm/src/discovery/types.rs:81
  field engine of struct DiscoveredFeature, previously in file /tmp/.tmpwjHmDS/libaipm/src/discovery/types.rs:81
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm-engine-spec`

<blockquote>

## [0.24.0] - 2026-05-05

### Bug Fixes
- Correct GitHub latest release download URL format in README installers ([#171](https://github.com/TheLarkInn/aipm/pull/171)) (99b7ec5)

### Documentation
- Add CI and Codecov badges to README ([#48](https://github.com/TheLarkInn/aipm/pull/48)) (df75b44)
- Rewrite README with full API docs, roadmap, and apm comparison ([#105](https://github.com/TheLarkInn/aipm/pull/105)) (1aa3cac)
- Document install/update/uninstall/link/unlink/list/lint commands and new libaipm modules ([#244](https://github.com/TheLarkInn/aipm/pull/244)) (fa03dcf)
- Add lint configuration guide and workspace.lints README example ([#263](https://github.com/TheLarkInn/aipm/pull/263)) (28b77d6)
- Add `aipm lint` and `aipm migrate` how-to guides ([#266](https://github.com/TheLarkInn/aipm/pull/266)) (d750692)
- Add missing guides, docs index, and fix lint path matching docs ([#268](https://github.com/TheLarkInn/aipm/pull/268)) (e55a9fb)
- Cross-link lint.md with configuring-lint.md and README ([#272](https://github.com/TheLarkInn/aipm/pull/272)) (5ddc7c9)
- Fix marketplace spec format and document mp: alias ([#279](https://github.com/TheLarkInn/aipm/pull/279)) (da9ec77)
- Add verbosity & logging guide and complete global flags reference ([#300](https://github.com/TheLarkInn/aipm/pull/300)) (a949eb3)
- Document `aipm lsp` command in README ([#403](https://github.com/TheLarkInn/aipm/pull/403)) (5714aa1)
- Add VS Code extension guide and aipm lsp command reference ([#411](https://github.com/TheLarkInn/aipm/pull/411)) (8dfd32f)
- Add VS Code extension setup guide and fix project structure ([#412](https://github.com/TheLarkInn/aipm/pull/412)) (9582f5a)
- Add editor schema support section to README ([#419](https://github.com/TheLarkInn/aipm/pull/419)) (d333739)
- Add missing install guide links to `aipm install` See also section ([#422](https://github.com/TheLarkInn/aipm/pull/422)) (faa0849)
- Fix Claude Code LSP artifact listing in README and add v0.19.7 changelog ([#425](https://github.com/TheLarkInn/aipm/pull/425)) (b81ea0d)
- Add instruction file patterns to VS Code LSP document selector ([#466](https://github.com/TheLarkInn/aipm/pull/466)) (8497d8d)
- Add `instructions/oversized` example to workspace lints in README ([#492](https://github.com/TheLarkInn/aipm/pull/492)) (46c94fb)
- Update README to reflect 18-rule lint coverage and `instructions/oversized` example ([#487](https://github.com/TheLarkInn/aipm/pull/487)) (3c88808)
- Add uninstall guide cross-reference to README `aipm uninstall` section ([#500](https://github.com/TheLarkInn/aipm/pull/500)) (0acf52a)
- Add `generate` and `wizard` modules to libaipm reference table ([#503](https://github.com/TheLarkInn/aipm/pull/503)) (2de0d46)
- Add `aipm init` workspace initialization guide ([#505](https://github.com/TheLarkInn/aipm/pull/505)) (3d38565)
- Add `aipm make plugin` command documentation ([#513](https://github.com/TheLarkInn/aipm/pull/513)) (7813296)
- Add `aipm update` guide and lockfile semantics reference ([#508](https://github.com/TheLarkInn/aipm/pull/508)) (2b94a6c)
- Add `make` to README command table and missing `See also` links ([#516](https://github.com/TheLarkInn/aipm/pull/516)) (8506b00)
- Fix init paths, registry caveat, aipm-pack note, and roadmap status markers ([#517](https://github.com/TheLarkInn/aipm/pull/517)) (49a36db)
- Add `--engine both` example to README `aipm make plugin` section ([#546](https://github.com/TheLarkInn/aipm/pull/546)) (c4c394e)
- Fix incorrect marketplace directory path in README `aipm init` section ([#567](https://github.com/TheLarkInn/aipm/pull/567)) (22c161f)
- Add Azure DevOps NuGet installation guide ([#664](https://github.com/TheLarkInn/aipm/pull/664)) (80fe35c)
- Bump example AIPM_VERSION to 0.22.4 ([#704](https://github.com/TheLarkInn/aipm/pull/704)) (12d758c)
- Add NuGet installation guide and update CHANGELOG for v0.22.4 ([#702](https://github.com/TheLarkInn/aipm/pull/702)) (fbb0eca)

### Features
- Merge aipm-pack into aipm ([#417](https://github.com/TheLarkInn/aipm/pull/417)) ([#522](https://github.com/TheLarkInn/aipm/pull/522)) (eab803d)
- Automatic nuget.org publishing pipeline ([#651](https://github.com/TheLarkInn/aipm/pull/651)) (134d94a)
- Engine API schema source-of-truth (libaipm-engine-spec crate) ([#771](https://github.com/TheLarkInn/aipm/pull/771)) (14a7f4f)
</blockquote>

## `libaipm`

<blockquote>

## [0.24.0] - 2026-05-05

### Features
- Engine API schema source-of-truth (libaipm-engine-spec crate) ([#771](https://github.com/TheLarkInn/aipm/pull/771)) (14a7f4f)
</blockquote>

## `aipm`

<blockquote>

## [0.24.0] - 2026-05-05

### Features
- Engine API schema source-of-truth (libaipm-engine-spec crate) ([#771](https://github.com/TheLarkInn/aipm/pull/771)) (14a7f4f)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).