### PR TITLE
[coverage-improver] Cover mkdir failure branch in LockedFile::open

### DIFF
--- a/crates/libaipm/src/locked_file.rs
+++ b/crates/libaipm/src/locked_file.rs
@@ -169,6 +169,21 @@ mod tests {
     }
 
     #[test]
+    fn open_fails_when_parent_creation_errors() {
+        // Create a regular file, then try to open a "nested" path underneath
+        // it. `create_dir_all` cannot create a directory where a file already
+        // exists, so it returns an I/O error — exercising the mkdir error
+        // branch in `LockedFile::open`.
+        let temp = tempfile::tempdir().unwrap_or_else(|_| unreachable_tempdir());
+        let blocker = temp.path().join("blocker");
+        std::fs::write(&blocker, b"not a dir").unwrap_or_else(|_| {});
+
+        let nested = blocker.join("child").join("data.json");
+        let result = LockedFile::open(&nested);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn open_path_with_no_parent_skips_mkdir_and_fails() {
         // Path::new("/").parent() returns None, so the `if let Some(parent)` branch
         // is skipped entirely.  Opening "/" as a regular file then fails because it


### PR DESCRIPTION
## What branch was uncovered

- **File**: `crates/libaipm/src/locked_file.rs`
- **Function**: `LockedFile::open`
- **Condition**: The `.map_err(...)` on the `std::fs::create_dir_all(parent)` call (line 28–29) that maps an I/O error into `Error::Io` when parent-directory creation fails. The success path was already covered; the failure path had zero hits.

## What scenario the new test covers

The new test `open_fails_when_parent_creation_errors` creates a regular file at a path (`blocker`), then calls `LockedFile::open` on a path nested underneath that file (`blocker/child/data.json`). Since `blocker` is a file rather than a directory, `create_dir_all` cannot create the `child` subdirectory under it and returns `NotADirectory`, which is mapped into `Error::Io`. This exercises the previously-uncovered error branch.

## Verification

- `cargo test -p libaipm --lib locked_file` — all 8 tests pass including the new test (re-verified locally on this branch)

## Context

This PR carries the output of Coverage Improver run [31819298036](https://github.com/TheLarkInn/aipm/actions/runs/31819298036), the first run after the livelock on the conflicting #887 was resolved (#1386). The run's `create_pull_request` safe output failed with `403 Resource not accessible by personal access token` (the `GH_AW_CI_TRIGGER_TOKEN` used since #1423 can push signed commits via GraphQL but cannot open PRs), so the workflow fell back to creating review issue #1429. This PR is that exact branch, opened manually.

Closes #1429.

<!-- gh-aw-workflow-id: improve-coverage -->