### PR TITLE
chore: release v0.24.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1541,7 +1541,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "libaipm-engine-spec"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "bitflags 2.11.0",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,8 +22,8 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.24.1" }
-libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.24.1" }
+libaipm = { path = "crates/libaipm", version = "0.24.2" }
+libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.24.2" }
 
 # Engine API schema source-of-truth (build-time codegen + runtime tables)
 phf = "0.13"

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.24.2] - 2026-05-07
+
+### Documentation
+- Add `libaipm-engine-spec` crate reference to README ([#809](https://github.com/TheLarkInn/aipm/pull/809)) (180fd96)
+- Fix `VALID_TOOLS` type and description in `libaipm-engine-spec` reference table ([#815](https://github.com/TheLarkInn/aipm/pull/815)) (e3508d7)
+
+### Testing
+- Cover migrate --no-summary branch in main.rs (36795b2)
+- Cover format_steps MultiSelect min_selections > 0 branch (fd8f94d)
+
 ## [0.24.1] - 2026-05-06
 
 ### Testing

--- a/crates/libaipm-engine-spec/CHANGELOG.md
+++ b/crates/libaipm-engine-spec/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.24.2] - 2026-05-07
+
+### Documentation
+- Add `libaipm-engine-spec` crate reference to README ([#809](https://github.com/TheLarkInn/aipm/pull/809)) (180fd96)
+- Fix `VALID_TOOLS` type and description in `libaipm-engine-spec` reference table ([#815](https://github.com/TheLarkInn/aipm/pull/815)) (e3508d7)
+
 ## [0.24.1] - 2026-05-06
 
 ## [0.24.0] - 2026-05-05

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.24.2] - 2026-05-07
+
+### Documentation
+- Add `libaipm-engine-spec` crate reference to README ([#809](https://github.com/TheLarkInn/aipm/pull/809)) (180fd96)
+- Fix `VALID_TOOLS` type and description in `libaipm-engine-spec` reference table ([#815](https://github.com/TheLarkInn/aipm/pull/815)) (e3508d7)
+
+### Testing
+- Cover format_engine_list/format_toml_string_array multi-engine branches (3411689)
+- Cover make_temp_dir cleanup-existing-dir branch (3bd18e7)
+- Cover all branches in migrate/mod.rs (4daf305)
+- Cover format_marker_string single-marker branch and empty engines list (d6f51d3)
+- Cover I/O error paths in lock(), store_file(), and store_package() (e270bf6)
+- Cover non-Agent dedup skip and missing-source early return (bd3db82)
+- Cover source_root.file_name() == None branch in lint loop (1cc0628)
+- Cover fallback sort_by comparator with 2+ artifacts (ec2be88)
+- Cover read_dir and read_to_string error paths in OutputStyleDetector (a8ae014)
+
 ## [0.24.1] - 2026-05-06
 
 ### Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `libaipm-engine-spec`: 0.24.1 -> 0.24.2 (✓ API compatible changes)
* `libaipm`: 0.24.1 -> 0.24.2 (✓ API compatible changes)
* `aipm`: 0.24.1 -> 0.24.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm-engine-spec`

<blockquote>

## [0.24.2] - 2026-05-07

### Documentation
- Add `libaipm-engine-spec` crate reference to README ([#809](https://github.com/TheLarkInn/aipm/pull/809)) (180fd96)
- Fix `VALID_TOOLS` type and description in `libaipm-engine-spec` reference table ([#815](https://github.com/TheLarkInn/aipm/pull/815)) (e3508d7)
</blockquote>

## `libaipm`

<blockquote>

## [0.24.2] - 2026-05-07

### Documentation
- Add `libaipm-engine-spec` crate reference to README ([#809](https://github.com/TheLarkInn/aipm/pull/809)) (180fd96)
- Fix `VALID_TOOLS` type and description in `libaipm-engine-spec` reference table ([#815](https://github.com/TheLarkInn/aipm/pull/815)) (e3508d7)

### Testing
- Cover format_engine_list/format_toml_string_array multi-engine branches (3411689)
- Cover make_temp_dir cleanup-existing-dir branch (3bd18e7)
- Cover all branches in migrate/mod.rs (4daf305)
- Cover format_marker_string single-marker branch and empty engines list (d6f51d3)
- Cover I/O error paths in lock(), store_file(), and store_package() (e270bf6)
- Cover non-Agent dedup skip and missing-source early return (bd3db82)
- Cover source_root.file_name() == None branch in lint loop (1cc0628)
- Cover fallback sort_by comparator with 2+ artifacts (ec2be88)
- Cover read_dir and read_to_string error paths in OutputStyleDetector (a8ae014)
</blockquote>

## `aipm`

<blockquote>

## [0.24.2] - 2026-05-07

### Documentation
- Add `libaipm-engine-spec` crate reference to README ([#809](https://github.com/TheLarkInn/aipm/pull/809)) (180fd96)
- Fix `VALID_TOOLS` type and description in `libaipm-engine-spec` reference table ([#815](https://github.com/TheLarkInn/aipm/pull/815)) (e3508d7)

### Testing
- Cover migrate --no-summary branch in main.rs (36795b2)
- Cover format_steps MultiSelect min_selections > 0 branch (fd8f94d)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).