### PR TITLE
ci: auto-close stale bot-authored PRs after 30 days (#1396)

### DIFF
--- a/.github/workflows/stale-bot-prs.yml
+++ b/.github/workflows/stale-bot-prs.yml
@@ -1,0 +1,86 @@
+name: Stale bot PRs
+
+# Stale-PR policy for bot-authored PRs, adopted per #1396.
+#
+# Open PRs authored by automation (agentic workflow output from coverage-improver,
+# docs-updater, update-docs, etc.) are closed after 30 days of inactivity, with a
+# comment stating the reason. Human-authored PRs are never touched.
+#
+# Rationale: four bot PRs sat open for ~3 months and one of them (#887) livelocked
+# the Coverage Improver (#1386) while every no-op run reported success. Closing stale
+# bot PRs keeps the queue actionable; the originating workflow can always open a
+# fresh PR against current main.
+#
+# This is deliberately a plain deterministic workflow (gh CLI only, no external
+# action pins) rather than an agentic gh-aw workflow: closing stale PRs needs no
+# model judgment, and external pins rot (see #1388).
+
+on:
+  schedule:
+    - cron: "23 5 * * *" # daily
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Report stale bot PRs without closing them"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  pull-requests: write
+  issues: write # PR comments use the issues API
+
+env:
+  STALE_DAYS: 30
+
+jobs:
+  close-stale-bot-prs:
+    name: Close stale bot-authored PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on and close stale bot PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          cutoff=$(date -u -d "-${STALE_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Inactivity cutoff (updatedAt older than): $cutoff"
+          echo "Dry run: $DRY_RUN"
+
+          # gh reports App-authored actors as "app/<slug>"; match both forms.
+          stale=$(gh pr list --repo "${{ github.repository }}" --state open --limit 200 \
+            --json number,title,updatedAt,author \
+            --jq ".[] | select(.author.login == \"app/github-actions\" or .author.login == \"github-actions[bot]\" or .author.login == \"app/copilot-swe-agent\" or .author.login == \"copilot[bot]\") | select(.updatedAt < \"$cutoff\") | .number")
+
+          if [ -z "$stale" ]; then
+            echo "No stale bot-authored PRs found."
+            echo "No stale bot-authored PRs found." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          for n in $stale; do
+            echo "::group::PR #$n"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "Would close PR #$n (dry run)"
+            else
+              comment=$(printf 'Closing as stale, per the stale-PR policy for bot-authored PRs adopted in #1396: bot-authored PRs with no activity for %s days are closed automatically (%s).\n\nIf this change is still relevant, rebase the branch onto `main` and reopen, or let the originating workflow open a fresh PR against current `main`.' "$STALE_DAYS" "$RUN_URL")
+              gh pr close "$n" --comment "$comment"
+              echo "Closed PR #$n"
+            fi
+            echo "::endgroup::"
+          done
+
+          {
+            echo "## Stale bot PRs"
+            echo
+            for n in $stale; do
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "- #$n — would close (dry run)"
+              else
+                echo "- #$n — closed"
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes #1396.

## Triage outcome (acceptance criteria 1–3)

All four stale bot PRs were triaged and **closed with stated reasons** ahead of this PR:

| PR | Outcome | Reason |
|---|---|---|
| #882 | Closed (superseded) | CHANGELOG `[0.25.0]` heading already on `main`; still-accurate doc additions ported |
| #887 | Closed (superseded) | Target branch already covered on `main` by `init_existing_aipm_toml_matching_engines_no_conflict_warn` (#1259) |
| #891 | Closed (superseded) | Still-valid fix ported to #1432 |
| #932 | Closed (stale) | Version pin 0.24.2→0.25.0 outdated (0.25.1 current); docs-updater refreshes pins on push since #1387 |

None were merged, so "merged PRs must pass CI first" is vacuously satisfied. The only open bot-authored PR today is #1409 (1 day old) — well inside the 30-day window, so no `[coverage-improver]`/`[docs-updater]` PR remains open past the staleness window.

## Policy decision (acceptance criterion 4)

**Implement**, don't decline — the #887 livelock (#1386) is concrete evidence of the cost of letting bot PRs accumulate. New workflow `.github/workflows/stale-bot-prs.yml`:

- **Scope:** open PRs authored by GitHub Apps (`app/github-actions` / `github-actions[bot]`, plus Copilot agent identities) — the authors of `coverage-improver`, `docs-updater`, and `update-docs` output. Human PRs are never touched.
- **Window:** 30 days of inactivity (`updatedAt`), then the PR is **closed** with a comment stating the reason and how to reopen (rebase + reopen, or let the originating workflow open a fresh PR).
- **Schedule:** daily (`23 5 * * *`); manual dispatch defaults to **dry-run** so the policy can be rehearsed safely.
- **Implementation:** plain deterministic workflow using only `gh` CLI — no agent run and no external action pins (per the pins-rot lesson from #1388). Closing stale PRs needs no model judgment, so this is intentionally *not* a gh-aw workflow.

## Verification

- Workflow YAML parses; extracted `run` script passes `bash -n`.
- Full simulation of the step script against live repo state:
  - 30-day cutoff → `No stale bot-authored PRs found.` (correct: only #1409, 1 day old)
  - 0-day cutoff + dry-run → correctly identifies #1409 as stale, reports "would close", writes step summary; nothing closed.
- Filter verified against real data: bot PRs report `author.login == "app/github-actions"`.