### PR TITLE
ci: add agentic workflow lock drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   LIBGIT2_SYS_USE_PKG_CONFIG: "1"
+  # Pinned so CI does not float to the latest gh-aw release. Bumping this is a
+  # deliberate change: update it, run `gh aw compile`, and commit the locks.
+  GH_AW_VERSION: v0.85.4
 
 jobs:
   ci:
@@ -47,6 +50,53 @@ jobs:
 
       - name: Format
         run: cargo fmt --check
+
+  aw-lock-drift:
+    name: Agentic workflow lock drift
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gh-aw (pinned)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh extension install github/gh-aw --pin "$GH_AW_VERSION"
+
+      - name: Recompile agentic workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh aw compile
+
+      - name: Fail if lock files are out of date
+        run: |
+          if ! git diff --exit-code -- .github/workflows .github/aw .gitattributes; then
+            echo "::error::Agentic workflow lock files are out of date. Run 'gh aw compile' with gh-aw ${GH_AW_VERSION} and commit the result."
+            exit 1
+          fi
+
+      - name: Fail if compile produced untracked files
+        run: |
+          UNTRACKED=$(git ls-files --others --exclude-standard -- .github/workflows .github/aw)
+          if [ -n "$UNTRACKED" ]; then
+            echo "::error::'gh aw compile' produced untracked files. Either commit them or remove the orphaned source."
+            echo "$UNTRACKED"
+            exit 1
+          fi
+
+      - name: Fail if lock files disagree on compiler version
+        run: |
+          # head -qn1 reads the first line of *each* file; `sed -n '1p'` would
+          # treat them as one concatenated stream and only inspect the first.
+          VERSIONS=$(head -qn1 .github/workflows/*.lock.yml \
+            | grep -o '"compiler_version":"[^"]*"' \
+            | sort -u)
+          echo "$VERSIONS"
+          if [ "$(echo "$VERSIONS" | wc -l)" -ne 1 ]; then
+            echo "::error::Lock files were compiled with different gh-aw versions. Recompile them all with ${GH_AW_VERSION}."
+            exit 1
+          fi
 
   coverage:
     name: Coverage (89% branch gate)


### PR DESCRIPTION
Fixes #1390

Stacked on #1401.

## What

Adds an `aw-lock-drift` job to CI that catches the class of rot behind #1385, #1388 and #1389.

## Why

Nothing verified that `.lock.yml` files matched their `.md` sources, or that they were all built with the same gh-aw version. That gap is *why* the agentic workflows decayed silently:

- five locks at compiler `v0.67.4`, one at `v0.71.1`
- the `v0.71.1` lock pinned an AWF binary later deleted upstream, failing Reverse Binary Analysis for **10+ consecutive weeks**
- `research-codebase.md` compiled to a lock file nobody tracked

`CLAUDE.md` asks contributors to run `gh aw compile` and commit both files, but that was honour-system only.

## The check

Installs a pinned gh-aw, recompiles, and fails when:

1. **recompiling changes any tracked file** — stale locks
2. **recompiling produces untracked files** — orphaned sources (would have caught #1385)
3. **lock files disagree on `compiler_version`** — skew (would have caught #1388)

The version is pinned via `GH_AW_VERSION: v0.85.4` rather than floating to `latest`, so CI can't spontaneously break when upstream cuts a release. Bumping it becomes a deliberate, reviewable change.

## A bug I caught while testing this

My first draft used `sed -n '1p' .github/workflows/*.lock.yml` to read each lock's header. That's wrong — `sed` treats multiple file arguments as a **single concatenated stream**, so it only ever inspects the first file.

I tested it against the actual pre-fix locks from `main`:

```
--- BROKEN: sed -n '1p' (single concatenated stream) ---
"compiler_version":"v0.67.4"

--- FIXED: head -qn1 (first line of each file) ---
"compiler_version":"v0.67.4"
"compiler_version":"v0.71.1"
distinct=2
RESULT: correctly FAILS on the original skew
```

The `sed` form would have shipped a check that silently passed on the exact skew it exists to catch. Fixed to `head -qn1`, with a comment explaining why.

## Verification

- `ci.yml` parses; jobs are now `['ci', 'aw-lock-drift', 'coverage']`
- **Positive test:** against the pre-fix locks from `origin/main`, the version assertion reports `distinct=2` and fails
- **Negative test:** against this branch's tree it reports a single `v0.85.4` and passes
- Untracked-file assertion is meaningful only because #1401 made `gh aw compile` idempotent — on a clean tree it now produces no unexpected output

## Follow-up worth considering

A scheduled job that checks whether pinned external artifacts still resolve (AWF release, action SHAs). The `v0.25.28` 404 would then surface the week it happened rather than 10 weeks later.
