### PR TITLE
ci(gh-aw): add CI guard for lock-file drift and compiler-version skew

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   LIBGIT2_SYS_USE_PKG_CONFIG: "1"
+  # Single source of truth for the pinned gh-aw compiler version (referenced by CLAUDE.md).
+  GH_AW_VERSION: v0.86.2
 
 jobs:
   ci:
@@ -116,3 +118,49 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
+
+  aw-lock-drift:
+    name: Agentic workflow lock drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pinned gh-aw extension
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh extension install github/gh-aw --pin "$GH_AW_VERSION"
+
+      - name: Recompile agentic workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh aw compile
+
+      - name: Fail on lock-file drift
+        run: |
+          if ! git diff --exit-code -- .github/workflows .github/aw; then
+            echo "::error::Lock files are out of date. Run 'gh aw compile' with gh-aw $GH_AW_VERSION and commit the regenerated files."
+            exit 1
+          fi
+
+      - name: Fail on untracked generated files
+        run: |
+          UNTRACKED="$(git status --porcelain --untracked-files=all -- .github/workflows .github/aw | grep '^??' || true)"
+          if [ -n "$UNTRACKED" ]; then
+            echo "::error::gh aw compile produced untracked files. Commit them or remove the orphaned source:"
+            echo "$UNTRACKED"
+            exit 1
+          fi
+
+      - name: Fail on compiler-version skew
+        run: |
+          SKEWED=0
+          for LOCK in .github/workflows/*.lock.yml; do
+            if ! head -1 "$LOCK" | grep -q "\"compiler_version\":\"$GH_AW_VERSION\""; then
+              echo "::error::$LOCK was not compiled with gh-aw $GH_AW_VERSION"
+              SKEWED=1
+            fi
+          done
+          if [ "$SKEWED" -ne 0 ]; then
+            echo "Recompile every workflow with gh-aw $GH_AW_VERSION ('gh aw compile') and commit the results."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ The manual `ci: trigger checks` empty-commit workaround is **obsolete** — do n
 
 ### Modifying workflow files
 
-After editing any `.github/workflows/<name>.md`, recompile its lock file:
+After editing any `.github/workflows/<name>.md`, recompile its lock file with the pinned gh-aw version (see below):
 
 ```bash
 gh aw compile <name>   # e.g. gh aw compile improve-coverage
@@ -109,7 +109,9 @@ Commit both the `.md` source and the regenerated `.lock.yml` together. The compi
 
 #### Keep every lock file on the same compiler version
 
-**All lock files must be compiled with the same `gh aw` version.** The repository is currently on **`v0.86.2`**; check yours with `gh aw version` and upgrade with `gh extension upgrade gh-aw` before recompiling.
+**All lock files must be compiled with the same `gh aw` version.** The pinned version is the `GH_AW_VERSION` env var at the top of `.github/workflows/ci.yml` (currently **`v0.86.2`**) — that is the single source of truth. Check yours with `gh aw version` and install the pinned release with `gh extension install github/gh-aw --pin <version>` (or `gh extension upgrade gh-aw --pin <version>` if already installed) before recompiling.
+
+The `aw-lock-drift` job in `ci.yml` enforces all of this: it recompiles every workflow with the pinned gh-aw and fails the build if `gh aw compile` produces any diff or untracked file under `.github/workflows` / `.github/aw`, or if any lock's embedded `compiler_version` does not match the pin. When bumping the pin, update `GH_AW_VERSION`, recompile everything, and commit it all in one PR.
 
 Recompiling a single workflow with a newer extension than the others introduces *compiler version skew*. Each lock file embeds a pinned [`gh-aw-firewall`](https://github.com/githubnext/gh-aw-firewall) (AWF) release, so a skewed lock ends up on a different AWF pin than its siblings. Upstream deletes old AWF releases, and when that happens the `Install AWF binary` step dies with `curl: (22) ... 404` and the workflow fails 100% of the time — which is exactly how `reverse-binary-analysis` (pinned to the deleted `v0.25.28`) silently failed every week for over two months ([#1388](https://github.com/TheLarkInn/aipm/issues/1388)).
 


### PR DESCRIPTION
Closes #1390

## What

Adds an \w-lock-drift\ job to \ci.yml\ that makes stale or skewed agentic-workflow locks fail the build instead of drifting silently for weeks (the class of bug behind #1388, the orphaned \esearch-codebase.md\ lock, and the 5-lock/2-compiler skew that went unnoticed for months).

The job:

1. Installs the **pinned** gh-aw extension — never \latest\, so upstream releases cannot spontaneously break CI
2. Runs \gh aw compile\
3. Fails if \git diff --exit-code -- .github/workflows .github/aw\ shows any change (an edited \.md\ without its committed regenerated \.lock.yml\)
4. Fails if \gh aw compile\ produces **untracked** files (catches orphaned \.md\ sources like \esearch-codebase.md\)
5. Fails if any \.lock.yml\'s embedded \compiler_version\ does not match the pin (catches compiler-version skew directly, even with no textual diff)

## Pin location

The pinned version is the \GH_AW_VERSION\ env var at the top of \ci.yml\ (currently \0.86.2\) — single source of truth, now referenced from \CLAUDE.md\'s compiler-version section, which also documents the guard.

## Verification

- [x] \gh aw compile\ with gh-aw v0.86.2 on a clean tree produces **zero diff** (6 workflows, 0 warnings) — the guard does not false-positive
- [x] **Drift scenario**: edited \daily-qa.md\ without committing the regenerated lock → drift check fails as intended
- [x] **Orphan scenario**: added an untracked \	est-orphan.md\ source → compile emitted an untracked \	est-orphan.lock.yml\, untracked check fails as intended
- [x] **Skew scenario**: tampered one lock's \compiler_version\ to \0.71.1\ → skew check fails as intended
- [x] \ci.yml\ parses as valid YAML

## Acceptance criteria

- [x] CI fails on a PR that edits a workflow \.md\ without committing the regenerated \.lock.yml\
- [x] CI fails if \gh aw compile\ produces untracked files
- [x] The gh-aw version is pinned and documented, and CI does not float to \latest\
- [x] Verified by deliberately introducing drift and observing the failure (run locally; the same shell runs in the CI job)