### PR TITLE
chore: release v0.25.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1541,7 +1541,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "libaipm-engine-spec"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "bitflags 2.11.0",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,8 +22,8 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.25.0" }
-libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.25.0" }
+libaipm = { path = "crates/libaipm", version = "0.25.1" }
+libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.25.1" }
 
 # Engine API schema source-of-truth (build-time codegen + runtime tables)
 phf = "0.13"

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-08-14
+
+### Documentation
+- Update CHANGELOG and README for v0.25.0 ([#884](https://github.com/TheLarkInn/aipm/pull/884)) (80bd042)
+
 ## [0.25.0] - 2026-05-11
 
 ### Documentation

--- a/crates/libaipm-engine-spec/CHANGELOG.md
+++ b/crates/libaipm-engine-spec/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-08-14
+
+### Documentation
+- Update CHANGELOG and README for v0.25.0 ([#884](https://github.com/TheLarkInn/aipm/pull/884)) (80bd042)
+
 ## [0.25.0] - 2026-05-11
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-08-14
+
+### Documentation
+- Update CHANGELOG and README for v0.25.0 ([#884](https://github.com/TheLarkInn/aipm/pull/884)) (80bd042)
+
+### Testing
+- Cover package-only manifest in compare_and_warn (e865eab)
+- Cover scaffold_marketplace ai_existed=true with no_starter=false branch (4809d41)
+- Cover compare_and_warn matching-engines guard branch (3a3d6d3)
+
 ## [0.25.0] - 2026-05-11
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm-engine-spec`: 0.25.0 -> 0.25.1 (✓ API compatible changes)
* `libaipm`: 0.25.0 -> 0.25.1 (✓ API compatible changes)
* `aipm`: 0.25.0 -> 0.25.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `libaipm-engine-spec`

<blockquote>

## [0.25.1] - 2026-08-14

### Documentation
- Update CHANGELOG and README for v0.25.0 ([#884](https://github.com/TheLarkInn/aipm/pull/884)) (80bd042)
</blockquote>

## `libaipm`

<blockquote>

## [0.25.1] - 2026-08-14

### Documentation
- Update CHANGELOG and README for v0.25.0 ([#884](https://github.com/TheLarkInn/aipm/pull/884)) (80bd042)

### Testing
- Cover package-only manifest in compare_and_warn (e865eab)
- Cover scaffold_marketplace ai_existed=true with no_starter=false branch (4809d41)
- Cover compare_and_warn matching-engines guard branch (3a3d6d3)
</blockquote>

## `aipm`

<blockquote>

## [0.25.1] - 2026-08-14

### Documentation
- Update CHANGELOG and README for v0.25.0 ([#884](https://github.com/TheLarkInn/aipm/pull/884)) (80bd042)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).