### PR TITLE
docs(gh-aw): sync CLAUDE.md agentic workflow docs with reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,12 +46,14 @@ All four must pass with zero warnings before any commit.
 ```bash
 cargo +nightly llvm-cov clean --workspace
 cargo +nightly llvm-cov --no-report --workspace --branch
-cargo +nightly llvm-cov --no-report --doc
+cargo +nightly llvm-cov --no-report --doc --branch
 cargo +nightly llvm-cov report --doctests --branch \
   --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\.rs|lsp\.rs|libaipm-engine-spec/build\.rs|libaipm-engine-spec/src/bin)'
 ```
 
 Verify the TOTAL branch column shows ≥ 89%. For HTML or lcov output, append `--html --open` or `--lcov --output-path lcov.info` to the report command.
+
+Keep the ignore regex in sync with `COVERAGE_IGNORE_REGEX` in `.github/workflows/ci.yml` — that single env var feeds every coverage step in CI, so the value here must match it exactly (change both together).
 
 ## Copilot Coding Agent Setup
 
@@ -81,7 +83,9 @@ The repository uses [GitHub Agentic Workflows](https://githubnext.com/projects/a
 | `update-docs.md` | 45 min | On push to `main` | Updates docs on every merge |
 | `build-timings.md` | 45 min | Weekdays daily | Analyzes compilation bottlenecks |
 | `reverse-binary-analysis.md` | 120 min | Weekly | Downloads AI engine CLIs, extracts plugin API surface, updates `crates/libaipm-engine-spec/data/engine-api-schema.json`, opens PR when schema changes |
-| `research-codebase.md` | 30 min | On `research` label applied to issue | Runs Copilot CLI to research the codebase, posts findings as the issue body, and relabels with `spec review` |
+| `research-codebase.yml` ⚠ **hand-written** | 30 min | On `research` label applied to issue | Runs Copilot CLI to research the codebase, posts findings as the issue body, and relabels with `spec review` |
+
+> **`research-codebase.yml` is intentionally hand-written** and is *not* managed by `gh aw compile`. It replaced a compiled gh-aw workflow in [#97](https://github.com/TheLarkInn/aipm/pull/97), and the orphaned `research-codebase.md` source was removed in [#1385](https://github.com/TheLarkInn/aipm/issues/1385). There is deliberately no `.md` source and no `research-codebase.lock.yml` — do **not** re-add them, or `gh aw compile` would emit a second workflow also named "Research Codebase" and both would fire on the same `research` label. Edit the `.yml` directly.
 
 ### Why different timeouts?
 
@@ -97,6 +101,15 @@ Most maintenance workflows are capped at **45 minutes**: the full agent cycle (n
 
 The manual `ci: trigger checks` empty-commit workaround is **obsolete** — do not push empty commits to trigger CI on `main`. If post-merge CI stops running again, check which token enabled auto-merge on the merged PR.
 
+### Operational gotchas
+
+Hard-won lessons from past workflow failures — check these before assuming a workflow is healthy:
+
+- **Bot merges via `GITHUB_TOKEN` do not emit `push` events** — anything relying on `on: push: [main]` needs a different trigger (see "Bot merges and push events" above). This silently disabled CI and Update Docs for ~3 months ([#1387](https://github.com/TheLarkInn/aipm/issues/1387)).
+- **A workflow that emits only `noop` exits `success`** — a livelocked workflow looks perfectly healthy on the dashboard. Check what a workflow *did* (its safe outputs), not just its conclusion.
+- **External pins rot.** The AWF firewall binary release referenced by a lock file was deleted upstream, breaking `reverse-binary-analysis` for 10+ weeks with no alert ([#1388](https://github.com/TheLarkInn/aipm/issues/1388)). Periodically verify the pin resolves using the `gh api` check in "Keep every lock file on the same compiler version" below.
+- **Lock files are generated** — never hand-edit a `.lock.yml`. Edit the `.md` source, recompile, and commit both together.
+
 ### Modifying workflow files
 
 After editing any `.github/workflows/<name>.md`, recompile its lock file:
@@ -104,6 +117,8 @@ After editing any `.github/workflows/<name>.md`, recompile its lock file:
 ```bash
 gh aw compile <name>   # e.g. gh aw compile improve-coverage
 ```
+
+**Compile with the repository's pinned gh-aw version — currently `v0.86.2`.** Check yours with `gh aw version` and upgrade with `gh extension upgrade gh-aw` before compiling. The pin is recorded in every `.lock.yml`'s `# gh-aw-metadata:` header as `compiler_version`, and the per-workflow setup action pin (`github/gh-aw-actions/setup`) must match it. Compiling with any other version rewrites the pins and reintroduces the compiler skew described below.
 
 Commit both the `.md` source and the regenerated `.lock.yml` together. The compiled lock file is the canonical version GitHub Actions runs.
 


### PR DESCRIPTION
Closes #1395

## What changed

`CLAUDE.md`'s "Agentic Workflows" section (and one coverage command) no longer described reality. Since it is the primary instruction file for AI agents in this repo, stale content actively causes wrong changes. This PR brings it back in sync:

- **Workflow table**: replaced the stale `research-codebase.md` row with the hand-written `research-codebase.yml`, and added a note documenting that it is intentionally *not* managed by `gh aw compile` ([#97](https://github.com/TheLarkInn/aipm/pull/97), [#1385](https://github.com/TheLarkInn/aipm/issues/1385)) — re-adding the `.md` source would emit a duplicate "Research Codebase" workflow.
- **Pinned gh-aw version**: documented `v0.86.2` directly alongside the `gh aw compile` instructions, including where the pin is recorded (the `# gh-aw-metadata:` header's `compiler_version` field in every `.lock.yml`).
- **Coverage drift**: the documented `--doc` step was missing `--branch` relative to `ci.yml`; fixed, and added a cross-reference to `COVERAGE_IGNORE_REGEX` in `.github/workflows/ci.yml` so the two stay in sync.
- **Operational gotchas**: new section capturing the lessons from this round of failures — `GITHUB_TOKEN` merges emit no `push` events ([#1387](https://github.com/TheLarkInn/aipm/issues/1387)), noop-only runs exit `success`, external pins rot ([#1388](https://github.com/TheLarkInn/aipm/issues/1388)), and lock files are generated artifacts that must be committed with their `.md` source.

## Verification (every documented command actually run)

- `gh aw version` → `v0.86.2` ✓ (matches the documented pin)
- `gh aw compile` → `6 succeeded, 0 warnings`, **zero content drift** in all lock files ✓
- AWF pin check across all `.lock.yml` files → exactly one pin: `v0.27.44` ✓
- `gh api repos/githubnext/gh-aw-firewall/releases/tags/v0.27.44` → resolves ✓
- Every workflow table row re-verified against frontmatter on disk: schedules (`*/15 * * * *`, `every 3h`, `daily on weekdays` ×2, `weekly`, push-to-`main`, `research` label) and timeouts (45/45/45/45/45/120/30 min) all match ✓
- `copilot-setup-steps.yml` re-verified row-by-row against the documented table (stable toolchain, nightly + llvm-tools, `libgit2-dev`/`libssl-dev`/`pkg-config`, `Swatinem/rust-cache@v2`, `cargo fetch --locked`, `CARGO_NET_RETRY: 10`) ✓

Docs-only change; no Rust code touched.