### PR TITLE
Add skill rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +696,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1078,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1573,6 +1597,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "ureq",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -3846,6 +3871,17 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 toml = "0.8"
 toml_edit = "0.22"
+# YAML — pure-Rust parser (no `unsafe` C bindings) used to strictly validate
+# markdown frontmatter blocks.
+yaml-rust2 = "0.11"
 
 # Semver
 semver = { version = "1", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ The following features are defined as BDD scenarios and tracked as open issues. 
 
 ### Quality & Portability
 
-- 🔨 **Guardrails** — `aipm lint` with 19 rules and 4 reporters ships today (see [`docs/guides/lint.md`](docs/guides/lint.md)); auto-fix and quality scoring on publish are not yet implemented ([#13](https://github.com/TheLarkInn/aipm/issues/13))
+- 🔨 **Guardrails** — `aipm lint` with 22 rules and 4 reporters ships today (see [`docs/guides/lint.md`](docs/guides/lint.md)); auto-fix and quality scoring on publish are not yet implemented ([#13](https://github.com/TheLarkInn/aipm/issues/13))
 - 🔨 **Compositional Reuse** — spec, acquirer, and marketplace modules ship; full publish/consume workflow for standalone primitives pending ([#14](https://github.com/TheLarkInn/aipm/issues/14))
 - 🔨 **Cross-Stack** — Claude Code and Copilot CLI adaptors ship today; Cursor and OpenCode adaptors planned ([#15](https://github.com/TheLarkInn/aipm/issues/15))
 

--- a/crates/aipm/src/lsp/helpers.rs
+++ b/crates/aipm/src/lsp/helpers.rs
@@ -490,8 +490,11 @@ mod tests {
         assert!(index.contains_key("source/misplaced-features"));
         assert!(index.contains_key("instructions/oversized"));
         assert!(index.contains_key("valid-tool-name"));
-        // 19 rules total (18 quality rules + source/misplaced-features)
-        assert_eq!(index.len(), 19);
+        assert!(index.contains_key("skill/invalid-frontmatter"));
+        assert!(index.contains_key("skill/name-not-kebab-case"));
+        assert!(index.contains_key("skill/description-invalid-chars"));
+        // 22 rules total (21 quality rules + source/misplaced-features)
+        assert_eq!(index.len(), 22);
     }
 
     #[test]

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+- Add strict YAML validation of skill frontmatter: new `skill/invalid-frontmatter` (exact `---` delimiters, valid YAML, mapping root, string `name`/`description`), `skill/name-not-kebab-case`, and Copilot-scoped `skill/description-invalid-chars` (`<`/`>`) lint rules. `skill/description-too-long` and `skill/name-too-long` now count Unicode code points after YAML parsing (so folded/literal scalars are measured correctly), and `skill/missing-description` now reports empty descriptions. LF and CRLF line endings are both supported.
+
 ## [0.25.0] - 2026-05-11
 
 ### Documentation

--- a/crates/libaipm/Cargo.toml
+++ b/crates/libaipm/Cargo.toml
@@ -33,6 +33,7 @@ tempfile = { workspace = true }
 annotate-snippets = { workspace = true }
 anstyle = { workspace = true }
 anstyle-query = { workspace = true }
+yaml-rust2 = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }

--- a/crates/libaipm/src/frontmatter.rs
+++ b/crates/libaipm/src/frontmatter.rs
@@ -9,6 +9,8 @@
 
 use std::collections::BTreeMap;
 
+pub mod strict;
+
 /// Parsed frontmatter from a markdown file.
 #[derive(Debug, Clone, Default)]
 pub struct Frontmatter {

--- a/crates/libaipm/src/frontmatter/strict.rs
+++ b/crates/libaipm/src/frontmatter/strict.rs
@@ -1,0 +1,325 @@
+//! Strict, YAML-backed validation of markdown frontmatter blocks.
+//!
+//! The line-oriented scanner in the parent [`crate::frontmatter`] module is
+//! deliberately lenient: it tolerates leading blank lines, never runs a real
+//! YAML parser, and exposes every value as raw text. That behaviour is useful
+//! for best-effort field extraction during migration, but it cannot answer the
+//! questions the AI engines actually ask when they load a `SKILL.md`:
+//!
+//! * Does the file start *immediately* with an exact `---` line?
+//! * Is the closing delimiter an exact `---` line?
+//! * Is the block between the delimiters valid YAML?
+//! * Is the YAML root a key/value mapping?
+//! * Is a given field a *string* (rather than a number, list, or mapping)?
+//! * What is the field's value *after* folded/block scalars are resolved?
+//!
+//! This module answers all of them. Both LF and CRLF line endings are accepted
+//! because [`str::lines`] normalizes `\r\n` away.
+
+use std::collections::BTreeMap;
+
+use yaml_rust2::{Yaml, YamlLoader};
+
+/// The exact delimiter line that must open and close a frontmatter block.
+const DELIMITER: &str = "---";
+
+/// Reason a frontmatter block failed strict validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// The file does not begin immediately with an exact `---` line.
+    MissingOpeningDelimiter {
+        /// `true` when the file begins with a UTF-8 byte-order mark, an
+        /// invisible cause of this failure worth calling out separately.
+        byte_order_mark: bool,
+    },
+    /// No exact `---` line closes the block.
+    MissingClosingDelimiter,
+    /// The block between the delimiters is not valid YAML.
+    InvalidYaml {
+        /// Human-readable parser message.
+        message: String,
+        /// 1-based line number *within the file* where the parser gave up.
+        line: usize,
+    },
+    /// The YAML parsed, but its root is not a key/value mapping.
+    RootNotMapping,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::MissingOpeningDelimiter { byte_order_mark: true } => f.write_str(
+                "file must start immediately with a `---` frontmatter delimiter (a UTF-8 byte-order mark precedes it)",
+            ),
+            Self::MissingOpeningDelimiter { byte_order_mark: false } => {
+                f.write_str("file must start immediately with a line containing exactly `---`")
+            },
+            Self::MissingClosingDelimiter => {
+                f.write_str("frontmatter is not closed by a line containing exactly `---`")
+            },
+            Self::InvalidYaml { ref message, line } => {
+                write!(f, "frontmatter is not valid YAML (line {line}): {message}")
+            },
+            Self::RootNotMapping => {
+                f.write_str("frontmatter must be a YAML mapping of keys to values")
+            },
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// A strictly validated frontmatter block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Document {
+    /// Root mapping entries keyed by their string keys. Keys that are not
+    /// YAML strings (e.g. `1: x`) are dropped — no aipm field uses them.
+    fields: BTreeMap<String, Yaml>,
+    /// 1-based line number of the closing `---` delimiter.
+    pub end_line: usize,
+}
+
+impl Document {
+    /// Look up a root-level field by key.
+    pub fn get(&self, key: &str) -> Option<&Yaml> {
+        self.fields.get(key)
+    }
+
+    /// Look up a root-level field that must be a YAML string.
+    ///
+    /// Returns `None` when the key is absent *or* present with a non-string
+    /// value. Folded (`>`) and literal (`|`) block scalars are returned in
+    /// their parsed form, so callers measure the value the engine sees.
+    pub fn string(&self, key: &str) -> Option<&str> {
+        match self.fields.get(key) {
+            Some(Yaml::String(s)) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Human-readable YAML type name of a root-level field, for diagnostics.
+    ///
+    /// Returns `None` when the key is absent.
+    pub fn type_name(&self, key: &str) -> Option<&'static str> {
+        self.fields.get(key).map(yaml_type_name)
+    }
+}
+
+/// Describe a [`Yaml`] value's type for diagnostic messages.
+const fn yaml_type_name(value: &Yaml) -> &'static str {
+    match *value {
+        Yaml::Real(_) => "number",
+        Yaml::Integer(_) => "integer",
+        Yaml::String(_) => "string",
+        Yaml::Boolean(_) => "boolean",
+        Yaml::Array(_) => "list",
+        Yaml::Hash(_) => "mapping",
+        Yaml::Alias(_) => "alias",
+        Yaml::Null => "null",
+        Yaml::BadValue => "invalid value",
+    }
+}
+
+/// Strictly parse and validate the frontmatter block of `content`.
+///
+/// # Errors
+///
+/// Returns [`Error`] when the delimiters are missing or inexact, the block is
+/// not valid YAML, or the YAML root is not a mapping.
+pub fn parse(content: &str) -> Result<Document, Error> {
+    let mut lines = content.lines();
+    if lines.next() != Some(DELIMITER) {
+        return Err(Error::MissingOpeningDelimiter {
+            byte_order_mark: content.starts_with('\u{feff}'),
+        });
+    }
+
+    let mut block = String::new();
+    let mut end_line = None;
+    for (offset, line) in lines.enumerate() {
+        if line == DELIMITER {
+            // `offset` is 0-based from the line after the opening delimiter,
+            // which is file line 2 — hence `+ 2`.
+            end_line = Some(offset + 2);
+            break;
+        }
+        block.push_str(line);
+        block.push('\n');
+    }
+    let Some(end_line) = end_line else {
+        return Err(Error::MissingClosingDelimiter);
+    };
+
+    let documents = YamlLoader::load_from_str(&block).map_err(|e| Error::InvalidYaml {
+        message: e.to_string(),
+        // The scanner's line is 1-based within `block`, which starts on file
+        // line 2.
+        line: e.marker().line().saturating_add(1),
+    })?;
+
+    let Some(Yaml::Hash(hash)) = documents.first() else {
+        return Err(Error::RootNotMapping);
+    };
+
+    let fields = hash
+        .iter()
+        .filter_map(|(key, value)| match *key {
+            Yaml::String(ref k) => Some((k.clone(), value.clone())),
+            _ => None,
+        })
+        .collect();
+
+    Ok(Document { fields, end_line })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_minimal_document() {
+        let doc = parse("---\nname: a\ndescription: b\n---\nbody").expect("valid");
+        assert_eq!(doc.string("name"), Some("a"));
+        assert_eq!(doc.string("description"), Some("b"));
+        assert_eq!(doc.end_line, 4);
+    }
+
+    #[test]
+    fn accepts_crlf_line_endings() {
+        let doc = parse("---\r\nname: a\r\ndescription: b\r\n---\r\nbody").expect("valid");
+        assert_eq!(doc.string("name"), Some("a"));
+        assert_eq!(doc.string("description"), Some("b"));
+        assert_eq!(doc.end_line, 4);
+    }
+
+    #[test]
+    fn accepts_frontmatter_without_trailing_body() {
+        let doc = parse("---\nname: a\n---").expect("valid");
+        assert_eq!(doc.string("name"), Some("a"));
+    }
+
+    #[test]
+    fn rejects_leading_blank_line() {
+        assert_eq!(
+            parse("\n---\nname: a\n---\n"),
+            Err(Error::MissingOpeningDelimiter { byte_order_mark: false })
+        );
+    }
+
+    #[test]
+    fn rejects_leading_byte_order_mark() {
+        assert_eq!(
+            parse("\u{feff}---\nname: a\n---\n"),
+            Err(Error::MissingOpeningDelimiter { byte_order_mark: true })
+        );
+    }
+
+    #[test]
+    fn rejects_inexact_opening_delimiter() {
+        for content in ["----\nname: a\n---\n", "--- \nname: a\n---\n", " ---\nname: a\n---\n"] {
+            assert!(
+                matches!(parse(content), Err(Error::MissingOpeningDelimiter { .. })),
+                "expected rejection of {content:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_inexact_closing_delimiter() {
+        for content in ["---\nname: a\n----\nbody", "---\nname: a\n--- \nbody", "---\nname: a\n"] {
+            assert_eq!(
+                parse(content),
+                Err(Error::MissingClosingDelimiter),
+                "expected rejection of {content:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_yaml() {
+        let err = parse("---\nname: [unclosed\n---\nbody").expect_err("should fail");
+        assert!(matches!(err, Error::InvalidYaml { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn invalid_yaml_line_is_file_relative() {
+        let err = parse("---\nname: ok\ntags: [a, b\n---\nbody").expect_err("should fail");
+        let line = if let Error::InvalidYaml { line, .. } = err { line } else { 0 };
+        assert!(line >= 2, "expected a file-relative line >= 2, got {line}");
+    }
+
+    #[test]
+    fn rejects_non_mapping_root() {
+        assert_eq!(parse("---\n- a\n- b\n---\nbody"), Err(Error::RootNotMapping));
+        assert_eq!(parse("---\njust a scalar\n---\nbody"), Err(Error::RootNotMapping));
+    }
+
+    #[test]
+    fn rejects_empty_frontmatter() {
+        assert_eq!(parse("---\n---\nbody"), Err(Error::RootNotMapping));
+    }
+
+    #[test]
+    fn folded_scalar_is_measured_after_parsing() {
+        let doc = parse("---\nname: a\ndescription: >\n  one\n  two\n---\nbody").expect("valid");
+        assert_eq!(doc.string("description"), Some("one two\n"));
+    }
+
+    #[test]
+    fn literal_scalar_is_measured_after_parsing() {
+        let doc = parse("---\nname: a\ndescription: |\n  one\n  two\n---\nbody").expect("valid");
+        assert_eq!(doc.string("description"), Some("one\ntwo\n"));
+    }
+
+    #[test]
+    fn non_string_fields_are_not_strings() {
+        let doc = parse("---\nname: 42\ndescription: [a, b]\n---\nbody").expect("valid");
+        assert_eq!(doc.string("name"), None);
+        assert_eq!(doc.string("description"), None);
+        assert_eq!(doc.type_name("name"), Some("integer"));
+        assert_eq!(doc.type_name("description"), Some("list"));
+        assert_eq!(doc.type_name("missing"), None);
+    }
+
+    #[test]
+    fn get_returns_underlying_value() {
+        let doc = parse("---\nname: a\n---\nbody").expect("valid");
+        assert_eq!(doc.get("name"), Some(&Yaml::String("a".to_string())));
+        assert_eq!(doc.get("nope"), None);
+    }
+
+    #[test]
+    fn non_string_keys_are_ignored() {
+        let doc = parse("---\n1: one\nname: a\n---\nbody").expect("valid");
+        assert_eq!(doc.string("name"), Some("a"));
+        assert_eq!(doc.get("1"), None);
+    }
+
+    #[test]
+    fn type_names_cover_every_variant() {
+        assert_eq!(yaml_type_name(&Yaml::Real("1.5".to_string())), "number");
+        assert_eq!(yaml_type_name(&Yaml::Integer(1)), "integer");
+        assert_eq!(yaml_type_name(&Yaml::String(String::new())), "string");
+        assert_eq!(yaml_type_name(&Yaml::Boolean(true)), "boolean");
+        assert_eq!(yaml_type_name(&Yaml::Array(vec![])), "list");
+        assert_eq!(yaml_type_name(&Yaml::Hash(yaml_rust2::yaml::Hash::new())), "mapping");
+        assert_eq!(yaml_type_name(&Yaml::Alias(0)), "alias");
+        assert_eq!(yaml_type_name(&Yaml::Null), "null");
+        assert_eq!(yaml_type_name(&Yaml::BadValue), "invalid value");
+    }
+
+    #[test]
+    fn error_display_messages() {
+        assert!(Error::MissingOpeningDelimiter { byte_order_mark: false }
+            .to_string()
+            .contains("start immediately"));
+        assert!(Error::MissingOpeningDelimiter { byte_order_mark: true }
+            .to_string()
+            .contains("byte-order mark"));
+        assert!(Error::MissingClosingDelimiter.to_string().contains("not closed"));
+        assert!(Error::InvalidYaml { message: "boom".to_string(), line: 3 }
+            .to_string()
+            .contains("line 3"));
+        assert!(Error::RootNotMapping.to_string().contains("mapping"));
+    }
+}

--- a/crates/libaipm/src/lint/rules/mod.rs
+++ b/crates/libaipm/src/lint/rules/mod.rs
@@ -17,11 +17,14 @@ pub mod plugin_missing_manifest;
 pub mod plugin_missing_registration;
 pub mod plugin_required_fields;
 pub(crate) mod scan;
+pub mod skill_desc_invalid_chars;
 pub mod skill_desc_too_long;
+pub mod skill_invalid_frontmatter;
 pub mod skill_invalid_shell;
 pub mod skill_missing_desc;
 pub mod skill_missing_name;
 pub mod skill_name_invalid;
+pub mod skill_name_not_kebab;
 pub mod skill_name_too_long;
 pub mod skill_oversized;
 #[cfg(test)]
@@ -124,12 +127,15 @@ pub(crate) fn read_hook_preamble(file_path: &Path, fs: &dyn Fs) -> Option<(Strin
 pub(crate) fn quality_rules_for_kind(kind: &FeatureKind, config: &Config) -> Vec<Box<dyn Rule>> {
     match kind {
         FeatureKind::Skill => vec![
+            Box::new(skill_invalid_frontmatter::InvalidFrontmatter),
             Box::new(skill_missing_name::MissingName),
             Box::new(skill_missing_desc::MissingDescription),
             Box::new(skill_oversized::Oversized),
             Box::new(skill_name_too_long::NameTooLong),
             Box::new(skill_name_invalid::NameInvalidChars),
+            Box::new(skill_name_not_kebab::NameNotKebabCase),
             Box::new(skill_desc_too_long::DescriptionTooLong),
+            Box::new(skill_desc_invalid_chars::DescriptionInvalidChars),
             Box::new(skill_invalid_shell::InvalidShell),
             Box::new(broken_paths::BrokenPaths),
             Box::new(valid_tool_name::ValidToolName),
@@ -182,12 +188,15 @@ pub(crate) fn quality_rules_for_kind(kind: &FeatureKind, config: &Config) -> Vec
 /// present) — users seeing this in the LSP almost certainly have `.ai/`.
 pub fn catalog() -> Vec<Box<dyn Rule>> {
     vec![
+        Box::new(skill_invalid_frontmatter::InvalidFrontmatter),
         Box::new(skill_missing_name::MissingName),
         Box::new(skill_missing_desc::MissingDescription),
         Box::new(skill_oversized::Oversized),
         Box::new(skill_name_too_long::NameTooLong),
         Box::new(skill_name_invalid::NameInvalidChars),
+        Box::new(skill_name_not_kebab::NameNotKebabCase),
         Box::new(skill_desc_too_long::DescriptionTooLong),
+        Box::new(skill_desc_invalid_chars::DescriptionInvalidChars),
         Box::new(skill_invalid_shell::InvalidShell),
         Box::new(broken_paths::BrokenPaths),
         Box::new(agent_missing_tools::MissingTools),

--- a/crates/libaipm/src/lint/rules/scan.rs
+++ b/crates/libaipm/src/lint/rules/scan.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use libaipm_engine_spec::paths;
 
-use crate::frontmatter::Frontmatter;
+use crate::frontmatter::{strict, Frontmatter};
 use crate::fs::Fs;
 
 /// A skill found during scanning.
@@ -16,8 +16,25 @@ pub struct FoundSkill {
     pub path: PathBuf,
     /// Parsed frontmatter (if any).
     pub frontmatter: Option<Frontmatter>,
+    /// Strictly validated YAML frontmatter, or the reason validation failed.
+    pub strict: Result<strict::Document, strict::Error>,
     /// Raw content of the file.
     pub content: String,
+}
+
+impl FoundSkill {
+    /// Read a frontmatter field as a string.
+    ///
+    /// Prefers the strictly parsed YAML value, so folded/literal block scalars
+    /// are measured after parsing. Falls back to the lenient line scanner when
+    /// the block failed strict validation, keeping the value-shape rules useful
+    /// on files that `skill/invalid-frontmatter` already flags.
+    pub fn field(&self, key: &str) -> Option<&str> {
+        self.strict.as_ref().map_or_else(
+            |_| self.frontmatter.as_ref().and_then(|fm| fm.fields.get(key)).map(String::as_str),
+            |doc| doc.string(key),
+        )
+    }
 }
 
 /// An agent found during scanning.
@@ -62,7 +79,8 @@ pub fn read_skill(path: &Path, fs: &dyn Fs) -> Option<FoundSkill> {
         },
     };
     let frontmatter = crate::frontmatter::parse(&content).ok().flatten();
-    Some(FoundSkill { path: path.to_path_buf(), frontmatter, content })
+    let strict = strict::parse(&content);
+    Some(FoundSkill { path: path.to_path_buf(), frontmatter, strict, content })
 }
 
 /// Read and parse a single agent `.md` file by absolute path.

--- a/crates/libaipm/src/lint/rules/skill_desc_invalid_chars.rs
+++ b/crates/libaipm/src/lint/rules/skill_desc_invalid_chars.rs
@@ -1,0 +1,222 @@
+//! Rule: `skill/description-invalid-chars` — description contains `<` or `>`.
+//!
+//! Copilot CLI injects skill descriptions into an XML-tagged block in the
+//! system prompt, so a `<` or `>` in the description corrupts that markup.
+//! This is **not** a general YAML restriction and Claude Code does not impose
+//! it, so the rule is scoped to skills that can reach Copilot:
+//!
+//! * skills under `.github/` → always checked (Copilot's own source root);
+//! * skills under `.claude/` → never checked;
+//! * everything else (`.ai/` plugins) → checked unless the nearest `aipm.toml`
+//!   declares an `engines` list that excludes `copilot`.
+
+use std::path::Path;
+
+use libaipm_engine_spec::EngineSet;
+
+use crate::fs::Fs;
+use crate::lint::diagnostic::{Diagnostic, Severity};
+use crate::lint::rule::Rule;
+use crate::lint::Error;
+
+/// Checks that skill descriptions consumed by Copilot contain no angle brackets.
+pub struct DescriptionInvalidChars;
+
+impl Rule for DescriptionInvalidChars {
+    fn id(&self) -> &'static str {
+        "skill/description-invalid-chars"
+    }
+
+    fn name(&self) -> &'static str {
+        "skill description invalid characters"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn help_url(&self) -> Option<&'static str> {
+        Some(
+            "https://github.com/TheLarkInn/aipm/blob/main/docs/rules/skill/description-invalid-chars.md",
+        )
+    }
+
+    fn help_text(&self) -> Option<&'static str> {
+        Some("remove `<` and `>` from the description, or exclude copilot from engines")
+    }
+
+    fn check_file(&self, file_path: &Path, fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error> {
+        self.check_file_in(file_path, Path::new(""), fs)
+    }
+
+    fn check_file_in(
+        &self,
+        file_path: &Path,
+        lint_dir: &Path,
+        fs: &dyn Fs,
+    ) -> Result<Vec<Diagnostic>, Error> {
+        let Some((source_type, skill)) = super::read_skill_preamble(file_path, fs) else {
+            return Ok(vec![]);
+        };
+        if !targets_copilot(file_path, lint_dir, fs) {
+            return Ok(vec![]);
+        }
+        let Some(desc) = skill.field("description") else { return Ok(vec![]) };
+        let found: Vec<char> = ['<', '>'].into_iter().filter(|c| desc.contains(*c)).collect();
+        if found.is_empty() {
+            return Ok(vec![]);
+        }
+        let desc_line =
+            skill.frontmatter.as_ref().and_then(|fm| fm.field_lines.get("description").copied());
+        let (col, end_col) = desc_line
+            .and_then(|n| skill.content.lines().nth(n.saturating_sub(1)))
+            .and_then(|line| crate::frontmatter::field_value_range(line, "description"))
+            .unzip();
+        let listed = found.iter().map(|c| format!("`{c}`")).collect::<Vec<_>>().join(" and ");
+        Ok(vec![Diagnostic {
+            rule_id: self.id().to_string(),
+            severity: self.default_severity(),
+            message: format!(
+                "skill description contains {listed}, which Copilot CLI does not allow"
+            ),
+            file_path: skill.path,
+            line: desc_line,
+            col,
+            end_line: desc_line,
+            end_col,
+            source_type,
+            help_text: None,
+            help_url: None,
+        }])
+    }
+}
+
+/// Decide whether the skill at `file_path` can be loaded by Copilot CLI.
+fn targets_copilot(file_path: &Path, lint_dir: &Path, fs: &dyn Fs) -> bool {
+    match super::scan::source_type_from_path(file_path) {
+        libaipm_engine_spec::paths::CLAUDE_DOT => false,
+        libaipm_engine_spec::paths::GITHUB_DOT => true,
+        _ => {
+            let declared =
+                super::valid_tool_name::nearest_declared_engines(file_path, lint_dir, fs);
+            declared.is_empty() || declared.contains(EngineSet::COPILOT)
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lint::rules::test_helpers::MockFs;
+    use std::path::PathBuf;
+
+    const ANGLED: &str = "---\nname: s\ndescription: Use <tool> here\n---\nbody";
+
+    fn check_at(path: &str, content: &str, manifest: Option<(&str, &str)>) -> Vec<Diagnostic> {
+        let mut fs = MockFs::new();
+        let path = PathBuf::from(path);
+        fs.exists.insert(path.clone());
+        fs.files.insert(path.clone(), content.to_string());
+        if let Some((manifest_path, manifest_body)) = manifest {
+            let manifest_path = PathBuf::from(manifest_path);
+            fs.exists.insert(manifest_path.clone());
+            fs.files.insert(manifest_path, manifest_body.to_string());
+        }
+        DescriptionInvalidChars.check_file(&path, &fs).ok().unwrap_or_default()
+    }
+
+    fn check(content: &str) -> Vec<Diagnostic> {
+        check_at(".ai/p/skills/s/SKILL.md", content, None)
+    }
+
+    #[test]
+    fn no_file_returns_empty() {
+        let fs = MockFs::new();
+        let diags = DescriptionInvalidChars
+            .check_file(Path::new(".ai/p/skills/s/SKILL.md"), &fs)
+            .ok()
+            .unwrap_or_default();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn clean_description_passes() {
+        assert!(check("---\nname: s\ndescription: All good\n---\nbody").is_empty());
+    }
+
+    #[test]
+    fn angle_brackets_are_reported() {
+        let diags = check(ANGLED);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].rule_id, "skill/description-invalid-chars");
+        assert!(diags[0].message.contains('<'));
+        assert_eq!(diags[0].line, Some(3));
+        assert_eq!(diags[0].col, Some(14));
+    }
+
+    #[test]
+    fn only_less_than_is_reported_singly() {
+        let diags = check("---\nname: s\ndescription: a < b\n---\nbody");
+        assert_eq!(diags.len(), 1);
+        assert!(!diags[0].message.contains(" and "));
+    }
+
+    #[test]
+    fn folded_description_is_checked_after_parsing() {
+        let diags = check("---\nname: s\ndescription: >\n  keep <this>\n  out\n---\nbody");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn github_source_is_always_checked() {
+        assert_eq!(check_at(".github/skills/s/SKILL.md", ANGLED, None).len(), 1);
+    }
+
+    #[test]
+    fn claude_source_is_never_checked() {
+        assert!(check_at(".claude/skills/s/SKILL.md", ANGLED, None).is_empty());
+    }
+
+    #[test]
+    fn claude_only_plugin_is_not_checked() {
+        let manifest = "[package]\nname = \"p\"\nversion = \"1.0.0\"\nengines = [\"claude\"]\n";
+        assert!(check_at(".ai/p/skills/s/SKILL.md", ANGLED, Some((".ai/p/aipm.toml", manifest)))
+            .is_empty());
+    }
+
+    #[test]
+    fn copilot_plugin_is_checked() {
+        let manifest = "[package]\nname = \"p\"\nversion = \"1.0.0\"\nengines = [\"copilot\"]\n";
+        assert_eq!(
+            check_at(".ai/p/skills/s/SKILL.md", ANGLED, Some((".ai/p/aipm.toml", manifest))).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn plugin_without_declared_engines_is_checked() {
+        let manifest = "[package]\nname = \"p\"\nversion = \"1.0.0\"\n";
+        assert_eq!(
+            check_at(".ai/p/skills/s/SKILL.md", ANGLED, Some((".ai/p/aipm.toml", manifest))).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn missing_description_is_ignored() {
+        assert!(check("---\nname: s\n---\nbody").is_empty());
+    }
+
+    #[test]
+    fn no_frontmatter_is_ignored() {
+        assert!(check("no frontmatter").is_empty());
+    }
+
+    #[test]
+    fn rule_metadata() {
+        assert_eq!(DescriptionInvalidChars.name(), "skill description invalid characters");
+        assert_eq!(DescriptionInvalidChars.default_severity(), Severity::Warning);
+        assert!(DescriptionInvalidChars.help_url().is_some());
+        assert!(DescriptionInvalidChars.help_text().is_some());
+    }
+}

--- a/crates/libaipm/src/lint/rules/skill_desc_too_long.rs
+++ b/crates/libaipm/src/lint/rules/skill_desc_too_long.rs
@@ -46,23 +46,24 @@ impl Rule for DescriptionTooLong {
         let Some((source_type, skill)) = super::read_skill_preamble(file_path, fs) else {
             return Ok(vec![]);
         };
-        let Some(ref fm) = skill.frontmatter else { return Ok(vec![]) };
-        let Some(desc) = fm.fields.get("description") else { return Ok(vec![]) };
-        if desc.len() <= MAX_DESCRIPTION_LENGTH {
+        let Some(desc) = skill.field("description") else { return Ok(vec![]) };
+        // Copilot's `z.string().max(1024)` counts Unicode code points, not bytes,
+        // and the value is measured after folded/literal scalars are parsed.
+        let length = desc.chars().count();
+        if length <= MAX_DESCRIPTION_LENGTH {
             return Ok(vec![]);
         }
-        let desc_line = fm.field_lines.get("description").copied();
+        let desc_line =
+            skill.frontmatter.as_ref().and_then(|fm| fm.field_lines.get("description").copied());
         let (col, end_col) = desc_line
-            .and_then(|n| skill.content.lines().nth(n - 1))
+            .and_then(|n| skill.content.lines().nth(n.saturating_sub(1)))
             .and_then(|line| crate::frontmatter::field_value_range(line, "description"))
             .unzip();
         Ok(vec![Diagnostic {
             rule_id: self.id().to_string(),
             severity: self.default_severity(),
             message: format!(
-                "skill description exceeds {} characters ({} chars, Copilot CLI limit)",
-                MAX_DESCRIPTION_LENGTH,
-                desc.len()
+                "skill description exceeds {MAX_DESCRIPTION_LENGTH} characters ({length} chars, Copilot CLI limit)"
             ),
             file_path: skill.path,
             line: desc_line,

--- a/crates/libaipm/src/lint/rules/skill_invalid_frontmatter.rs
+++ b/crates/libaipm/src/lint/rules/skill_invalid_frontmatter.rs
@@ -1,0 +1,252 @@
+//! Rule: `skill/invalid-frontmatter` — SKILL.md frontmatter is structurally invalid.
+//!
+//! Both Claude Code and Copilot CLI extract the frontmatter block with an
+//! anchored `---` match and then hand the block to a YAML parser. A file that
+//! does not start immediately with an exact `---` line, is not closed by an
+//! exact `---` line, does not contain valid YAML, or whose YAML root is not a
+//! mapping is silently ignored by those engines — the skill never loads.
+//!
+//! This rule additionally reports `name` / `description` fields that parse to a
+//! non-string YAML value (a list, mapping, number, or boolean), which the
+//! engines' schemas reject.
+
+use std::path::Path;
+
+use crate::frontmatter::strict;
+use crate::fs::Fs;
+use crate::lint::diagnostic::{Diagnostic, Severity};
+use crate::lint::rule::Rule;
+use crate::lint::Error;
+
+/// Frontmatter fields that must be YAML strings when present.
+const STRING_FIELDS: [&str; 2] = ["name", "description"];
+
+/// Checks that SKILL.md frontmatter is a well-formed YAML mapping.
+pub struct InvalidFrontmatter;
+
+impl Rule for InvalidFrontmatter {
+    fn id(&self) -> &'static str {
+        "skill/invalid-frontmatter"
+    }
+
+    fn name(&self) -> &'static str {
+        "invalid skill frontmatter"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    fn help_url(&self) -> Option<&'static str> {
+        Some("https://github.com/TheLarkInn/aipm/blob/main/docs/rules/skill/invalid-frontmatter.md")
+    }
+
+    fn help_text(&self) -> Option<&'static str> {
+        Some("open and close the frontmatter with exact `---` lines wrapping a YAML mapping")
+    }
+
+    fn check_file(&self, file_path: &Path, fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error> {
+        let Some((source_type, skill)) = super::read_skill_preamble(file_path, fs) else {
+            return Ok(vec![]);
+        };
+        let doc = match skill.strict {
+            Ok(ref doc) => doc,
+            Err(ref err) => {
+                return Ok(vec![self.diagnostic(
+                    err.to_string(),
+                    &skill,
+                    error_line(err),
+                    &source_type,
+                )]);
+            },
+        };
+
+        let mut diagnostics = Vec::new();
+        for field in STRING_FIELDS {
+            let Some(type_name) = doc.type_name(field) else { continue };
+            if doc.string(field).is_some() {
+                continue;
+            }
+            let line = skill
+                .frontmatter
+                .as_ref()
+                .and_then(|fm| fm.field_lines.get(field).copied())
+                .unwrap_or(1);
+            diagnostics.push(self.diagnostic(
+                format!("SKILL.md field \"{field}\" must be a string, found {type_name}"),
+                &skill,
+                line,
+                &source_type,
+            ));
+        }
+        Ok(diagnostics)
+    }
+}
+
+impl InvalidFrontmatter {
+    /// Build a diagnostic anchored at `line`, highlighting the whole line.
+    fn diagnostic(
+        &self,
+        message: String,
+        skill: &super::scan::FoundSkill,
+        line: usize,
+        source_type: &str,
+    ) -> Diagnostic {
+        let end_col = skill
+            .content
+            .lines()
+            .nth(line.saturating_sub(1))
+            .map_or(4, |l| l.chars().count().saturating_add(1).max(2));
+        Diagnostic {
+            rule_id: self.id().to_string(),
+            severity: self.default_severity(),
+            message,
+            file_path: skill.path.clone(),
+            line: Some(line),
+            col: Some(1),
+            end_line: Some(line),
+            end_col: Some(end_col),
+            source_type: source_type.to_string(),
+            help_text: None,
+            help_url: None,
+        }
+    }
+}
+
+/// Line to anchor a structural failure on.
+const fn error_line(err: &strict::Error) -> usize {
+    match *err {
+        strict::Error::InvalidYaml { line, .. } => line,
+        _ => 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lint::rules::test_helpers::MockFs;
+    use std::path::PathBuf;
+
+    fn skill_path() -> PathBuf {
+        PathBuf::from(".ai/p/skills/s/SKILL.md")
+    }
+
+    fn check(content: &str) -> Vec<Diagnostic> {
+        let mut fs = MockFs::new();
+        let path = skill_path();
+        fs.exists.insert(path.clone());
+        fs.files.insert(path.clone(), content.to_string());
+        InvalidFrontmatter.check_file(&path, &fs).ok().unwrap_or_default()
+    }
+
+    #[test]
+    fn no_file_returns_empty() {
+        let fs = MockFs::new();
+        let diags = InvalidFrontmatter.check_file(&skill_path(), &fs).ok().unwrap_or_default();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn valid_frontmatter_produces_no_diagnostics() {
+        assert!(check("---\nname: my-skill\ndescription: Does things\n---\nbody").is_empty());
+    }
+
+    #[test]
+    fn valid_crlf_frontmatter_produces_no_diagnostics() {
+        assert!(
+            check("---\r\nname: my-skill\r\ndescription: Does things\r\n---\r\nbody").is_empty()
+        );
+    }
+
+    #[test]
+    fn leading_blank_line_is_reported() {
+        let diags = check("\n---\nname: s\n---\nbody");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].rule_id, "skill/invalid-frontmatter");
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert!(diags[0].message.contains("start immediately"));
+        assert_eq!(diags[0].line, Some(1));
+    }
+
+    #[test]
+    fn byte_order_mark_is_called_out() {
+        let diags = check("\u{feff}---\nname: s\n---\nbody");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("byte-order mark"));
+    }
+
+    #[test]
+    fn missing_closing_delimiter_is_reported() {
+        let diags = check("---\nname: s\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("not closed"));
+    }
+
+    #[test]
+    fn inexact_closing_delimiter_is_reported() {
+        let diags = check("---\nname: s\n----\nbody");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("not closed"));
+    }
+
+    #[test]
+    fn invalid_yaml_is_reported() {
+        let diags = check("---\nname: [unclosed\n---\nbody");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("not valid YAML"), "got {}", diags[0].message);
+    }
+
+    #[test]
+    fn non_mapping_root_is_reported() {
+        let diags = check("---\n- one\n- two\n---\nbody");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("mapping"));
+    }
+
+    #[test]
+    fn no_frontmatter_at_all_is_reported() {
+        let diags = check("# Just a heading\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("start immediately"));
+    }
+
+    #[test]
+    fn non_string_name_is_reported() {
+        let diags = check("---\nname: 42\ndescription: ok\n---\nbody");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("\"name\" must be a string, found integer"));
+        assert_eq!(diags[0].line, Some(2));
+    }
+
+    #[test]
+    fn non_string_description_is_reported() {
+        let diags = check("---\nname: s\ndescription:\n  - a\n  - b\n---\nbody");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("\"description\" must be a string, found list"));
+    }
+
+    #[test]
+    fn both_fields_non_string_produce_two_diagnostics() {
+        let diags = check("---\nname: true\ndescription: 1.5\n---\nbody");
+        assert_eq!(diags.len(), 2);
+    }
+
+    #[test]
+    fn folded_description_is_a_string() {
+        assert!(check("---\nname: s\ndescription: >\n  folded\n  text\n---\nbody").is_empty());
+    }
+
+    #[test]
+    fn error_line_defaults_to_one() {
+        assert_eq!(error_line(&strict::Error::RootNotMapping), 1);
+        assert_eq!(error_line(&strict::Error::InvalidYaml { message: String::new(), line: 7 }), 7);
+    }
+
+    #[test]
+    fn rule_metadata() {
+        assert_eq!(InvalidFrontmatter.id(), "skill/invalid-frontmatter");
+        assert_eq!(InvalidFrontmatter.name(), "invalid skill frontmatter");
+        assert!(InvalidFrontmatter.help_url().is_some());
+        assert!(InvalidFrontmatter.help_text().is_some());
+    }
+}

--- a/crates/libaipm/src/lint/rules/skill_missing_desc.rs
+++ b/crates/libaipm/src/lint/rules/skill_missing_desc.rs
@@ -36,7 +36,27 @@ impl Rule for MissingDescription {
             return Ok(vec![]);
         };
         let diag = match skill.frontmatter {
-            Some(ref fm) if fm.fields.contains_key("description") => return Ok(vec![]),
+            Some(ref fm) if fm.fields.contains_key("description") => {
+                // Present but blank is as useless to the engine as absent: the
+                // description is what drives skill selection.
+                if skill.field("description").is_some_and(|d| d.trim().is_empty()) {
+                    let line = fm.field_lines.get("description").copied().unwrap_or(fm.start_line);
+                    return Ok(vec![Diagnostic {
+                        rule_id: self.id().to_string(),
+                        severity: self.default_severity(),
+                        message: "SKILL.md field \"description\" is empty".to_string(),
+                        file_path: skill.path,
+                        line: Some(line),
+                        col: Some(1),
+                        end_line: Some(line),
+                        end_col: Some(12),
+                        source_type,
+                        help_text: None,
+                        help_url: None,
+                    }]);
+                }
+                return Ok(vec![]);
+            },
             Some(ref fm) => Diagnostic {
                 rule_id: self.id().to_string(),
                 severity: self.default_severity(),

--- a/crates/libaipm/src/lint/rules/skill_name_invalid.rs
+++ b/crates/libaipm/src/lint/rules/skill_name_invalid.rs
@@ -51,14 +51,14 @@ impl Rule for NameInvalidChars {
         let Some((source_type, skill)) = super::read_skill_preamble(file_path, fs) else {
             return Ok(vec![]);
         };
-        let Some(ref fm) = skill.frontmatter else { return Ok(vec![]) };
-        let Some(name) = fm.fields.get("name") else { return Ok(vec![]) };
+        let Some(name) = skill.field("name") else { return Ok(vec![]) };
         if name.is_empty() || is_valid_copilot_name(name) {
             return Ok(vec![]);
         }
-        let name_line = fm.field_lines.get("name").copied();
+        let name_line =
+            skill.frontmatter.as_ref().and_then(|fm| fm.field_lines.get("name").copied());
         let (col, end_col) = name_line
-            .and_then(|n| skill.content.lines().nth(n - 1))
+            .and_then(|n| skill.content.lines().nth(n.saturating_sub(1)))
             .and_then(|line| crate::frontmatter::field_value_range(line, "name"))
             .unzip();
         Ok(vec![Diagnostic {

--- a/crates/libaipm/src/lint/rules/skill_name_not_kebab.rs
+++ b/crates/libaipm/src/lint/rules/skill_name_not_kebab.rs
@@ -1,0 +1,170 @@
+//! Rule: `skill/name-not-kebab-case` — skill name is not lowercase kebab-case.
+//!
+//! Skill directories and skill names are addressed on the command line and in
+//! plugin manifests, so the portable form is lowercase kebab-case: groups of
+//! lowercase ASCII letters and digits joined by single hyphens.
+
+use std::path::Path;
+
+use crate::fs::Fs;
+use crate::lint::diagnostic::{Diagnostic, Severity};
+use crate::lint::rule::Rule;
+use crate::lint::Error;
+
+/// Check whether `name` is lowercase kebab-case (`^[a-z0-9]+(-[a-z0-9]+)*$`).
+fn is_kebab_case(name: &str) -> bool {
+    !name.is_empty()
+        && name.split('-').all(|part| {
+            !part.is_empty() && part.bytes().all(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+        })
+}
+
+/// Checks that skill names are lowercase kebab-case.
+pub struct NameNotKebabCase;
+
+impl Rule for NameNotKebabCase {
+    fn id(&self) -> &'static str {
+        "skill/name-not-kebab-case"
+    }
+
+    fn name(&self) -> &'static str {
+        "skill name not kebab-case"
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Warning
+    }
+
+    fn help_url(&self) -> Option<&'static str> {
+        Some("https://github.com/TheLarkInn/aipm/blob/main/docs/rules/skill/name-not-kebab-case.md")
+    }
+
+    fn help_text(&self) -> Option<&'static str> {
+        Some("use lowercase letters and digits separated by single hyphens")
+    }
+
+    fn check_file(&self, file_path: &Path, fs: &dyn Fs) -> Result<Vec<Diagnostic>, Error> {
+        let Some((source_type, skill)) = super::read_skill_preamble(file_path, fs) else {
+            return Ok(vec![]);
+        };
+        let Some(name) = skill.field("name") else { return Ok(vec![]) };
+        if name.trim().is_empty() || is_kebab_case(name) {
+            return Ok(vec![]);
+        }
+        let name_line =
+            skill.frontmatter.as_ref().and_then(|fm| fm.field_lines.get("name").copied());
+        let (col, end_col) = name_line
+            .and_then(|n| skill.content.lines().nth(n.saturating_sub(1)))
+            .and_then(|line| crate::frontmatter::field_value_range(line, "name"))
+            .unzip();
+        Ok(vec![Diagnostic {
+            rule_id: self.id().to_string(),
+            severity: self.default_severity(),
+            message: format!(
+                "skill name \"{name}\" is not lowercase kebab-case (must match /^[a-z0-9]+(-[a-z0-9]+)*$/)"
+            ),
+            file_path: skill.path,
+            line: name_line,
+            col,
+            end_line: name_line,
+            end_col,
+            source_type,
+            help_text: None,
+            help_url: None,
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lint::rules::test_helpers::MockFs;
+    use std::path::PathBuf;
+
+    fn check(content: &str) -> Vec<Diagnostic> {
+        let mut fs = MockFs::new();
+        let path = PathBuf::from(".ai/p/skills/s/SKILL.md");
+        fs.exists.insert(path.clone());
+        fs.files.insert(path.clone(), content.to_string());
+        NameNotKebabCase.check_file(&path, &fs).ok().unwrap_or_default()
+    }
+
+    #[test]
+    fn accepts_kebab_case() {
+        assert!(is_kebab_case("skill"));
+        assert!(is_kebab_case("my-skill"));
+        assert!(is_kebab_case("pdf-2-text"));
+        assert!(is_kebab_case("a1"));
+    }
+
+    #[test]
+    fn rejects_non_kebab_case() {
+        assert!(!is_kebab_case(""));
+        assert!(!is_kebab_case("MySkill"));
+        assert!(!is_kebab_case("my_skill"));
+        assert!(!is_kebab_case("my skill"));
+        assert!(!is_kebab_case("my.skill"));
+        assert!(!is_kebab_case("-leading"));
+        assert!(!is_kebab_case("trailing-"));
+        assert!(!is_kebab_case("double--hyphen"));
+    }
+
+    #[test]
+    fn no_file_returns_empty() {
+        let fs = MockFs::new();
+        let diags = NameNotKebabCase
+            .check_file(Path::new(".ai/p/skills/s/SKILL.md"), &fs)
+            .ok()
+            .unwrap_or_default();
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn kebab_case_name_passes() {
+        assert!(check("---\nname: my-skill\ndescription: d\n---\nbody").is_empty());
+    }
+
+    #[test]
+    fn uppercase_name_is_reported() {
+        let diags = check("---\nname: MySkill\ndescription: d\n---\nbody");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].rule_id, "skill/name-not-kebab-case");
+        assert_eq!(diags[0].line, Some(2));
+        assert_eq!(diags[0].col, Some(7));
+        assert_eq!(diags[0].end_col, Some(14));
+    }
+
+    #[test]
+    fn underscore_name_is_reported() {
+        assert_eq!(check("---\nname: my_skill\n---\nbody").len(), 1);
+    }
+
+    #[test]
+    fn missing_name_is_ignored() {
+        assert!(check("---\ndescription: d\n---\nbody").is_empty());
+    }
+
+    #[test]
+    fn blank_name_is_ignored() {
+        assert!(check("---\nname: \"  \"\n---\nbody").is_empty());
+    }
+
+    #[test]
+    fn no_frontmatter_is_ignored() {
+        assert!(check("no frontmatter here").is_empty());
+    }
+
+    #[test]
+    fn non_string_name_is_ignored() {
+        // `skill/invalid-frontmatter` owns the type error; this rule stays quiet.
+        assert!(check("---\nname: [a, b]\n---\nbody").is_empty());
+    }
+
+    #[test]
+    fn rule_metadata() {
+        assert_eq!(NameNotKebabCase.name(), "skill name not kebab-case");
+        assert_eq!(NameNotKebabCase.default_severity(), Severity::Warning);
+        assert!(NameNotKebabCase.help_url().is_some());
+        assert!(NameNotKebabCase.help_text().is_some());
+    }
+}

--- a/crates/libaipm/src/lint/rules/skill_name_too_long.rs
+++ b/crates/libaipm/src/lint/rules/skill_name_too_long.rs
@@ -44,23 +44,22 @@ impl Rule for NameTooLong {
         let Some((source_type, skill)) = super::read_skill_preamble(file_path, fs) else {
             return Ok(vec![]);
         };
-        let Some(ref fm) = skill.frontmatter else { return Ok(vec![]) };
-        let Some(name) = fm.fields.get("name") else { return Ok(vec![]) };
-        if name.len() <= MAX_SKILL_NAME_LENGTH {
+        let Some(name) = skill.field("name") else { return Ok(vec![]) };
+        let length = name.chars().count();
+        if length <= MAX_SKILL_NAME_LENGTH {
             return Ok(vec![]);
         }
-        let name_line = fm.field_lines.get("name").copied();
+        let name_line =
+            skill.frontmatter.as_ref().and_then(|fm| fm.field_lines.get("name").copied());
         let (col, end_col) = name_line
-            .and_then(|n| skill.content.lines().nth(n - 1))
+            .and_then(|n| skill.content.lines().nth(n.saturating_sub(1)))
             .and_then(|line| crate::frontmatter::field_value_range(line, "name"))
             .unzip();
         Ok(vec![Diagnostic {
             rule_id: self.id().to_string(),
             severity: self.default_severity(),
             message: format!(
-                "skill name exceeds {} characters ({} chars, Copilot CLI limit)",
-                MAX_SKILL_NAME_LENGTH,
-                name.len()
+                "skill name exceeds {MAX_SKILL_NAME_LENGTH} characters ({length} chars, Copilot CLI limit)"
             ),
             file_path: skill.path,
             line: name_line,

--- a/crates/libaipm/src/lint/rules/valid_tool_name.rs
+++ b/crates/libaipm/src/lint/rules/valid_tool_name.rs
@@ -199,7 +199,11 @@ fn format_toml_string_array(names: &[&'static str]) -> String {
 /// Returns [`EngineSet::empty()`] when no manifest is found, the manifest
 /// cannot be read or parsed, or the resolved engines are `None` /
 /// `Some(EngineSet::empty())`.
-fn nearest_declared_engines(file_path: &Path, lint_dir: &Path, fs: &dyn Fs) -> EngineSet {
+pub(crate) fn nearest_declared_engines(
+    file_path: &Path,
+    lint_dir: &Path,
+    fs: &dyn Fs,
+) -> EngineSet {
     let Some(manifest_path) = find_nearest_manifest(file_path, lint_dir, fs) else {
         return EngineSet::empty();
     };

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,11 +39,14 @@ Quality rules enforced by `aipm lint`:
 
 | Rule | Default | Description |
 |------|---------|-------------|
+| [invalid-frontmatter](rules/skill/invalid-frontmatter.md) | error | Frontmatter delimiters, YAML syntax, root shape, or field types are invalid |
 | [missing-name](rules/skill/missing-name.md) | warn | Skill has no `name` in frontmatter |
-| [missing-description](rules/skill/missing-description.md) | warn | Skill has no `description` in frontmatter |
+| [missing-description](rules/skill/missing-description.md) | warn | Skill has no `description` in frontmatter, or it is empty |
 | [name-invalid-chars](rules/skill/name-invalid-chars.md) | warn | Skill name contains disallowed characters |
+| [name-not-kebab-case](rules/skill/name-not-kebab-case.md) | warn | Skill name is not lowercase kebab-case |
 | [name-too-long](rules/skill/name-too-long.md) | warn | Skill name exceeds the maximum length |
 | [description-too-long](rules/skill/description-too-long.md) | warn | Skill description exceeds the maximum length |
+| [description-invalid-chars](rules/skill/description-invalid-chars.md) | warn | Skill description contains `<` or `>` (Copilot only) |
 | [invalid-shell](rules/skill/invalid-shell.md) | error | Skill references an unrecognized shell |
 | [oversized](rules/skill/oversized.md) | warn | Skill file exceeds the recommended size |
 

--- a/docs/guides/lint.md
+++ b/docs/guides/lint.md
@@ -329,11 +329,14 @@ All available rules, grouped by category:
 
 | Rule | Severity | Description |
 |------|----------|-------------|
+| [`skill/description-invalid-chars`](../rules/skill/description-invalid-chars.md) | warning | `description` contains `<` or `>` (Copilot-targeted skills only) |
 | [`skill/description-too-long`](../rules/skill/description-too-long.md) | warning | `description` frontmatter value exceeds the length limit |
+| [`skill/invalid-frontmatter`](../rules/skill/invalid-frontmatter.md) | error | Frontmatter delimiters, YAML syntax, root shape, or `name`/`description` types are invalid |
 | [`skill/invalid-shell`](../rules/skill/invalid-shell.md) | error | `shell` frontmatter value is not a recognised shell |
-| [`skill/missing-description`](../rules/skill/missing-description.md) | warning | SKILL.md is missing a `description` field in frontmatter |
+| [`skill/missing-description`](../rules/skill/missing-description.md) | warning | SKILL.md is missing a `description` field in frontmatter, or it is empty |
 | [`skill/missing-name`](../rules/skill/missing-name.md) | warning | SKILL.md is missing a `name` field in frontmatter |
 | [`skill/name-invalid-chars`](../rules/skill/name-invalid-chars.md) | warning | Skill `name` contains characters that are not allowed |
+| [`skill/name-not-kebab-case`](../rules/skill/name-not-kebab-case.md) | warning | Skill `name` is not lowercase kebab-case |
 | [`skill/name-too-long`](../rules/skill/name-too-long.md) | warning | Skill `name` exceeds the maximum length |
 | [`skill/oversized`](../rules/skill/oversized.md) | warning | SKILL.md file exceeds the recommended size limit |
 

--- a/docs/rules/skill/description-invalid-chars.md
+++ b/docs/rules/skill/description-invalid-chars.md
@@ -1,0 +1,55 @@
+# skill/description-invalid-chars
+
+**Severity:** warning
+**Fixable:** No
+
+Checks that a skill `description` contains no `<` or `>` characters.
+
+Copilot CLI injects skill descriptions into an XML-tagged block in the system prompt, so angle brackets in a description corrupt that markup. This is **not** a general YAML restriction and Claude Code does not impose it, so the rule is scoped to skills that Copilot can actually load:
+
+| Skill location | Checked? |
+|---|---|
+| `.github/` | Always — Copilot's own source root |
+| `.claude/` | Never |
+| `.ai/<plugin>/` | Unless the nearest `aipm.toml` declares an `engines` list that excludes `copilot` |
+
+The description is evaluated **after** YAML parsing, so folded (`>`) and literal (`|`) block scalars are checked by their resolved value rather than their source text.
+
+## Examples
+
+### Incorrect
+
+```markdown
+---
+name: my-skill
+description: Wraps the <tool> invocation for you
+---
+```
+
+### Correct
+
+```markdown
+---
+name: my-skill
+description: Wraps the tool invocation for you
+---
+```
+
+Or opt the plugin out of Copilot in `aipm.toml`:
+
+```toml
+[package]
+name = "my-plugin"
+version = "1.0.0"
+engines = ["claude"]
+```
+
+## How to fix
+
+Rewrite the description without angle brackets — name the tag or tool in prose instead — or declare `engines` in `aipm.toml` without `copilot` if the plugin is Claude-only.
+
+## See also
+
+- [skill/description-too-long](description-too-long.md) — validates the description length limit
+- [skill/missing-description](missing-description.md) — validates that a `description` field is present and non-empty
+- [Using `aipm lint`](../../guides/lint.md) — CLI reference for running the lint system

--- a/docs/rules/skill/description-too-long.md
+++ b/docs/rules/skill/description-too-long.md
@@ -5,6 +5,8 @@
 
 Checks that the `description` field in SKILL.md frontmatter is no longer than 1 024 characters. This limit is derived from the Copilot CLI Zod schema (`z.string().max(1024)`). Very long descriptions are truncated in `aipm list` output and plugin marketplace listings.
 
+The limit counts **Unicode code points**, not bytes, and the value is measured **after** YAML parsing — a folded (`>`) or literal (`|`) block scalar is measured by the string the engine actually receives, not by its source text.
+
 ## Examples
 
 ### Incorrect
@@ -29,6 +31,7 @@ Shorten the description to 1 024 characters or fewer. Keep it to one or two sent
 ## See also
 
 - [skill/missing-description](missing-description.md) — validates that a `description` field is present
+- [skill/description-invalid-chars](description-invalid-chars.md) — rejects `<` and `>` in Copilot-targeted descriptions
 - [skill/name-too-long](name-too-long.md) — validates the name length limit
 - [Creating a plugin](../../guides/creating-a-plugin.md) — how to scaffold a new plugin with all required frontmatter
 - [Using `aipm lint`](../../guides/lint.md) — CLI reference for running the lint system

--- a/docs/rules/skill/invalid-frontmatter.md
+++ b/docs/rules/skill/invalid-frontmatter.md
@@ -1,0 +1,107 @@
+# skill/invalid-frontmatter
+
+**Severity:** error
+**Fixable:** No
+
+Validates the *structure* of a `SKILL.md` frontmatter block. Both Claude Code and Copilot CLI extract frontmatter with an anchored `---` match and then hand the block to a YAML parser — if any of the checks below fail, the engine silently ignores the file and the skill never loads.
+
+This rule reports:
+
+| Check | Failure message |
+|---|---|
+| The file starts **immediately** with a line containing exactly `---` | `file must start immediately with a line containing exactly ---` |
+| A UTF-8 byte-order mark precedes the opening delimiter | `... (a UTF-8 byte-order mark precedes it)` |
+| The block is closed by a line containing exactly `---` | `frontmatter is not closed by a line containing exactly ---` |
+| The block between the delimiters is valid YAML | `frontmatter is not valid YAML (line N): ...` |
+| The YAML root is a key/value mapping | `frontmatter must be a YAML mapping of keys to values` |
+| `name` parses to a YAML string | `SKILL.md field "name" must be a string, found <type>` |
+| `description` parses to a YAML string | `SKILL.md field "description" must be a string, found <type>` |
+
+Both LF and CRLF line endings are accepted. Delimiters must be *exact*: `----`, `--- `, or an indented `---` are all rejected.
+
+## Examples
+
+### Incorrect
+
+A blank line before the frontmatter:
+
+```markdown
+
+---
+name: my-skill
+description: Does something useful
+---
+```
+
+An inexact closing delimiter:
+
+```markdown
+---
+name: my-skill
+description: Does something useful
+----
+```
+
+Invalid YAML:
+
+```markdown
+---
+name: my-skill
+tags: [unclosed
+---
+```
+
+A root that is not a mapping:
+
+```markdown
+---
+- my-skill
+- Does something useful
+---
+```
+
+A non-string field:
+
+```markdown
+---
+name: 42
+description:
+  - one
+  - two
+---
+```
+
+### Correct
+
+```markdown
+---
+name: my-skill
+description: Does something useful
+---
+
+# My Skill
+```
+
+Folded and literal block scalars are valid — they parse to strings:
+
+```markdown
+---
+name: my-skill
+description: >
+  A long description that wraps
+  across several source lines.
+---
+```
+
+## How to fix
+
+1. Remove anything (including blank lines and byte-order marks) before the opening `---`.
+2. Make both delimiter lines contain exactly three hyphens and nothing else.
+3. Fix the YAML syntax reported in the message — the line number is file-relative.
+4. Make sure the block is a mapping of keys to values, and that `name` and `description` are strings (quote them if they would otherwise parse as a number or boolean).
+
+## See also
+
+- [skill/missing-name](missing-name.md) — validates that a `name` field is present
+- [skill/missing-description](missing-description.md) — validates that a `description` field is present and non-empty
+- [Using `aipm lint`](../../guides/lint.md) — CLI reference for running the lint system

--- a/docs/rules/skill/missing-description.md
+++ b/docs/rules/skill/missing-description.md
@@ -3,7 +3,9 @@
 **Severity:** warning
 **Fixable:** No
 
-Checks that every SKILL.md file includes a `description` field in the YAML frontmatter. A description helps users understand the purpose of the skill when browsing or listing installed plugins.
+Checks that every SKILL.md file includes a non-empty `description` field in the YAML frontmatter. A description helps users understand the purpose of the skill when browsing or listing installed plugins, and it is what the engine uses to decide when to activate the skill.
+
+A `description` that is present but empty or whitespace-only is reported as well: `SKILL.md field "description" is empty`.
 
 ## Examples
 
@@ -12,6 +14,14 @@ Checks that every SKILL.md file includes a `description` field in the YAML front
 ---
 name: my-skill
 shell: bash
+---
+Skill instructions here...
+```
+
+```markdown
+---
+name: my-skill
+description: "   "
 ---
 Skill instructions here...
 ```
@@ -27,11 +37,13 @@ Skill instructions here...
 ```
 
 ## How to fix
-Add a `description` field to the YAML frontmatter. Write a short sentence summarising what the skill does.
+Add a `description` field to the YAML frontmatter with a short sentence summarising what the skill does. If the field is already present, give it a non-blank value.
 
 ## See also
 
 - [skill/missing-name](missing-name.md) — validates the skill's `name` field
 - [skill/description-too-long](description-too-long.md) — validates the description length limit
+- [skill/description-invalid-chars](description-invalid-chars.md) — rejects `<` and `>` in Copilot-targeted descriptions
+- [skill/invalid-frontmatter](invalid-frontmatter.md) — validates the frontmatter structure and field types
 - [Creating a plugin](../../guides/creating-a-plugin.md) — how to scaffold a new plugin with all required frontmatter
 - [Using `aipm lint`](../../guides/lint.md) — CLI reference for running the lint system

--- a/docs/rules/skill/missing-name.md
+++ b/docs/rules/skill/missing-name.md
@@ -33,6 +33,7 @@ Add a `name` field to the YAML frontmatter at the top of your SKILL.md file. The
 
 - [skill/missing-description](missing-description.md) — validates the skill's `description` field
 - [skill/name-invalid-chars](name-invalid-chars.md) — validates that the name uses allowed characters
+- [skill/name-not-kebab-case](name-not-kebab-case.md) — validates that the name is lowercase kebab-case
 - [skill/name-too-long](name-too-long.md) — validates the name length limit
 - [Creating a plugin](../../guides/creating-a-plugin.md) — how to scaffold a new plugin with all required frontmatter
 - [Using `aipm lint`](../../guides/lint.md) — CLI reference for running the lint system

--- a/docs/rules/skill/name-invalid-chars.md
+++ b/docs/rules/skill/name-invalid-chars.md
@@ -51,5 +51,6 @@ Remove any characters that are not alphanumeric, dots, underscores, hyphens, or 
 
 - [skill/missing-name](missing-name.md) — validates that a `name` field is present
 - [skill/name-too-long](name-too-long.md) — validates the name length limit
+- [skill/name-not-kebab-case](name-not-kebab-case.md) — validates that the name is lowercase kebab-case
 - [Creating a plugin](../../guides/creating-a-plugin.md) — how to scaffold a new plugin with correct naming
 - [Using `aipm lint`](../../guides/lint.md) — CLI reference for running the lint system

--- a/docs/rules/skill/name-not-kebab-case.md
+++ b/docs/rules/skill/name-not-kebab-case.md
@@ -1,0 +1,72 @@
+# skill/name-not-kebab-case
+
+**Severity:** warning
+**Fixable:** No
+
+Checks that the `name` field in SKILL.md frontmatter is lowercase kebab-case — groups of lowercase ASCII letters and digits joined by single hyphens:
+
+```
+^[a-z0-9]+(-[a-z0-9]+)*$
+```
+
+Skill names are typed on the command line, used as directory names, and referenced from plugin manifests, so a single portable casing convention avoids case-sensitivity and quoting surprises across platforms.
+
+This rule is stricter than [skill/name-invalid-chars](name-invalid-chars.md), which only rejects characters outside the engine's permitted set.
+
+## Examples
+
+### Incorrect
+
+```markdown
+---
+name: MySkill
+description: Uppercase letters are not kebab-case
+---
+```
+
+```markdown
+---
+name: my_skill
+description: Underscores are not hyphens
+---
+```
+
+```markdown
+---
+name: my skill
+description: Spaces are not hyphens
+---
+```
+
+```markdown
+---
+name: my--skill
+description: Doubled hyphens leave an empty segment
+---
+```
+
+### Correct
+
+```markdown
+---
+name: my-skill
+description: Does something useful
+---
+```
+
+```markdown
+---
+name: pdf-2-text
+description: Digits are allowed inside segments
+---
+```
+
+## How to fix
+
+Lowercase the name and replace every separator (spaces, underscores, dots, camelCase boundaries) with a single hyphen. Drop leading and trailing hyphens.
+
+## See also
+
+- [skill/name-invalid-chars](name-invalid-chars.md) — validates the engine-permitted character set
+- [skill/name-too-long](name-too-long.md) — validates the name length limit
+- [Using `aipm lint`](../../guides/lint.md) — CLI reference for running the lint system

--- a/docs/rules/skill/name-too-long.md
+++ b/docs/rules/skill/name-too-long.md
@@ -30,6 +30,7 @@ Shorten the name to 64 characters or fewer. Use a concise, descriptive identifie
 
 - [skill/missing-name](missing-name.md) — validates that a `name` field is present
 - [skill/name-invalid-chars](name-invalid-chars.md) — validates that the name uses allowed characters
+- [skill/name-not-kebab-case](name-not-kebab-case.md) — validates that the name is lowercase kebab-case
 - [skill/description-too-long](description-too-long.md) — validates the description length limit
 - [Creating a plugin](../../guides/creating-a-plugin.md) — how to scaffold a new plugin with correct naming
 - [Using `aipm lint`](../../guides/lint.md) — CLI reference for running the lint system

--- a/fixtures/extension-test/WHAT_SHOULD_FAIL.md
+++ b/fixtures/extension-test/WHAT_SHOULD_FAIL.md
@@ -35,6 +35,7 @@ You need the Even Better TOML extension + the bundled schema to see them.
 
 ### `invalid-chars/SKILL.md`
 - **`skill/name-invalid-chars`** (Warning): `name: has@invalid#chars!` — `@`, `#`, `!` are not in `[a-zA-Z0-9._- ]`.
+- **`skill/name-not-kebab-case`** (Warning): the same `name` is not lowercase kebab-case.
 
 ### `desc-too-long/SKILL.md`
 - **`skill/description-too-long`** (Warning): `description` is 1025 chars, limit is 1024.
@@ -91,7 +92,7 @@ You need the Even Better TOML extension + the bundled schema to see them.
 
 ---
 
-## Summary: All 17 Rule IDs That Should Fire
+## Summary: All 18 Rule IDs That Should Fire
 
 | Rule ID | Severity | File |
 |---------|----------|------|
@@ -100,6 +101,7 @@ You need the Even Better TOML extension + the bundled schema to see them.
 | `skill/oversized` | Warning | `broken-skills/skills/oversized/SKILL.md` |
 | `skill/name-too-long` | Warning | `broken-skills/skills/name-too-long/SKILL.md` |
 | `skill/name-invalid-chars` | Warning | `broken-skills/skills/invalid-chars/SKILL.md` |
+| `skill/name-not-kebab-case` | Warning | `broken-skills/skills/invalid-chars/SKILL.md` |
 | `skill/description-too-long` | Warning | `broken-skills/skills/desc-too-long/SKILL.md` |
 | `skill/invalid-shell` | Error | `broken-skills/skills/invalid-shell/SKILL.md` |
 | `plugin/broken-paths` | Error | `broken-skills/skills/broken-ref/SKILL.md` |

--- a/schemas/aipm.toml.schema.json
+++ b/schemas/aipm.toml.schema.json
@@ -60,7 +60,7 @@
             }
           },
           "patternProperties": {
-            "^(skill/missing-name|skill/missing-description|skill/oversized|skill/name-too-long|skill/name-invalid-chars|skill/description-too-long|skill/invalid-shell|plugin/broken-paths|agent/missing-tools|hook/unknown-event|hook/legacy-event-name|source/misplaced-features|marketplace/source-resolve|marketplace/plugin-field-mismatch|plugin/missing-registration|plugin/missing-manifest|plugin/required-fields)$": {
+            "^(skill/missing-name|skill/missing-description|skill/oversized|skill/name-too-long|skill/name-invalid-chars|skill/name-not-kebab-case|skill/description-too-long|skill/description-invalid-chars|skill/invalid-frontmatter|skill/invalid-shell|plugin/broken-paths|agent/missing-tools|hook/unknown-event|hook/legacy-event-name|source/misplaced-features|marketplace/source-resolve|marketplace/plugin-field-mismatch|plugin/missing-registration|plugin/missing-manifest|plugin/required-fields)$": {
               "description": "Override the severity of a lint rule, or suppress it entirely.",
               "oneOf": [
                 {

--- a/vscode-aipm/schemas/aipm.toml.schema.json
+++ b/vscode-aipm/schemas/aipm.toml.schema.json
@@ -36,7 +36,7 @@
             }
           },
           "patternProperties": {
-            "^(skill/missing-name|skill/missing-description|skill/oversized|skill/name-too-long|skill/name-invalid-chars|skill/description-too-long|skill/invalid-shell|plugin/broken-paths|agent/missing-tools|hook/unknown-event|hook/legacy-event-name|source/misplaced-features|marketplace/source-resolve|marketplace/plugin-field-mismatch|plugin/missing-registration|plugin/missing-manifest|plugin/required-fields)$": {
+            "^(skill/missing-name|skill/missing-description|skill/oversized|skill/name-too-long|skill/name-invalid-chars|skill/name-not-kebab-case|skill/description-too-long|skill/description-invalid-chars|skill/invalid-frontmatter|skill/invalid-shell|plugin/broken-paths|agent/missing-tools|hook/unknown-event|hook/legacy-event-name|source/misplaced-features|marketplace/source-resolve|marketplace/plugin-field-mismatch|plugin/missing-registration|plugin/missing-manifest|plugin/required-fields)$": {
               "description": "Override the severity of a lint rule, or suppress it entirely.",
               "oneOf": [
                 {


### PR DESCRIPTION
## Enforce strict skill frontmatter validation

Adds a YAML-backed validator (`frontmatter/strict.rs`, pure-Rust `yaml-rust2`), plus three rules:

- **`skill/invalid-frontmatter`** (error) — exact `---` delimiters, valid YAML, mapping root, string-typed `name`/`description`
- **`skill/name-not-kebab-case`** (warn)
- **`skill/description-invalid-chars`** (warn) — `<`/`>`, scoped to Copilot since it's a prompt-markup constraint: `.github/` always checked, `.claude/` never, `.ai/` unless `aipm.toml` `engines` excludes copilot

Tightens: `name`/`description` lengths now count Unicode code points, not bytes,
on the parsed value, so folded scalars measure correctly; `missing-description`
catches whitespace-only.

Docs, schemas, and changelog updated; build, fmt, and full test suite pass.