### PR TITLE
docs(gh-aw): fix stale agentic workflow docs in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ cargo +nightly llvm-cov report --doctests --branch \
 
 Verify the TOTAL branch column shows ≥ 89%. For HTML or lcov output, append `--html --open` or `--lcov --output-path lcov.info` to the report command.
 
+The `--ignore-filename-regex` pattern is duplicated in `ci.yml` as the `COVERAGE_IGNORE_REGEX` env var — when changing either one, keep the two in sync.
+
 ## Copilot Coding Agent Setup
 
 The file `.github/workflows/copilot-setup-steps.yml` defines the pre-build environment for the [GitHub Copilot coding agent](https://docs.github.com/en/copilot/using-github-copilot/using-claude-sonnet-in-github-copilot). It runs before every agent task and installs all toolchain prerequisites so the sandbox does not need network access during the actual build:
@@ -71,7 +73,7 @@ Do **not** remove or weaken `CARGO_NET_RETRY` (currently `10`) or the `--locked`
 
 ## Agentic Workflows
 
-The repository uses [GitHub Agentic Workflows](https://githubnext.com/projects/agentics) (`.github/workflows/*.md` compiled via `gh aw compile`) for automated maintenance tasks.
+The repository uses [GitHub Agentic Workflows](https://githubnext.com/projects/agentics) (`.github/workflows/*.md` compiled via `gh aw compile`) for automated maintenance tasks. One exception: `research-codebase.yml` is intentionally hand-written — see the note below the table.
 
 | Workflow file | Timeout | Schedule | Purpose |
 |---|---|---|---|
@@ -81,7 +83,9 @@ The repository uses [GitHub Agentic Workflows](https://githubnext.com/projects/a
 | `update-docs.md` | 45 min | On push to `main` | Updates docs on every merge |
 | `build-timings.md` | 45 min | Weekdays daily | Analyzes compilation bottlenecks |
 | `reverse-binary-analysis.md` | 120 min | Weekly | Downloads AI engine CLIs, extracts plugin API surface, updates `crates/libaipm-engine-spec/data/engine-api-schema.json`, opens PR when schema changes |
-| `research-codebase.md` | 30 min | On `research` label applied to issue | Runs Copilot CLI to research the codebase, posts findings as the issue body, and relabels with `spec review` |
+| `research-codebase.yml` † | 30 min | On `research` label applied to issue | Runs Copilot CLI to research the codebase, writes findings to `research/docs/`, posts the generated file as the issue body, and relabels with `spec review` |
+
+† **`research-codebase.yml` is intentionally hand-written and is NOT managed by `gh aw compile`.** It replaced a compiled gh-aw workflow in [#97](https://github.com/TheLarkInn/aipm/pull/97). There is deliberately no `research-codebase.md` source and no `research-codebase.lock.yml` — do not re-add them: `gh aw compile` would emit a second workflow also named "Research Codebase", and both would fire on the same `research` label. Edit the `.yml` directly.
 
 ### Why different timeouts?
 
@@ -97,6 +101,10 @@ Most maintenance workflows are capped at **45 minutes**: the full agent cycle (n
 
 The manual `ci: trigger checks` empty-commit workaround is **obsolete** — do not push empty commits to trigger CI on `main`. If post-merge CI stops running again, check which token enabled auto-merge on the merged PR.
 
+### A green run is not a healthy run
+
+A gh-aw workflow that emits only `noop` outputs still exits `success` — the run log literally says "Agent succeeded with only noop outputs - this is not a failure". A workflow can therefore be livelocked while the dashboard shows green for weeks: `improve-coverage` parked indefinitely on an unmergeable PR exactly this way ([#1391](https://github.com/TheLarkInn/aipm/issues/1391)). When auditing a workflow, check what it *did* — issues/PRs created, comments posted — not just its conclusion, and treat repeated identical `noop` cycles as a failure signal.
+
 ### Modifying workflow files
 
 After editing any `.github/workflows/<name>.md`, recompile its lock file:
@@ -105,11 +113,11 @@ After editing any `.github/workflows/<name>.md`, recompile its lock file:
 gh aw compile <name>   # e.g. gh aw compile improve-coverage
 ```
 
-Commit both the `.md` source and the regenerated `.lock.yml` together. The compiled lock file is the canonical version GitHub Actions runs.
+Never hand-edit a `.lock.yml`: commit both the `.md` source and the regenerated `.lock.yml` together. The compiled lock file is the canonical version GitHub Actions runs.
 
 #### Keep every lock file on the same compiler version
 
-**All lock files must be compiled with the same `gh aw` version.** The repository is currently on **`v0.86.2`**; check yours with `gh aw version` and upgrade with `gh extension upgrade gh-aw` before recompiling.
+**All lock files must be compiled with the same `gh aw` version.** The repository is currently on **`v0.86.2`**. The pin is recorded in every lock file's `# gh-aw-metadata:` header as `compiler_version` — there is no separate pin file; the locks themselves are the record. Check yours with `gh aw version` and upgrade with `gh extension upgrade gh-aw` before recompiling.
 
 Recompiling a single workflow with a newer extension than the others introduces *compiler version skew*. Each lock file embeds a pinned [`gh-aw-firewall`](https://github.com/githubnext/gh-aw-firewall) (AWF) release, so a skewed lock ends up on a different AWF pin than its siblings. Upstream deletes old AWF releases, and when that happens the `Install AWF binary` step dies with `curl: (22) ... 404` and the workflow fails 100% of the time — which is exactly how `reverse-binary-analysis` (pinned to the deleted `v0.25.28`) silently failed every week for over two months ([#1388](https://github.com/TheLarkInn/aipm/issues/1388)).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ All four must pass with zero warnings before any commit.
 ```bash
 cargo +nightly llvm-cov clean --workspace
 cargo +nightly llvm-cov --no-report --workspace --branch
-cargo +nightly llvm-cov --no-report --doc
+cargo +nightly llvm-cov --no-report --doc --branch
 cargo +nightly llvm-cov report --doctests --branch \
   --ignore-filename-regex '(tests/|research/|specs/|wizard_tty\.rs|lsp\.rs|libaipm-engine-spec/build\.rs|libaipm-engine-spec/src/bin)'
 ```
@@ -86,6 +86,8 @@ The repository uses [GitHub Agentic Workflows](https://githubnext.com/projects/a
 | `research-codebase.yml` † | 30 min | On `research` label applied to issue | Runs Copilot CLI to research the codebase, writes findings to `research/docs/`, posts the generated file as the issue body, and relabels with `spec review` |
 
 † **`research-codebase.yml` is intentionally hand-written and is NOT managed by `gh aw compile`.** It replaced a compiled gh-aw workflow in [#97](https://github.com/TheLarkInn/aipm/pull/97). There is deliberately no `research-codebase.md` source and no `research-codebase.lock.yml` — do not re-add them: `gh aw compile` would emit a second workflow also named "Research Codebase", and both would fire on the same `research` label. Edit the `.yml` directly.
+
+Every workflow in the table also supports manual runs via `workflow_dispatch` (`research-codebase.yml` requires an `issue_number` input when dispatched manually).
 
 ### Why different timeouts?
 


### PR DESCRIPTION
Closes #1395

## What changed

`CLAUDE.md`'s Agentic Workflows section now matches the files on disk:

- **`research-codebase` row fixed** — the table listed the orphaned `research-codebase.md`; it now points at the hand-written `research-codebase.yml`, with an explicit note that it is **not** managed by `gh aw compile` (replaced in #97; no `.md` source, no `.lock.yml`; re-adding them would compile a duplicate "Research Codebase" workflow firing on the same label).
- **Pinned gh-aw version location documented** — `v0.86.2` is recorded in every lock file's `# gh-aw-metadata:` header as `compiler_version`; the locks are the record, there is no separate pin file.
- **Livelock gotcha added** — a gh-aw run emitting only `noop` exits `success` ("Agent succeeded with only noop outputs - this is not a failure"), so a livelocked workflow looks healthy on the dashboard (#1391). Audit what a workflow *did*, not its conclusion.
- **Lock-file hygiene stated plainly** — never hand-edit a `.lock.yml`; always commit `.md` + regenerated `.lock.yml` together.
- **Coverage cross-reference + flag sync** — the `--ignore-filename-regex` pattern is cross-referenced with `ci.yml`'s `COVERAGE_IGNORE_REGEX`, and the doctest collection command now passes `--doc --branch` exactly like `ci.yml`, so locally collected branch-coverage data matches what the gate measures.
- **Manual triggers documented** — every workflow in the table supports `workflow_dispatch`; `research-codebase.yml` requires an `issue_number` input when dispatched.

Gotchas already captured by earlier PRs and verified still accurate: bot merges via `GITHUB_TOKEN` emitting no `push` events (#1387), and AWF pin rot breaking `reverse-binary-analysis` for 10+ weeks (#1388).

## Verification (every documented command executed)

| Check | Result |
|---|---|
| Workflow table vs `.md` frontmatter + compiled `.lock.yml` | All timeouts (45/45/45/45/45/120/30 min) and triggers (15-min cron, 3 h, weekdays, push to `main`, weekdays, weekly, `research` label) match; all 7 files also expose `workflow_dispatch` |
| `copilot-setup-steps.yml` table rows vs file | All 5 rows + `CARGO_NET_RETRY=10` match |
| Coverage commands vs `ci.yml` coverage job | Identical (regex via `COVERAGE_IGNORE_REGEX`; doctest step now `--doc --branch` in both) |
| `gh aw version` | `v0.86.2` — matches the pin in all 6 lock files' metadata |
| AWF pin grep one-liner | Prints exactly one version: `v0.27.44` |
| `gh api repos/githubnext/gh-aw-firewall/releases/tags/v0.27.44 --jq .tag_name` | Resolves upstream |
| `gh aw compile` (bare, all workflows) | 6 succeeded, 0 warnings, zero content drift (`git diff --quiet` clean) |

`gh extension upgrade gh-aw` is the one documented command not executed: upgrading past the repo pin is exactly what the doc warns against without recompiling everything. The `cargo`/`llvm-cov` commands are exercised daily by the `ci.yml` coverage job, which this PR now mirrors verbatim.

## Note on dependencies

The issue's "Depends on" list: orphaned `research-codebase.md` removal (#1385) and compiler unification (#1427) are both merged. The build-timings `add-labels` fix (#1389) is still open, but it doesn't change any documented file, trigger, or timeout, so the docs are accurate as written.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>