### PR TITLE
chore: release v0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1541,7 +1541,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "libaipm-engine-spec"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "bitflags 2.11.0",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,8 +22,8 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.24.0" }
-libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.24.0" }
+libaipm = { path = "crates/libaipm", version = "0.24.1" }
+libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.24.1" }
 
 # Engine API schema source-of-truth (build-time codegen + runtime tables)
 phf = "0.13"

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.24.1] - 2026-05-06
+
+### Testing
+- Cover defensive branches in decode_engine_multi_select (2cbb36b)
+
 ## [0.24.0] - 2026-05-05
 
 ### Features

--- a/crates/libaipm-engine-spec/CHANGELOG.md
+++ b/crates/libaipm-engine-spec/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.24.1] - 2026-05-06
+
 ## [0.24.0] - 2026-05-05
 
 ### Bug Fixes

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.24.1] - 2026-05-06
+
+### Bug Fixes
+- Address #793 — ADO log-command injection, lint path containment, NuGet hardening ([#804](https://github.com/TheLarkInn/aipm/pull/804)) (fe598f0)
+
+### Testing
+- Cover wrong-filename guard branches in match_marketplace and match_plugin_json (7608d30)
+
 ## [0.24.0] - 2026-05-05
 
 ### Features


### PR DESCRIPTION



## 🤖 New release

* `libaipm-engine-spec`: 0.24.0 -> 0.24.1
* `libaipm`: 0.24.0 -> 0.24.1 (✓ API compatible changes)
* `aipm`: 0.24.0 -> 0.24.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `libaipm`

<blockquote>

## [0.24.1] - 2026-05-06

### Bug Fixes
- Address #793 — ADO log-command injection, lint path containment, NuGet hardening ([#804](https://github.com/TheLarkInn/aipm/pull/804)) (fe598f0)

### Testing
- Cover wrong-filename guard branches in match_marketplace and match_plugin_json (7608d30)
</blockquote>

## `aipm`

<blockquote>

## [0.24.1] - 2026-05-06

### Testing
- Cover defensive branches in decode_engine_multi_select (2cbb36b)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).