### PR TITLE
chore: release v0.25.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aipm"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1541,7 +1541,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libaipm"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "annotate-snippets",
  "anstyle",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "libaipm-engine-spec"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "bitflags 2.11.0",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 # =============================================================================
 
 [workspace.package]
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/thelarkinn/aipm"
@@ -22,8 +22,8 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Shared library
-libaipm = { path = "crates/libaipm", version = "0.25.1" }
-libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.25.1" }
+libaipm = { path = "crates/libaipm", version = "0.25.2" }
+libaipm-engine-spec = { path = "crates/libaipm-engine-spec", version = "0.25.2" }
 
 # Engine API schema source-of-truth (build-time codegen + runtime tables)
 phf = "0.13"

--- a/crates/aipm/CHANGELOG.md
+++ b/crates/aipm/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.2] - 2026-08-22
+
 ## [0.25.1] - 2026-08-14
 
 ### Documentation

--- a/crates/libaipm-engine-spec/CHANGELOG.md
+++ b/crates/libaipm-engine-spec/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.2] - 2026-08-22
+
 ## [0.25.1] - 2026-08-14
 
 ### Documentation

--- a/crates/libaipm/CHANGELOG.md
+++ b/crates/libaipm/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.25.2] - 2026-08-22
+
+### Bug Fixes
+- Resolve clippy::manual_is_variant_and from Rust 1.98 stable (3704870)
+
+### Testing
+- Cover mkdir failure branch in LockedFile::open (b3ed660)
+
 ## [0.25.1] - 2026-08-14
 
 ### Documentation


### PR DESCRIPTION



## 🤖 New release

* `libaipm-engine-spec`: 0.25.1 -> 0.25.2
* `libaipm`: 0.25.1 -> 0.25.2 (✓ API compatible changes)
* `aipm`: 0.25.1 -> 0.25.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `libaipm`

<blockquote>

## [0.25.2] - 2026-08-22

### Bug Fixes
- Resolve clippy::manual_is_variant_and from Rust 1.98 stable (3704870)

### Testing
- Cover mkdir failure branch in LockedFile::open (b3ed660)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).