### PR TITLE
chore: release v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1541,7 +1541,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "libaipm-engine-spec"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "bitflags 2.11.0",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.24.2"
+version = "0.25.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,8 +22,8 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.24.2" }
-libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.24.2" }
+libaipm = { path = "crates/libaipm", version = "0.25.0" }
+libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.25.0" }
 
 # Engine API schema source-of-truth (build-time codegen + runtime tables)
 phf = "0.13"

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-11
+
+### Documentation
+- Add `.github/copilot-instructions.md` to README `aipm lint` and `aipm lsp` file pattern lists ([#835](https://github.com/TheLarkInn/aipm/pull/835)) (c98c68d)
+- Fix Copilot skill layouts in README and rule count in configuring-lint ([#836](https://github.com/TheLarkInn/aipm/pull/836)) (a495874)
+- Fix `libaipm-engine-spec` helper function signatures in README ([#846](https://github.com/TheLarkInn/aipm/pull/846)) (39a75aa)
+
+### Features
+- Make aipm init idempotent over existing artifacts ([#850](https://github.com/TheLarkInn/aipm/pull/850)) ([#861](https://github.com/TheLarkInn/aipm/pull/861)) (4987783)
+
+### Testing
+- Cover non-UTF-8 path component branch in derive_summary_sources (2001835)
+- Cover non-Normal path component branch in derive_summary_sources (f04c869)
+- Cover derive_summary_sources uncovered branches (4e7a027)
+
 ### Features
 - `aipm init` no longer fails when `aipm.toml` or `.ai/` already exist. The wizard now reuses them and continues — surfacing `Using existing aipm.toml in <dir>` and `Using existing .ai/ marketplace in <dir>` on stdout. With `--engine claude,copilot`, init writes the engine-appropriate `marketplace.json` for every selected engine and prints `Wrote <Engine> marketplace manifest at <path>` per engine ([#850](https://github.com/TheLarkInn/aipm/issues/850)).
 - `cmd_init` gains four new stdout messages for the new `InitAction` variants: `Using existing aipm.toml`, `Using existing .ai/ marketplace`, `Wrote <Engine> marketplace manifest at <path>`, and `Found existing <Engine> marketplace manifest at <path>` ([#850](https://github.com/TheLarkInn/aipm/issues/850)).

--- a/crates/libaipm-engine-spec/CHANGELOG.md
+++ b/crates/libaipm-engine-spec/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-11
+
+### Documentation
+- Add `.github/copilot-instructions.md` to README `aipm lint` and `aipm lsp` file pattern lists ([#835](https://github.com/TheLarkInn/aipm/pull/835)) (c98c68d)
+- Fix Copilot skill layouts in README and rule count in configuring-lint ([#836](https://github.com/TheLarkInn/aipm/pull/836)) (a495874)
+- Fix `libaipm-engine-spec` helper function signatures in README ([#846](https://github.com/TheLarkInn/aipm/pull/846)) (39a75aa)
+
+### Features
+- Make aipm init idempotent over existing artifacts ([#850](https://github.com/TheLarkInn/aipm/pull/850)) ([#861](https://github.com/TheLarkInn/aipm/pull/861)) (4987783)
+
 ### Bug Fixes
 - Schema fix: Claude marketplace manifest path corrected from `.claude-plugin/marketplace.toml` to `.claude-plugin/marketplace.json` to match the format Claude actually consumes. `engine::marketplace_manifest_path(Engine::Claude)` now returns `.json` (was `.toml`); the data file in `data/engine-api-schema.json` already declared `.json` in `manifest_search_paths`, only the `marketplace_manifest_path_for("claude")` builder lookup was out of step ([#850](https://github.com/TheLarkInn/aipm/issues/850)).
 

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-11
+
+### Documentation
+- Add `.github/copilot-instructions.md` to README `aipm lint` and `aipm lsp` file pattern lists ([#835](https://github.com/TheLarkInn/aipm/pull/835)) (c98c68d)
+- Fix Copilot skill layouts in README and rule count in configuring-lint ([#836](https://github.com/TheLarkInn/aipm/pull/836)) (a495874)
+- Fix `libaipm-engine-spec` helper function signatures in README ([#846](https://github.com/TheLarkInn/aipm/pull/846)) (39a75aa)
+
+### Features
+- Make aipm init idempotent over existing artifacts ([#850](https://github.com/TheLarkInn/aipm/pull/850)) ([#861](https://github.com/TheLarkInn/aipm/pull/861)) (4987783)
+
+### Testing
+- Cover clone_index success path (line 87) (da6294d)
+- Cover non-object JSON branch in claude adaptor (3acf253)
+- Cover EmptyIdentifier branch in Spec::from_str (06868c7)
+- Cover emit error-propagation paths in unified migrate (cae0110)
+- Cover empty-artifacts non-package-scoped branch (7df87a4)
+- Cover unsafe name checks in emit_plugin_with_name (1be2f26)
+- Cover adaptor.apply() == false branch in init() (6e900fc)
+- Cover anonymous-remote branch and fix serve_one branch (1693526)
+- Cover ValidatedPath::new error paths via public API (1103216)
+
 ### Features
 - `aipm init` is now idempotent over pre-existing `aipm.toml` and `.ai/` artifacts. Both are reused with `tracing::info!` events instead of returning a hard error. Engine-aware fan-out: `scaffold_marketplace` writes the engine-appropriate `marketplace.json` (e.g. `.claude-plugin/marketplace.json` for Claude, `.github/plugin/marketplace.json` for Copilot) for every engine in `opts.engines_scaffold` ([#850](https://github.com/TheLarkInn/aipm/issues/850)).
 


### PR DESCRIPTION



## 🤖 New release

* `libaipm-engine-spec`: 0.24.2 -> 0.25.0 (✓ API compatible changes)
* `libaipm`: 0.24.2 -> 0.25.0 (⚠ API breaking changes)
* `aipm`: 0.24.2 -> 0.25.0

### ⚠ `libaipm` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant InitAction:WorkspaceFoundExisting in /tmp/.tmppjfKI8/aipm/crates/libaipm/src/workspace_init/mod.rs:95
  variant InitAction:MarketplaceFoundExisting in /tmp/.tmppjfKI8/aipm/crates/libaipm/src/workspace_init/mod.rs:99
  variant InitAction:MarketplaceManifestWritten in /tmp/.tmppjfKI8/aipm/crates/libaipm/src/workspace_init/mod.rs:101
  variant InitAction:MarketplaceManifestFoundExisting in /tmp/.tmppjfKI8/aipm/crates/libaipm/src/workspace_init/mod.rs:110
  variant Error:ExistingManifestInvalid in /tmp/.tmppjfKI8/aipm/crates/libaipm/src/workspace_init/error.rs:27
  variant Error:ExistingMarketplaceInvalid in /tmp/.tmppjfKI8/aipm/crates/libaipm/src/workspace_init/error.rs:43
  variant Error:ExistingManifestInvalid in /tmp/.tmppjfKI8/aipm/crates/libaipm/src/workspace_init/error.rs:27
  variant Error:ExistingMarketplaceInvalid in /tmp/.tmppjfKI8/aipm/crates/libaipm/src/workspace_init/error.rs:43

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Error::WorkspaceAlreadyInitialized, previously in file /tmp/.tmp8rWHVO/libaipm/src/workspace_init/error.rs:10
  variant Error::MarketplaceAlreadyExists, previously in file /tmp/.tmp8rWHVO/libaipm/src/workspace_init/error.rs:14
  variant Error::WorkspaceAlreadyInitialized, previously in file /tmp/.tmp8rWHVO/libaipm/src/workspace_init/error.rs:10
  variant Error::MarketplaceAlreadyExists, previously in file /tmp/.tmp8rWHVO/libaipm/src/workspace_init/error.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm-engine-spec`

<blockquote>

## [0.25.0] - 2026-05-11

### Documentation
- Add `.github/copilot-instructions.md` to README `aipm lint` and `aipm lsp` file pattern lists ([#835](https://github.com/TheLarkInn/aipm/pull/835)) (c98c68d)
- Fix Copilot skill layouts in README and rule count in configuring-lint ([#836](https://github.com/TheLarkInn/aipm/pull/836)) (a495874)
- Fix `libaipm-engine-spec` helper function signatures in README ([#846](https://github.com/TheLarkInn/aipm/pull/846)) (39a75aa)

### Features
- Make aipm init idempotent over existing artifacts ([#850](https://github.com/TheLarkInn/aipm/pull/850)) ([#861](https://github.com/TheLarkInn/aipm/pull/861)) (4987783)

### Bug Fixes
- Schema fix: Claude marketplace manifest path corrected from `.claude-plugin/marketplace.toml` to `.claude-plugin/marketplace.json` to match the format Claude actually consumes. `engine::marketplace_manifest_path(Engine::Claude)` now returns `.json` (was `.toml`); the data file in `data/engine-api-schema.json` already declared `.json` in `manifest_search_paths`, only the `marketplace_manifest_path_for("claude")` builder lookup was out of step ([#850](https://github.com/TheLarkInn/aipm/issues/850)).
</blockquote>

## `libaipm`

<blockquote>

## [0.25.0] - 2026-05-11

### Documentation
- Add `.github/copilot-instructions.md` to README `aipm lint` and `aipm lsp` file pattern lists ([#835](https://github.com/TheLarkInn/aipm/pull/835)) (c98c68d)
- Fix Copilot skill layouts in README and rule count in configuring-lint ([#836](https://github.com/TheLarkInn/aipm/pull/836)) (a495874)
- Fix `libaipm-engine-spec` helper function signatures in README ([#846](https://github.com/TheLarkInn/aipm/pull/846)) (39a75aa)

### Features
- Make aipm init idempotent over existing artifacts ([#850](https://github.com/TheLarkInn/aipm/pull/850)) ([#861](https://github.com/TheLarkInn/aipm/pull/861)) (4987783)

### Testing
- Cover clone_index success path (line 87) (da6294d)
- Cover non-object JSON branch in claude adaptor (3acf253)
- Cover EmptyIdentifier branch in Spec::from_str (06868c7)
- Cover emit error-propagation paths in unified migrate (cae0110)
- Cover empty-artifacts non-package-scoped branch (7df87a4)
- Cover unsafe name checks in emit_plugin_with_name (1be2f26)
- Cover adaptor.apply() == false branch in init() (6e900fc)
- Cover anonymous-remote branch and fix serve_one branch (1693526)
- Cover ValidatedPath::new error paths via public API (1103216)

### Features
- `aipm init` is now idempotent over pre-existing `aipm.toml` and `.ai/` artifacts. Both are reused with `tracing::info!` events instead of returning a hard error. Engine-aware fan-out: `scaffold_marketplace` writes the engine-appropriate `marketplace.json` (e.g. `.claude-plugin/marketplace.json` for Claude, `.github/plugin/marketplace.json` for Copilot) for every engine in `opts.engines_scaffold` ([#850](https://github.com/TheLarkInn/aipm/issues/850)).

### Breaking Changes
- Removed `workspace_init::Error::WorkspaceAlreadyInitialized` and `workspace_init::Error::MarketplaceAlreadyExists`. Added `workspace_init::Error::ExistingManifestInvalid { path, source }` and `workspace_init::Error::ExistingMarketplaceInvalid { path, source }` for the only remaining hard-fail paths (malformed pre-existing files). `workspace_init::InitAction` gains four variants: `WorkspaceFoundExisting`, `MarketplaceFoundExisting`, `MarketplaceManifestWritten { engine, path }`, `MarketplaceManifestFoundExisting { engine, path }` ([#850](https://github.com/TheLarkInn/aipm/issues/850)).
- `make/discovery.rs::find_marketplace` now iterates `Engine::ALL` and accepts a marketplace under any engine's path. Previously only `.claude-plugin/marketplace.json` was recognised ([#850](https://github.com/TheLarkInn/aipm/issues/850)).
</blockquote>

## `aipm`

<blockquote>

## [0.25.0] - 2026-05-11

### Documentation
- Add `.github/copilot-instructions.md` to README `aipm lint` and `aipm lsp` file pattern lists ([#835](https://github.com/TheLarkInn/aipm/pull/835)) (c98c68d)
- Fix Copilot skill layouts in README and rule count in configuring-lint ([#836](https://github.com/TheLarkInn/aipm/pull/836)) (a495874)
- Fix `libaipm-engine-spec` helper function signatures in README ([#846](https://github.com/TheLarkInn/aipm/pull/846)) (39a75aa)

### Features
- Make aipm init idempotent over existing artifacts ([#850](https://github.com/TheLarkInn/aipm/pull/850)) ([#861](https://github.com/TheLarkInn/aipm/pull/861)) (4987783)

### Testing
- Cover non-UTF-8 path component branch in derive_summary_sources (2001835)
- Cover non-Normal path component branch in derive_summary_sources (f04c869)
- Cover derive_summary_sources uncovered branches (4e7a027)

### Features
- `aipm init` no longer fails when `aipm.toml` or `.ai/` already exist. The wizard now reuses them and continues — surfacing `Using existing aipm.toml in <dir>` and `Using existing .ai/ marketplace in <dir>` on stdout. With `--engine claude,copilot`, init writes the engine-appropriate `marketplace.json` for every selected engine and prints `Wrote <Engine> marketplace manifest at <path>` per engine ([#850](https://github.com/TheLarkInn/aipm/issues/850)).
- `cmd_init` gains four new stdout messages for the new `InitAction` variants: `Using existing aipm.toml`, `Using existing .ai/ marketplace`, `Wrote <Engine> marketplace manifest at <path>`, and `Found existing <Engine> marketplace manifest at <path>` ([#850](https://github.com/TheLarkInn/aipm/issues/850)).

### Breaking Changes
- `aipm init` over a directory that already contains `aipm.toml` or `.ai/` previously exited non-zero. It now exits zero. Scripts using `aipm init || ...` to detect prior initialisation must inspect stdout for the `Using existing X` messages instead ([#850](https://github.com/TheLarkInn/aipm/issues/850)).
- A pre-existing `aipm.toml` that fails to parse or validate now produces a typed `existing manifest at <path> is invalid: <reason>` error (previously a generic "already initialized" message).
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).