### PR TITLE
fix(clippy): use Result::is_ok_and for Rust 1.98.0 manual_is_variant_and lint

### DIFF
--- a/crates/libaipm/src/migrate/cleanup.rs
+++ b/crates/libaipm/src/migrate/cleanup.rs
@@ -201,7 +201,7 @@ mod tests {
         let outcome = make_outcome(Vec::new());
         let result = remove_migrated_sources(&outcome, &fs);
         assert!(result.is_ok());
-        assert!(result.ok().is_some_and(|a| a.is_empty()));
+        assert!(result.is_ok_and(|a| a.is_empty()));
     }
 
     #[test]
@@ -277,7 +277,7 @@ mod tests {
 
         let result = remove_migrated_sources(&outcome, &fs);
         assert!(result.is_ok());
-        assert!(result.ok().is_some_and(|a| a.is_empty()));
+        assert!(result.is_ok_and(|a| a.is_empty()));
     }
 
     #[test]
@@ -290,7 +290,7 @@ mod tests {
 
         let result = remove_migrated_sources(&outcome, &fs);
         assert!(result.is_ok());
-        assert!(result.ok().is_some_and(|a| a.is_empty()));
+        assert!(result.is_ok_and(|a| a.is_empty()));
     }
 
     #[test]

--- a/crates/libaipm/src/resolver/mod.rs
+++ b/crates/libaipm/src/resolver/mod.rs
@@ -465,7 +465,7 @@ fn select_sorted_candidates(
         .versions
         .iter()
         .filter(|v| !v.yanked)
-        .filter(|v| Version::parse(&v.vers).ok().is_some_and(|ver| req.matches(&ver)))
+        .filter(|v| Version::parse(&v.vers).is_ok_and(|ver| req.matches(&ver)))
         .cloned()
         .collect();
 

--- a/crates/libaipm/src/security.rs
+++ b/crates/libaipm/src/security.rs
@@ -80,7 +80,7 @@ pub enum Error {
 
 /// Check if the environment variable forces enforcement.
 fn is_env_enforced() -> bool {
-    std::env::var(ENFORCE_ENV_VAR).ok().is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+    std::env::var(ENFORCE_ENV_VAR).is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"))
 }
 
 /// Check if a URL matches any of the given glob-style patterns.

--- a/crates/libaipm/src/version.rs
+++ b/crates/libaipm/src/version.rs
@@ -328,7 +328,7 @@ mod tests {
     fn stable_version_is_not_prerelease() {
         let v = Version::parse("1.0.0");
         assert!(v.is_ok());
-        assert!(v.ok().is_some_and(|v| !v.is_prerelease()));
+        assert!(v.is_ok_and(|v| !v.is_prerelease()));
     }
 
     #[test]


### PR DESCRIPTION
## What

Rust 1.98.0 stable shipped a new pedantic clippy lint, `clippy::manual_is_variant_and`, which fires on `.ok().is_some_and(..)` called on a `Result`. Because CI builds with `-D warnings`, the **Build & Test job is now failing on main** (first observed on #1630's run, which contains no Rust changes).

This replaces `.ok().is_some_and(..)` with the suggested `.is_ok_and(..)` (stable since Rust 1.70) at all six call sites:

- `crates/libaipm/src/resolver/mod.rs:468`
- `crates/libaipm/src/security.rs:83`
- `crates/libaipm/src/migrate/cleanup.rs:204, 280, 293` (tests)
- `crates/libaipm/src/version.rs:331` (test)

`Result::ok().is_some_and(f)` and `Result::is_ok_and(f)` are semantically identical — behavior is unchanged.

Unblocks #1630 and every other open PR.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>