### PR TITLE
ci: consolidate stale bot-PR triage and stale-PR policy (#1396)

### DIFF
--- a/.github/workflows/stale-bot-prs.yml
+++ b/.github/workflows/stale-bot-prs.yml
@@ -1,0 +1,105 @@
+name: Stale Bot PRs
+
+# Auto-closes bot-authored PRs (coverage-improver, docs-updater, update-docs,
+# Copilot agent output, etc.) that sit inactive, so they cannot accumulate or
+# livelock the workflows that own them — four bot PRs sat open for ~3 months
+# and one of them (#887) livelocked the Coverage Improver (#1386).
+# See https://github.com/TheLarkInn/aipm/issues/1396.
+#
+# Policy:
+#   - A bot PR idle for STALE_DAYS is labeled `stale` and warned via comment.
+#   - If no activity happens within CLOSE_AFTER_STALE_DAYS of that warning,
+#     the PR is closed (it can always be reopened, or the originating
+#     workflow can open a fresh PR against current `main`).
+#   - Any human activity (comment, push, review) resets the idle clock.
+#   - PRs labeled `keep-open` are exempt.
+#
+# This is deliberately a plain deterministic workflow (gh CLI only, no
+# external action pins) rather than an agentic gh-aw workflow: closing stale
+# PRs needs no model judgment, and external pins rot (see #1388).
+
+on:
+  schedule:
+    - cron: "17 4 * * *" # daily at 04:17 UTC
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Report stale bot PRs without labeling, commenting, or closing"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  issues: write # PR comments go through the issues API
+  pull-requests: write
+
+env:
+  STALE_DAYS: "14"
+  CLOSE_AFTER_STALE_DAYS: "7"
+  STALE_LABEL: "stale"
+  EXEMPT_LABEL: "keep-open"
+
+jobs:
+  sweep:
+    name: Close stale bot-authored PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Mark and close stale bot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$DRY_RUN" != "true" ]; then
+            gh label create "$STALE_LABEL" --repo "$GITHUB_REPOSITORY" \
+              --description "Inactive bot-authored PR; will be auto-closed without activity" \
+              --color ededed --force
+          fi
+
+          now=$(date +%s)
+
+          # gh reports App-authored actors as "app/<slug>"; cover the GitHub
+          # Actions app plus Copilot agent identities.
+          gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 200 \
+            --json number,title,updatedAt,labels,author \
+            --jq '.[] | select(.author.login == "app/github-actions" or .author.login == "github-actions[bot]" or .author.login == "app/copilot-swe-agent" or .author.login == "copilot[bot]")' |
+            jq -c '.' |
+            while read -r pr; do
+              number=$(jq -r '.number' <<<"$pr")
+              title=$(jq -r '.title' <<<"$pr")
+              updated=$(date -d "$(jq -r '.updatedAt' <<<"$pr")" +%s)
+              idle_days=$(( (now - updated) / 86400 ))
+              labels=$(jq -r '[.labels[].name] | join(",")' <<<"$pr")
+
+              if [[ ",$labels," == *",$EXEMPT_LABEL,"* ]]; then
+                echo "PR #$number ($title): exempt via '$EXEMPT_LABEL' label — skipping"
+                continue
+              fi
+
+              if [[ ",$labels," == *",$STALE_LABEL,"* ]]; then
+                if (( idle_days >= CLOSE_AFTER_STALE_DAYS )); then
+                  if [ "$DRY_RUN" = "true" ]; then
+                    echo "PR #$number ($title): would close (marked stale ${idle_days}d ago, dry run)"
+                  else
+                    echo "PR #$number ($title): no activity for ${idle_days}d since stale warning — closing"
+                    gh pr close "$number" --repo "$GITHUB_REPOSITORY" \
+                      --comment "Auto-closed: this bot-authored PR was marked stale ${CLOSE_AFTER_STALE_DAYS}+ days ago and saw no activity since. If the change is still needed, the owning workflow will open a fresh PR; otherwise reopen with a comment explaining why. See https://github.com/TheLarkInn/aipm/issues/1396 for the policy."
+                  fi
+                else
+                  echo "PR #$number ($title): marked stale, last activity ${idle_days}d ago — grace period"
+                fi
+              elif (( idle_days >= STALE_DAYS )); then
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "PR #$number ($title): would mark stale (idle ${idle_days}d, dry run)"
+                else
+                  echo "PR #$number ($title): idle for ${idle_days}d — marking stale"
+                  gh pr edit "$number" --repo "$GITHUB_REPOSITORY" --add-label "$STALE_LABEL"
+                  gh pr comment "$number" --repo "$GITHUB_REPOSITORY" \
+                    --body "This bot-authored PR has had no activity for ${STALE_DAYS}+ days and has been marked \`stale\`. It will be auto-closed in ${CLOSE_AFTER_STALE_DAYS} days unless there is new activity. Maintainers: comment, push, or apply the \`${EXEMPT_LABEL}\` label to keep it open. See https://github.com/TheLarkInn/aipm/issues/1396 for the policy."
+                fi
+              else
+                echo "PR #$number ($title): idle ${idle_days}d (< ${STALE_DAYS}d) — active"
+              fi
+            done

--- a/.github/workflows/stale-bot-prs.yml
+++ b/.github/workflows/stale-bot-prs.yml
@@ -48,7 +48,9 @@ jobs:
       - name: Mark and close stale bot PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
+          # Dashed input keys need bracket notation; github.event.inputs is
+          # null on schedule runs, which the || 'false' fallback covers.
+          DRY_RUN: ${{ github.event.inputs['dry-run'] || 'false' }}
         run: |
           set -euo pipefail
 
@@ -81,11 +83,11 @@ jobs:
               if [[ ",$labels," == *",$STALE_LABEL,"* ]]; then
                 if (( idle_days >= CLOSE_AFTER_STALE_DAYS )); then
                   if [ "$DRY_RUN" = "true" ]; then
-                    echo "PR #$number ($title): would close (marked stale ${idle_days}d ago, dry run)"
+                    echo "PR #$number ($title): would close (no activity for ${idle_days}d while labeled '$STALE_LABEL', dry run)"
                   else
-                    echo "PR #$number ($title): no activity for ${idle_days}d since stale warning — closing"
+                    echo "PR #$number ($title): no activity for ${idle_days}d while labeled '$STALE_LABEL' — closing"
                     gh pr close "$number" --repo "$GITHUB_REPOSITORY" \
-                      --comment "Auto-closed: this bot-authored PR was marked stale ${CLOSE_AFTER_STALE_DAYS}+ days ago and saw no activity since. If the change is still needed, the owning workflow will open a fresh PR; otherwise reopen with a comment explaining why. See https://github.com/TheLarkInn/aipm/issues/1396 for the policy."
+                      --comment "Auto-closed: this bot-authored PR is labeled \`${STALE_LABEL}\` and had no activity for ${CLOSE_AFTER_STALE_DAYS}+ days. If the change is still needed, the owning workflow will open a fresh PR; otherwise reopen with a comment explaining why. See https://github.com/TheLarkInn/aipm/issues/1396 for the policy."
                   fi
                 else
                   echo "PR #$number ($title): marked stale, last activity ${idle_days}d ago — grace period"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Automation
+
+- **Stale bot-PR policy** ([#1396](https://github.com/TheLarkInn/aipm/issues/1396)) — new scheduled `stale-bot-prs` workflow closes bot-authored PRs (coverage-improver, docs-updater, and other automation) that sit idle: warned and labeled `stale` after 14 days of inactivity, auto-closed 7 days later unless there is new activity. Apply the `keep-open` label to exempt a PR; `workflow_dispatch` supports a `dry-run` mode.
+
+### Documentation
+
+- Document `aipm migrate --no-summary` and the default stderr scan summary in `docs/guides/migrating-existing-configs.md`, and add the v0.25.0 note on the withdrawn `<engine>-instructions.md` classifier to `docs/guides/lint.md` (ported from the stale bot PR [#882](https://github.com/TheLarkInn/aipm/pull/882)).
+- Fix `instructions/oversized` docs to describe filename-only classification of `copilot-instructions.md` (the rule is not limited to `.github/`) in `docs/guides/lint.md` and `docs/rules/instructions/oversized.md` (ported from the stale bot PR [#891](https://github.com/TheLarkInn/aipm/pull/891)).
+
 ## [0.25.0] - 2026-05-11
 
 ### Features

--- a/docs/guides/lint.md
+++ b/docs/guides/lint.md
@@ -341,7 +341,14 @@ All available rules, grouped by category:
 
 | Rule | Severity | Description |
 |------|----------|-------------|
-| [`instructions/oversized`](../rules/instructions/oversized.md) | warning | Instruction file (`CLAUDE.md`, `AGENTS.md`, `COPILOT.md`, `GEMINI.md`, `INSTRUCTIONS.md`, `*.instructions.md`, `.github/copilot-instructions.md`) exceeds the configured line or character limit |
+| [`instructions/oversized`](../rules/instructions/oversized.md) | warning | Instruction file (`CLAUDE.md`, `AGENTS.md`, `COPILOT.md`, `GEMINI.md`, `INSTRUCTIONS.md`, `copilot-instructions.md`, `*.instructions.md`) exceeds the configured line or character limit |
+
+> **Note (v0.25.0+):** Files named `claude-instructions.md`, `agents-instructions.md`, or
+> `gemini-instructions.md` are **no longer classified** as instruction files. Engine
+> documentation verification confirmed that no AI runtime reads files with those names
+> (the lone real name `copilot-instructions.md` is preserved). If you were relying on the
+> old pattern, rename the file to use the canonical name (`CLAUDE.md`, `AGENTS.md`, etc.)
+> or the `*.instructions.md` suffix.
 
 ### `source/`
 
@@ -386,7 +393,7 @@ File types that receive diagnostics and completions:
 | `**/GEMINI.md` | Gemini instruction file |
 | `**/INSTRUCTIONS.md` | Generic instruction file |
 | `**/*.instructions.md` | Scoped instruction files (e.g. `frontend.instructions.md`) |
-| `.github/copilot-instructions.md` | GitHub Copilot repository-level instructions |
+| `**/copilot-instructions.md` | GitHub Copilot repository-level instructions |
 
 ### Configuration
 

--- a/docs/guides/lint.md
+++ b/docs/guides/lint.md
@@ -393,7 +393,7 @@ File types that receive diagnostics and completions:
 | `**/GEMINI.md` | Gemini instruction file |
 | `**/INSTRUCTIONS.md` | Generic instruction file |
 | `**/*.instructions.md` | Scoped instruction files (e.g. `frontend.instructions.md`) |
-| `**/copilot-instructions.md` | GitHub Copilot repository-level instructions |
+| `**/.github/copilot-instructions.md` | GitHub Copilot repository-level instructions (always under `.github/`; matches the extension's glob in `vscode-aipm/src/extension.ts`) |
 
 ### Configuration
 

--- a/docs/guides/migrating-existing-configs.md
+++ b/docs/guides/migrating-existing-configs.md
@@ -63,6 +63,25 @@ aipm migrate [OPTIONS] [DIR]
 | `--source <SRC>` | Limit to a specific source directory (e.g., `.claude`) |
 | `--max-depth <N>` | Maximum depth for recursive source discovery |
 | `--manifest` | Generate `aipm.toml` plugin manifests for each migrated plugin |
+| `--no-summary` | Suppress the default scan summary line printed to stderr |
+
+### Scan summary
+
+After every run, `aipm migrate` prints a one-line summary to **stderr** describing what
+the discovery walker found before writing any files:
+
+```
+Scanned 5 directories in [.github, .claude]; matched 3 skills, 2 agents, 1 hook
+```
+
+Categories with zero matches are omitted. If nothing was discovered the summary reads:
+
+```
+Scanned 2 directories in [.claude]; matched 0 features
+```
+
+Suppress the summary with `--no-summary`. It is also auto-suppressed when using
+`--log-format=json`.
 
 ## Recursive discovery
 

--- a/docs/rules/instructions/oversized.md
+++ b/docs/rules/instructions/oversized.md
@@ -4,7 +4,7 @@
 **Fixable:** No
 
 Checks that instruction files (`CLAUDE.md`, `AGENTS.md`, `COPILOT.md`, `GEMINI.md`,
-`INSTRUCTIONS.md`, `.github/copilot-instructions.md`, and `*.instructions.md` files
+`INSTRUCTIONS.md`, `copilot-instructions.md`, and `*.instructions.md` files
 anywhere in the project tree) do not exceed
 configurable line and character limits. Oversized instruction files slow down context loading,
 consume more tokens, and may be truncated or rejected by AI runtimes.


### PR DESCRIPTION
Closes #1396. Supersedes #1432 and #1449.

## Why a third PR?

Issue #1396 was picked up twice, producing **two competing open PRs that both add `.github/workflows/stale-bot-prs.yml`** — an add/add conflict guaranteeing the second to merge breaks:

- **#1432** — docs ports (from #882/#891) + two-stage policy (warn at 14d, close 7d later)
- **#1449** — policy-only, single-shot close at 30d, with dry-run input and Copilot agent author coverage

This PR consolidates both into one coherent change.

## Triage outcome (acceptance criteria 1–3)

All four stale bot PRs were triaged and closed with stated reasons ahead of this PR (see [#1396 comment](https://github.com/TheLarkInn/aipm/issues/1396)):

| PR | Outcome | Reason |
|---|---|---|
| #882 | Closed (superseded) | CHANGELOG `[0.25.0]` heading already on `main`; still-accurate doc additions ported here |
| #887 | Closed (superseded) | Livelock resolved in #1386; target branch already covered on `main` |
| #891 | Closed (superseded) | Still-valid fix ported here |
| #932 | Closed (stale) | Version pin 0.24.2→0.25.0 outdated (0.25.1 current); docs-updater refreshes pins on push since #1387 |

None of the four were merged, so "merged PRs must pass CI first" is vacuously satisfied. The only open bot-authored PR today is #1409 (1 day old) — inside any reasonable staleness window.

## Policy decision (criterion 4): implement

The #887 livelock (#1386) is concrete evidence of the cost of letting bot PRs accumulate. New workflow `.github/workflows/stale-bot-prs.yml` — deliberately a **plain deterministic workflow** (gh CLI only, no external action pins, no gh-aw compilation): closing stale PRs needs no model judgment, and external pins rot (#1388).

Best-of-both consolidation:

- **Two-stage warn → close** (from #1432): idle **14 days** → labeled `stale` + warning comment; **7 days** later with no activity → auto-closed with an explanatory comment. Gentler than a silent 30-day close and gives maintainers a visible off-ramp.
- **`keep-open` label exemption** (from #1432); any human activity resets the idle clock.
- **Broader bot author coverage** (from #1449): `app/github-actions`, `github-actions[bot]`, `app/copilot-swe-agent`, `copilot[bot]`.
- **`workflow_dispatch` dry-run input** (from #1449), defaulting to dry-run so the policy can be rehearsed safely.
- Daily cron at 04:17 UTC.

## Docs ports (verified against current source)

- **`aipm migrate --no-summary`** and the default stderr scan summary documented in `docs/guides/migrating-existing-configs.md` — verified against `crates/aipm/src/scan_summary.rs` and `src/main.rs` (port of #882).
- **`instructions/oversized` filename-only classification**: `crates/libaipm/src/discovery/instruction.rs` classifies by file *name* alone, so `copilot-instructions.md` is matched anywhere in the tree, not just under `.github/`. Fixed `docs/guides/lint.md` (rule table + VS Code activation table → `**/copilot-instructions.md`) and `docs/rules/instructions/oversized.md` (port of #891, with the further path correction noted in #1432).
- Added the v0.25.0 note on the withdrawn `<engine>-instructions.md` classifier to `docs/guides/lint.md`.

## Validation

- Workflow YAML parses; embedded bash passes `bash -n`.
- No Rust code changes — build/test/coverage unaffected.